### PR TITLE
File modified is updated instead of parent container's

### DIFF
--- a/api/dao/liststorage.py
+++ b/api/dao/liststorage.py
@@ -211,9 +211,9 @@ class FileStorage(ListStorage):
         query[self.list_name] = {'$elemMatch': query_params}
 
         if not update.get('$set'):
-            update['$set'] = {'modified': datetime.datetime.utcnow()}
+            update['$set'] = {'files.$.modified': datetime.datetime.utcnow()}
         else:
-            update['$set']['modified'] = datetime.datetime.utcnow()
+            update['$set']['files.$.modified'] = datetime.datetime.utcnow()
 
         return self.dbc.update_one(query, update)
 

--- a/tests/integration_tests/python/test_containers.py
+++ b/tests/integration_tests/python/test_containers.py
@@ -835,6 +835,11 @@ def test_edit_file_info(data_builder, as_admin, file_form):
     }
 
 
+    r = as_admin.get('/projects/' + project + '/files/' + file_name + '/info')
+    assert r.ok
+
+    premodified_time = r.json().get('modified')
+
     r = as_admin.post('/projects/' + project + '/files/' + file_name + '/info', json={
         'replace': file_info
     })
@@ -843,7 +848,8 @@ def test_edit_file_info(data_builder, as_admin, file_form):
     r = as_admin.get('/projects/' + project + '/files/' + file_name + '/info')
     assert r.ok
     assert r.json()['info'] == file_info
-
+    postmodified_time = r.json().get('modified')
+    assert postmodified_time != premodified_time
 
     # Use 'set' to add new key
     r = as_admin.post('/projects/' + project + '/files/' + file_name + '/info', json={


### PR DESCRIPTION
When a file's info is modified, the file's modified timestamp should be updated.
- Should both be updated?
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
