### PR TITLE
Disable coverage % requirement in build, fix default in SessionStorage call

### DIFF
--- a/api/dao/containerstorage.py
+++ b/api/dao/containerstorage.py
@@ -279,7 +279,7 @@ class SessionStorage(ContainerStorage):
             a_ids = AcquisitionStorage().get_all_el({'collections': bson.ObjectId(collection_id)}, None, {'session': 1})
             query['_id'] = {'$in': list(set([a['session'] for a in a_ids]))}
 
-        return super(SessionStorage, self).get_all_el(query, user, projection, fill_defaults=False)
+        return super(SessionStorage, self).get_all_el(query, user, projection, fill_defaults=fill_defaults)
 
 
     def recalc_session_compliance(self, session_id, session=None, template=None, hard=False):

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,16 +7,16 @@ coverage:
     project: no
     patch:
       default:
-        enabled: yes
+        enabled: no
         # basic
         target: 100%  # we always want 100% coverage for new code
         threshold: null
-        base: pr 
+        base: pr
     changes:
       default:
         enabled: yes
         # basic
-        base: pr 
+        base: pr
 comment:
   layout: "diff"
   behavior: default


### PR DESCRIPTION
The coverage % requirement was broken until recently. It was only ever intended to be informational, so it has been disabled. 

Also, rather than honoring a parameter's state in an override of `get_all_el` in `SessionStorage`, `False` was being passed to the super call. This affected SDK builds and has been amended. 

Attn @ryansanford, @ehlertjd 
