### PR TITLE
Gear context inputs

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -153,6 +153,7 @@ endpoints = [
             route('/<:[^/]+>',                           GearHandler),
             route('/<:[^/]+>/invocation',                GearHandler, h='get_invocation'),
             route('/<:[^/]+>/suggest/<:{cname}|subjects>/<:[^/]+>', GearHandler, h='suggest'),
+            route('/<:[^/]+>/context/<:{cname}>/<:{cid}>', GearHandler, h='get_context', m=['GET']),
         ]),
 
         # Batch jobs

--- a/api/jobs/batch.py
+++ b/api/jobs/batch.py
@@ -6,7 +6,7 @@ import copy
 import datetime
 
 from .. import config
-from ..dao.containerstorage import AcquisitionStorage, AnalysisStorage
+from ..dao.containerstorage import AnalysisStorage
 from .jobs import Job
 from .queue import Queue
 from ..web.errors import APINotFoundException, APIStorageException

--- a/api/jobs/batch.py
+++ b/api/jobs/batch.py
@@ -93,11 +93,11 @@ def find_matching_conts(gear, containers, container_type, context_inputs=False, 
             else:
                 # Create input map of file refs
                 inputs = {}
-                for input_name, files in suggestions.iteritems():
-                    if files[0]['base'] == 'file':
-                        inputs[input_name] = {'type': container_type, 'id': str(c['_id']), 'name': files[0]['name']}
+                for input_name, suggested_inputs in suggestions.iteritems():
+                    if suggested_inputs[0]['base'] == 'file':
+                        inputs[input_name] = {'type': container_type, 'id': str(c['_id']), 'name': suggested_inputs[0]['name']}
                     else:
-                        inputs[input_name] = files[0]
+                        inputs[input_name] = suggested_inputs[0]
                 c['inputs'] = inputs
                 matched_conts.append(c)
         else:

--- a/api/jobs/batch.py
+++ b/api/jobs/batch.py
@@ -11,6 +11,7 @@ from .jobs import Job
 from .queue import Queue
 from ..web.errors import APINotFoundException, APIStorageException
 from . import gears
+from . import job_util
 
 log = config.log
 
@@ -50,7 +51,7 @@ def get(batch_id, projection=None, get_jobs=False):
 
     return batch_job
 
-def find_matching_conts(gear, containers, container_type):
+def find_matching_conts(gear, containers, container_type, context_inputs=False, uid=None):
     """
     Give a gear and a list of containers, find files that:
       - have no solution to the gear's input schema (not matched)
@@ -64,11 +65,15 @@ def find_matching_conts(gear, containers, container_type):
     matched_conts = []
     not_matched_conts = []
     ambiguous_conts = []
+    context = None
 
     for c in containers:
+        if context_inputs:
+            context = job_util.get_context_for_destination(container_type, str(c['_id']), uid)
+
         files = c.get('files')
         if files:
-            suggestions = gears.suggest_for_files(gear, files)
+            suggestions = gears.suggest_for_files(gear, files, context=context)
 
             # Determine if any of the inputs are ambiguous or not satisfied
             ambiguous = False # Are any of the inputs ambiguous?
@@ -89,7 +94,10 @@ def find_matching_conts(gear, containers, container_type):
                 # Create input map of file refs
                 inputs = {}
                 for input_name, files in suggestions.iteritems():
-                    inputs[input_name] = {'type': container_type, 'id': str(c['_id']), 'name': files[0]}
+                    if files[0]['base'] == 'file':
+                        inputs[input_name] = {'type': container_type, 'id': str(c['_id']), 'name': files[0]['name']}
+                    else:
+                        inputs[input_name] = files[0]
                 c['inputs'] = inputs
                 matched_conts.append(c)
         else:
@@ -132,10 +140,9 @@ def run(batch_job):
     """
 
     proposal = batch_job.get('proposal')
-    if not proposal:
+    if not proposal or not 'jobs' in proposal:
         raise APIStorageException('The batch job is not formatted correctly.')
-    proposed_inputs = proposal.get('inputs', [])
-    proposed_destinations = proposal.get('destinations', [])
+    proposed_jobs = proposal.get('jobs', [])
 
     gear_id = batch_job['gear_id']
     gear = gears.get_gear(gear_id)
@@ -152,7 +159,6 @@ def run(batch_job):
             time_now = datetime.datetime.utcnow()
             analysis_base['label'] = {'label': '{} {}'.format(gear_name, time_now)}
         an_storage = AnalysisStorage()
-        acq_storage = AcquisitionStorage()
 
     jobs = []
     job_ids = []
@@ -165,47 +171,23 @@ def run(batch_job):
         'inputs':   {}
     }
 
-    for inputs in proposed_inputs:
-
+    for proposed_job in proposed_jobs:
         job_map = copy.deepcopy(job_defaults)
-        job_map['inputs'] = inputs
+        if 'inputs' in proposed_job:
+            job_map['inputs'] = proposed_job['inputs']
+
+        if 'destination' not in proposed_job:
+            raise APIStorageException('Destination is required for all proposed jobs')
+        job_map['destination'] = proposed_job['destination']
 
         if gear.get('category') == 'analysis':
-
             analysis = copy.deepcopy(analysis_base)
 
             # Create analysis
-            acquisition_id = inputs.values()[0].get('id')
-            session_id = acq_storage.get_container(acquisition_id, projection={'session': 1}).get('session')
+            # NOTE: Batch destinations *MUST* be a session
+            session_id = bson.ObjectId(job_map['destination']['id'])
             analysis['job'] = job_map
-            result = an_storage.create_el(analysis, 'sessions', session_id, origin, None)
-
-            analysis = an_storage.get_el(result.inserted_id)
-            an_storage.inflate_job_info(analysis)
-            job = analysis.get('job')
-            job_id = bson.ObjectId(job.id_)
-
-        else:
-
-            job = Queue.enqueue_job(job_map, origin)
-            job_id = job.id_
-
-
-        jobs.append(job)
-        job_ids.append(job_id)
-
-    for dest in proposed_destinations:
-
-        job_map = copy.deepcopy(job_defaults)
-        job_map['destination'] = dest
-
-        if gear.get('category') == 'analysis':
-
-            analysis = copy.deepcopy(analysis_base)
-
-            # Create analysis
-            analysis['job'] = job_map
-            result = an_storage.create_el(analysis, 'sessions', bson.ObjectId(dest['id']), origin, None)
+            result = an_storage.create_el(analysis, 'sessions', session_id, origin, None) 
 
             analysis = an_storage.get_el(result.inserted_id)
             an_storage.inflate_job_info(analysis)

--- a/api/jobs/gears.py
+++ b/api/jobs/gears.py
@@ -87,7 +87,7 @@ def suggest_for_files(gear, files, context=None):
                 suggested_inputs[x] = [{
                     'base': 'context',
                     'found': True,
-                    'value': context[x]
+                    'value': context[x]['value']
                 }]
             else:
                 suggested_inputs[x] = [{

--- a/api/jobs/gears.py
+++ b/api/jobs/gears.py
@@ -63,7 +63,7 @@ def add_suggest_info_to_files(gear, files):
     schemas = {}
     for x in gear['gear']['inputs']:
         input_ = gear['gear']['inputs'][x]
-        if input_.get('base') != 'context':
+        if input_.get('base') == 'file':
             schema = gear_tools.isolate_file_invocation(invocation_schema, x)
             schemas[x] = Draft4Validator(schema)
 

--- a/api/jobs/gears.py
+++ b/api/jobs/gears.py
@@ -62,8 +62,10 @@ def add_suggest_info_to_files(gear, files):
 
     schemas = {}
     for x in gear['gear']['inputs']:
-        schema = gear_tools.isolate_file_invocation(invocation_schema, x)
-        schemas[x] = Draft4Validator(schema)
+        input_ = gear['gear']['inputs'][x]
+        if input_.get('base') != 'context':
+            schema = gear_tools.isolate_file_invocation(invocation_schema, x)
+            schemas[x] = Draft4Validator(schema)
 
     for f in files:
         f['suggested'] = {}
@@ -72,22 +74,40 @@ def add_suggest_info_to_files(gear, files):
 
     return files
 
-def suggest_for_files(gear, files):
+def suggest_for_files(gear, files, context=None):
 
     invocation_schema = get_invocation_schema(gear)
     schemas = {}
-    for x in gear['gear']['inputs']:
-        schema = gear_tools.isolate_file_invocation(invocation_schema, x)
-        schemas[x] = Draft4Validator(schema)
+    suggested_inputs = {}
 
-    suggested_files = {}
+    for x in gear['gear']['inputs']:
+        input_ = gear['gear']['inputs'][x]
+        if input_.get('base') == 'context':
+            if x in context:
+                suggested_inputs[x] = [{
+                    'base': 'context',
+                    'found': True,
+                    'value': context[x]
+                }]
+            else:
+                suggested_inputs[x] = [{
+                    'base': 'context',
+                    'found': False
+                }]
+        else:
+            schema = gear_tools.isolate_file_invocation(invocation_schema, x)
+            schemas[x] = Draft4Validator(schema)
+
     for input_name, schema in schemas.iteritems():
-        suggested_files[input_name] = []
+        suggested_inputs[input_name] = []
         for f in files:
             if schema.is_valid(f):
-                suggested_files[input_name].append(f.get('name'))
+                suggested_inputs[input_name].append({
+                    'base': 'file',
+                    'name': f.get('name')
+                })
 
-    return suggested_files
+    return suggested_inputs
 
 def validate_gear_config(gear, config_):
     if len(gear.get('manifest', {}).get('config', {})) > 0:
@@ -123,6 +143,8 @@ def fill_gear_default_values(gear, config_):
 
     return config_
 
+def count_file_inputs(geardoc):
+    return len([inp for inp in geardoc['gear']['inputs'].values() if inp['base'] == 'file'])
 
 def insert_gear(doc):
     gear_tools.validate_manifest(doc['gear'])

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -465,7 +465,8 @@ class JobHandler(base.RequestHandler):
         if not self.superuser_request:
             if job.inputs is not None:
                 for x in job.inputs:
-                    job.inputs[x].check_access(self.uid, 'ro')
+                    if hasattr(job.inputs[x], 'check_access'):
+                        job.inputs[x].check_access(self.uid, 'ro')
                 # Unlike jobs-add, explicitly not checking write access to destination.
 
     def get_logs(self, _id):
@@ -514,7 +515,8 @@ class JobHandler(base.RequestHandler):
         # Permission check
         if not self.superuser_request:
             for x in j.inputs:
-                j.inputs[x].check_access(self.uid, 'ro')
+                if hasattr(j.inputs[x], 'check_access'):
+                    j.inputs[x].check_access(self.uid, 'ro')
             j.destination.check_access(self.uid, 'rw')
 
         new_id = Queue.retry(j, force=True)

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -720,7 +720,7 @@ class BatchHandler(base.RequestHandler):
                 for match in matched:
                     batch_proposal['proposal']['jobs'].append({               
                         'inputs': match.pop('inputs'),
-                        'destination': { 'id': str(match['session']), 'type': 'session'}
+                        'destination': { 'id': str(match['_id']), 'type': 'acquisition' }
                     })
 
             batch.insert(batch_proposal)

--- a/api/jobs/job_util.py
+++ b/api/jobs/job_util.py
@@ -1,0 +1,66 @@
+"""
+Job related utilities.
+"""
+from ..auth import has_access
+from ..dao.basecontainerstorage import ContainerStorage
+
+def get_context_for_destination(destination, uid):
+    """ Get gear run context for the given destination container.
+    
+    Arguments:
+        destination (ContainerRef): A reference to the destination container.
+        uid (str): The user id for permission checking
+
+    Returns:
+        dict: The context built from the container hierarchy
+    """
+    storage = ContainerStorage.factory(destination.type)
+    cont = storage.get_container(destination.id)
+    parent_tree = storage.get_parent_tree(destination.id, cont=cont)
+
+    # This is a quick and dirty solution that walks top down, updating
+    # context from each parent container if the user has ro permissions.
+    context = {}
+
+    # Walk top down, updating context as we go
+    parent_tree.reverse()
+    parent_tree.append(cont)
+
+    for parent in parent_tree:
+        if not uid or has_access(uid, parent, 'ro'):
+            parent_context = parent.get('info', {}).get('context', {})
+            context.update(parent_context)
+
+    return context
+
+def resolve_context_inputs(config, gear, destination, uid):
+    """ Resolve input fields with a base of 'context' given a destination and gear spec.
+    
+    Arguments:
+        config (dict): The job configuration to be updated
+        gear (dict): The gear spec
+        destination (ContainerRef): A reference to the destination container.
+        uid (str): The user id for permission checking
+    """
+    # Callers don't (shouldn't) specify the context inputs when scheduling a job,
+    # so we walk the gear inputs, checking for any context inputs.
+    context = None
+    for x in gear['gear']['inputs']:
+        input_type = gear['gear']['inputs'][x]['base']
+        if input_type == 'context':
+            # Lazily resolve the context a single time
+            if context is None:
+                context = get_context_for_destination(destination, uid)
+
+            if x in context:
+                config['inputs'][x] = {
+                    'base': 'context',
+                    'found': True,
+                    'value': context[x]
+                }
+            else:
+                config['inputs'][x] = {
+                    'base': 'context',
+                    'found': False
+                }
+

--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -143,7 +143,10 @@ class Job(object):
 
             for i in d['inputs']:
                 inp = i.pop('input')
-                input_dict[inp] = create_filereference_from_dictionary(i)
+                if 'type' in i and 'name' in i:
+                    input_dict[inp] = create_filereference_from_dictionary(i)
+                else:
+                    input_dict[inp] = i
 
             d['inputs'] = input_dict
 
@@ -190,7 +193,8 @@ class Job(object):
 
         if d.get('inputs'):
             for x in d['inputs'].keys():
-                d['inputs'][x] = d['inputs'][x].__dict__
+                if not isinstance(d['inputs'][x], dict):
+                    d['inputs'][x] = d['inputs'][x].__dict__
         else:
             d.pop('inputs')
 

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -167,9 +167,14 @@ class Queue(object):
         # Translate maps to FileReferences
         inputs = {}
         for x in job_map.get('inputs', {}).keys():
+
+            # Ensure input is in gear manifest
+            if x not in gear['gear']['inputs']:
+                raise InputValidationException('Job input {} is not listed in gear manifest'.format(x))
+
             input_map = job_map['inputs'][x]
-            base = gear['gear'].get('inputs', {}).get(x, {}).get('base')
-            if base == 'file':
+            
+            if gear['gear']['inputs'][x]['base'] == 'file':
                 try:
                     inputs[x] = create_filereference_from_dictionary(input_map)
                 except KeyError:
@@ -228,11 +233,6 @@ class Queue(object):
         # So option #2 is potentially more convenient, but unintuitive and prone to user confusion.
 
         for x in inputs:
-
-            # Ensure input is in gear manifest
-            if x not in gear['gear']['inputs']:
-                raise InputValidationException('Job input {} is not listed in gear manifest'.format(x))
-
             input_type = gear['gear']['inputs'][x]['base']
             if input_type == 'file':
 

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -200,7 +200,7 @@ class Queue(object):
         # Permission check
         if perm_check_uid:
             for x in inputs:
-                if isinstance(inputs[x], FileReference):
+                if hasattr(inputs[x], 'check_access'):
                     inputs[x].check_access(perm_check_uid, 'ro')
             destination.check_access(perm_check_uid, 'rw')
 

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -11,6 +11,7 @@ from .. import config
 from .jobs import Job, Logs, JobTicket
 from .gears import get_gear, validate_gear_config, fill_gear_default_values
 from ..dao.containerutil import create_filereference_from_dictionary, create_containerreference_from_dictionary, create_containerreference_from_filereference
+from .job_util import resolve_context_inputs 
 from ..web.errors import InputValidationException
 
 
@@ -243,6 +244,9 @@ class Queue(object):
             else:
                 # Note: API key inputs should not be passed as input
                 raise Exception('Non-file input base type')
+
+        # Populate any context inputs for the gear
+        resolve_context_inputs(config_, gear, destination, perm_check_uid)
 
         gear_name = gear['gear']['name']
 

--- a/api/jobs/rules.py
+++ b/api/jobs/rules.py
@@ -146,8 +146,8 @@ def queue_job_legacy(algorithm_id, input_):
 
     gear = gears.get_gear_by_name(algorithm_id)
 
-    if len(gear['gear']['inputs']) != 1:
-        raise Exception("Legacy gear enqueue attempt of " + algorithm_id + " failed: must have exactly 1 input in manifest")
+    if gears.count_file_inputs(gear) != 1:
+        raise Exception("Legacy gear enqueue attempt of " + algorithm_id + " failed: must have exactly 1 file input in manifest")
 
     input_name = gear['gear']['inputs'].keys()[0]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ unicodecsv==0.9.0
 uwsgi==2.0.13.1
 webapp2==2.5.2
 WebOb==1.5.1
-git+https://github.com/flywheel-io/gears.git@v0.1.4#egg=gears
+git+https://github.com/flywheel-io/gears.git@v0.1.5#egg=gears

--- a/swagger/paths/gears.yaml
+++ b/swagger/paths/gears.yaml
@@ -12,7 +12,7 @@
         examples:
           response:
             $ref: examples/output/gear-list.json
-        
+
 # TODO: Can we make the parameter here consistent, or split
 # this into two separate APIs?
 /gears/{GearIdOrName}:
@@ -50,7 +50,7 @@
       - name: body
         in: body
         required: true
-        schema: 
+        schema:
           $ref: schemas/input/gear.json
     tags:
     - gears
@@ -91,5 +91,35 @@
           description: The gear invocation schema.
           schema:
             type: object
+
+/gears/{GearId}/context/{ContainerType}/{ContainerId}:
+    parameters:
+      - name: GearId
+        in: path
+        type: string
+        required: true
+        description: Id of the gear to interact with
+      - name: ContainerType
+        in: path
+        type: string
+        required: true
+        description: Type of the container to interact with
+      - name: ContainerId
+        in: path
+        type: string
+        required: true
+        description: Id of the container to interact with
+    get:
+      summary: Get context values for the given gear and container.
+      description: |
+        Ref: https://github.com/flywheel-io/gears/tree/master/spec#contextual-values
+      operationId: get_gear_context
+      tags:
+      - gears
+      responses:
+        '200':
+          description: The gear context values.
+          schema:
+            $ref: schemas/output/gear-context.json
 
 

--- a/swagger/schemas/definitions/gear.json
+++ b/swagger/schemas/definitions/gear.json
@@ -82,22 +82,28 @@
             }
         },
         "gear-context-lookup-item": {
-        	"properties": {
-        		"found": {
-        			"type": "boolean",
-        			"description": "Was the context value found?"
-        		},
-        		"container_type": {
-        			"$ref": "container.json#/definitions/container-type"
-        		},
-        		"label": {
-        			"type": "string",
-        			"description": "Label of the container where the context value was found, if any."
-        		},
-        		"value": {
-        			"description": "The value if found. Valid IFF found is true. Can be null."
-        		}
-        	}
+            "properties": {
+                "found": {
+                    "type": "boolean",
+                    "description": "Was the context value found?"
+                },
+                "container_type": {
+                    "$ref": "container.json#/definitions/container-type"
+                },
+                "id": {
+                    "type": "string",
+                    "description": "Id of the container where the context value was found, if any."
+                },
+                "label": {
+                    "type": "string",
+                    "description": "Label of the container where the context value was found, if any."
+                },
+                "value": {
+                    "description": "The value if found. Valid IFF found is true. Can be null."
+                }
+            },
+            "required": [ "found" ],
+            "additionalProperties": false
         },
         "gear-context-lookup": {
             "description": "Describes a gear input",

--- a/swagger/schemas/definitions/gear.json
+++ b/swagger/schemas/definitions/gear.json
@@ -49,7 +49,7 @@
         "gear-license": {
             "type": "string",
             "description": "Software license of the gear"
-        }, 
+        },
         "gear-name": {
             "type": "string",
             "pattern": "^[a-z0-9\\-]+$",
@@ -79,6 +79,30 @@
             "required": [ "base" ],
             "additionalProperties": {
                 "$ref": "#/definitions/gear-directive"
+            }
+        },
+        "gear-context-lookup-item": {
+        	"properties": {
+        		"found": {
+        			"type": "boolean",
+        			"description": "Was the context value found?"
+        		},
+        		"container_type": {
+        			"$ref": "container.json#/definitions/container-type"
+        		},
+        		"label": {
+        			"type": "string",
+        			"description": "Label of the container where the context value was found, if any."
+        		},
+        		"value": {
+        			"description": "The value if found. Valid IFF found is true. Can be null."
+        		}
+        	}
+        },
+        "gear-context-lookup": {
+            "description": "Describes a gear input",
+            "additionalProperties": {
+            	"$ref": "#/definitions/gear-context-lookup-item"
             }
         },
         "gear-inputs": {

--- a/swagger/schemas/output/gear-context.json
+++ b/swagger/schemas/output/gear-context.json
@@ -7,13 +7,11 @@
         "found": true,
         "container_type": "project",
         "label": "Project Bob",
+        "id": "58063f24e5dc5b001657a93c",
         "value": "some super important value"
       },
       "Y": {
-        "found": false,
-        "container_type": "",
-        "label": "",
-        "value": null
+        "found": false
       }
     }
 }

--- a/swagger/schemas/output/gear-context.json
+++ b/swagger/schemas/output/gear-context.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type":"object",
+    "allOf":[{"$ref":"../definitions/gear.json#/definitions/gear-context-lookup"}],
+    "example": {
+      "X": {
+        "found": true,
+        "container_type": "project",
+        "label": "Project Bob",
+        "value": "some super important value"
+      },
+      "Y": {
+        "found": false,
+        "container_type": "",
+        "label": "",
+        "value": null
+      }
+    }
+}
+
+

--- a/tests/integration_tests/python/test_batch.py
+++ b/tests/integration_tests/python/test_batch.py
@@ -586,14 +586,14 @@ def test_file_input_context_batch(data_builder, default_payload, as_admin, as_ro
     # Check job configs for inputs
     jobs = r.json()
 
-    assert jobs[0]['config']['destination']['id'] == session
+    assert jobs[0]['config']['destination']['id'] == acquisition
     job1_inputs = jobs[0]['config']['inputs']
     assert 'test_context_value' in job1_inputs
     assert job1_inputs['test_context_value']['found'] == True 
     assert job1_inputs['test_context_value']['value'] == 'session_context_value'
 
     job2_inputs = jobs[1]['config']['inputs']
-    assert jobs[1]['config']['destination']['id'] == session2
+    assert jobs[1]['config']['destination']['id'] == acquisition2 
     assert 'test_context_value' in job2_inputs
     assert job2_inputs['test_context_value']['found'] == True 
     assert job2_inputs['test_context_value']['value'] == 'project_context_value'

--- a/tests/integration_tests/python/test_batch.py
+++ b/tests/integration_tests/python/test_batch.py
@@ -546,6 +546,10 @@ def test_file_input_context_batch(data_builder, default_payload, as_admin, as_ro
     assert 'test_context_value' in job2_inputs
     assert job2_inputs['test_context_value']['found'] == False
 
+    # try to cancel non-running batch
+    r = as_admin.post('/batch/' + batch_id + '/cancel')
+    assert r.ok
+
     # Set context at project level
     r = as_admin.post('/projects/' + project + '/info', json={
         'set': {
@@ -593,6 +597,10 @@ def test_file_input_context_batch(data_builder, default_payload, as_admin, as_ro
     assert 'test_context_value' in job2_inputs
     assert job2_inputs['test_context_value']['found'] == True 
     assert job2_inputs['test_context_value']['value'] == 'project_context_value'
+
+    # test batch.state after calling run
+    r = as_admin.get('/batch/' + batch_id)
+    assert r.json()['state'] == 'running'
 
     # Cleanup
     r = as_root.delete('/gears/' + gear)


### PR DESCRIPTION
This is a first-pass, backward compatible implementation of Context Inputs added to flywheel-io/gears#30.

There are currently no required frontend changes since context inputs are populated automatically at job creation time. This PR makes a slight change to how batch proposals are constructed, requiring destination to be resolved at proposal time in order to populate the context input values. 

I have not implemented the endpoint described in flywheel-io/frontend#1442 in this PR.

Tests have been added to cover individual job creation, batch job creation, and rule-based job creation, and I have tested those scenarios via UI.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
