### PR TITLE
Fix testing issues;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 /htmlcov
 /persistent
 /runtime
-/tests/running_integration
+/tests/artifacts
 bootstrap.json
 coverage.xml
 endpoints.json

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,9 +4,12 @@ Build flywheel/core and run automated tests in a docker container:
 ./tests/bin/docker-tests.sh
 ```
 
-* To skip building the image, use `--no-build` (`-B`)
 * All tests (unit, integration and linting) are executed by default
-* To pass any arguments to `py.test`, use `-- PYTEST_ARGS`
+* To enter a test shell, use `--shell` (`-s`)
+* To skip building the image, use `--no-build` (`-B`)
+* To skip linting, use `--skip-lint` (`-L`)
+* Conversely, run linting only with `--lint-only` (`-l`)
+* Any additional arguments are passed to `py.test`:
     * To run only a subset of test, use the [keyword expression filter](https://docs.pytest.org/en/latest/usage.html#specifying-tests-selecting-tests) `-k`
     * To see `print` output during tests, increase verbosity with `-vvv`
     * To get a debugger session on failures, use [`--pdb`](https://docs.pytest.org/en/latest/usage.html#dropping-to-pdb-python-debugger-on-failures)
@@ -15,10 +18,13 @@ See [py.test usage](https://docs.pytest.org/en/latest/usage.html) for more.
 
 ### Example
 The most common use case is adding a new (still failing) test, and wanting to
-* (re-)run it as fast as possible (`-B` and `-k foo`)
+* (re-)run it as fast as possible
+   * skip building with `-B`
+   * skip linting with `-L`
+   * skip all other tests but 'foo' with `-k foo`
 * see output from quick and dirty `print` statements in the test (`-vvv`)
 * get into an interactive pdb session to inspect what went wrong (`--pdb`)
 
 ```
-./tests/bin/docker-tests.sh -B -- -k foo -vvv --pdb
+./tests/bin/docker-tests.sh -B -L -k foo -vvv --pdb
 ```

--- a/tests/bin/docker-tests.sh
+++ b/tests/bin/docker-tests.sh
@@ -67,52 +67,28 @@ main() {
         docker tag "$DOCKER_IMAGE" "flywheel/core:testing"
     fi
 
-    log "Cleaning pyc and previous coverage results ..."
-    # Run within container to avoid permission problems
-    docker run --rm \
-        --name core-test-cleanup \
-        --volume $(pwd):/var/scitran/code/api \
-        --workdir /var/scitran/code/api \
-        flywheel/core:testing \
-        sh -c "
-            find . -type d -name __pycache__ -exec rm -rf {} \;;
-            find . -type f -name '*.pyc' -delete;
-            rm -rf .coverage htmlcov;
-        "
-
+    log "INFO: Spinning up dependencies ..."
     trap clean_up EXIT
+
     docker network create core-test
 
-    # Launch core test service (includes mongo)
     docker run -d \
-        --name core-test-service \
+        --name core-test-mongo \
         --network core-test \
-        --volume $(pwd)/api:/var/scitran/code/api/api \
-        --volume $(pwd)/tests:/var/scitran/code/api/tests \
-        --env PRE_RUNAS_CMD='[ "$1" = uwsgi ] && mongod > /dev/null 2>&1 &' \
-        --env SCITRAN_CORE_DRONE_SECRET=secret \
-        --env SCITRAN_RUNTIME_COVERAGE=true \
-        --env SCITRAN_CORE_ACCESS_LOG_ENABLED=true \
-        --workdir /var/scitran/code/api \
         flywheel/core:testing \
-            uwsgi --ini /var/scitran/config/uwsgi-config.ini --http [::]:9000 \
-            --processes 1 --threads 1 --enable-threads \
-            --http-keepalive --so-keepalive --add-header "Connection: Keep-Alive" \
-            --logformat '[%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) request_id=%(request_id)'
+        mongod
 
     # Run core test cmd
     local CORE_TEST_CMD
     [ $RUN_SHELL ] && CORE_TEST_CMD=bash || \
                       CORE_TEST_CMD="tests/bin/tests.sh -- $PYTEST_ARGS"
     docker run -it \
-        --name core-test-runner \
+        --name core-test-core \
         --network core-test \
         --volume $(pwd)/api:/var/scitran/code/api/api \
         --volume $(pwd)/tests:/var/scitran/code/api/tests \
-        --env SCITRAN_SITE_API_URL=http://core-test-service:9000/api \
-        --env SCITRAN_CORE_DRONE_SECRET=secret \
-        --env SCITRAN_PERSISTENT_DB_URI=mongodb://core-test-service:27017/scitran \
-        --env SCITRAN_PERSISTENT_DB_LOG_URI=mongodb://core-test-service:27017/logs \
+        --env SCITRAN_PERSISTENT_DB_URI=mongodb://core-test-mongo:27017/scitran \
+        --env SCITRAN_PERSISTENT_DB_LOG_URI=mongodb://core-test-mongo:27017/logs \
         --workdir /var/scitran/code/api \
         flywheel/core:testing \
         $CORE_TEST_CMD
@@ -123,41 +99,19 @@ clean_up() {
     local TEST_RESULT_CODE=$?
     set +e
 
-    if [ "${TEST_RESULT_CODE}" = "0" ]; then
-        log "INFO: Test return code = $TEST_RESULT_CODE"
-        log "INFO: Collecting coverage..."
+    log "INFO: Saving test artifacts ..."
+    docker cp core-test-core:/var/scitran/code/api/htmlcov .
+    docker cp core-test-core:/var/scitran/code/api/coverage.xml .
+    docker cp core-test-core:/var/scitran/code/api/endpoints.json .
 
-        # Copy unit test coverage
-        docker cp core-test-runner:/var/scitran/code/api/.coverage .coverage.unit-tests
-
-        # Save integration test coverage
-        docker wait $(docker stop core-test-service)
-        docker cp core-test-service:/var/scitran/code/api/.coverage.integration-tests .
-
-        # Combine unit/integ coverage and report/grenerate html
-        docker run --rm \
-            --name core-test-coverage \
-            --volume $(pwd):/var/scitran/code/api \
-            --workdir /var/scitran/code/api \
-            flywheel/core:testing \
-            sh -c '
-                coverage combine;
-                coverage report --skip-covered --show-missing;
-                coverage html;
-                coverage xml;
-            '
-    else
-        log "ERROR: Test return code = $TEST_RESULT_CODE"
-        if [ -f tests/running_integration ]; then
-            log "INFO: Tailing core logs..."
-            docker logs --tail 25 core-test-service
-        fi
-    fi
-
-    # Spin down core service
-    docker rm --force --volumes core-test-runner
-    docker rm --force --volumes core-test-service
+    log "INFO: Spinning down dependencies ..."
+    docker rm --force --volumes core-test-core
+    docker rm --force --volumes core-test-mongo
     docker network rm core-test
+
+    [ "$TEST_RESULT_CODE" = "0" ] && log "INFO: Test return code = $TEST_RESULT_CODE" \
+                                  || log "ERROR: Test return code = $TEST_RESULT_CODE"
+
     exit $TEST_RESULT_CODE
 }
 

--- a/tests/bin/tests.sh
+++ b/tests/bin/tests.sh
@@ -7,7 +7,7 @@ cd "$( dirname "$0" )/../.."
 
 USAGE="
 Usage:
-    $0 [-- PYTEST_ARGS...]
+    $0 [OPTION...] [[--] PYTEST_ARGS...]
 
 Runs all tests (unit, integ and linting) if no options are provided.
 
@@ -16,7 +16,12 @@ of its dependencies are installed the same way as in the Dockerfile.
 
 Options:
     -h, --help           Print this help and exit
-    -- PYTEST_ARGS       Arguments passed to py.test
+
+    -s, --shell          Enter shell instead of running tests
+    -l, --lint-only      Run linting only
+    -L, --skip-lint      Skip linting
+
+    PYTEST_ARGS          Arguments passed to py.test
 
 Envvars (required for integration tests):
     SCITRAN_PERSISTENT_DB_URI       Mongo URI to the scitran DB
@@ -26,7 +31,8 @@ Envvars (required for integration tests):
 
 main() {
     export PYTHONDONTWRITEBYTECODE=1
-    local PYTEST_ARGS=
+    local RUN_SHELL=false
+    local LINT_TOGGLE=
 
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -34,15 +40,21 @@ main() {
                 log "$USAGE"
                 exit 0
                 ;;
+            -s|--shell)
+                RUN_SHELL=true
+                ;;
+            -l|--lint-only)
+                LINT_TOGGLE=true
+                ;;
+            -L|--skip-lint)
+                LINT_TOGGLE=false
+                ;;
             --)
                 shift
-                PYTEST_ARGS="$@"
                 break
                 ;;
             *)
-                log "Invalid argument: $1"
-                log "$USAGE"
-                exit 1
+                break
                 ;;
         esac
         shift
@@ -51,56 +63,74 @@ main() {
     log "INFO: Cleaning pyc and previous coverage results ..."
     find . -type d -name __pycache__ -exec rm -rf {} \;
     find . -type f -name '*.pyc' -delete
-    rm -rf .coverage htmlcov
+    rm -rf .coverage htmlcov tests/artifacts
 
-    log "INFO: Staring core ..."
-    export SCITRAN_CORE_DRONE_SECRET=${SCITRAN_CORE_DRONE_SECRET:-change-me}
-    uwsgi --ini /var/scitran/config/uwsgi-config.ini --http [::]:9000 \
-        --env SCITRAN_COLLECT_ENDPOINTS=true \
-        --env SCITRAN_CORE_ACCESS_LOG_ENABLED=true \
-        --env SCITRAN_CORE_LOG_LEVEL=debug \
-        --env SCITRAN_RUNTIME_COVERAGE=true \
-        --processes 1 --threads 1 --enable-threads \
-        --http-keepalive --so-keepalive --add-header "Connection: Keep-Alive" \
-        --logformat '[%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) request_id=%(request_id)' \
-        >/tmp/core.log 2>&1 &
-    export CORE_PID=$!
-    export SCITRAN_SITE_API_URL=http://localhost:9000/api
+    if [ "$LINT_TOGGLE" != true ]; then
+        log "INFO: Staring core ..."
+        export SCITRAN_CORE_DRONE_SECRET=${SCITRAN_CORE_DRONE_SECRET:-change-me}
+        uwsgi --ini /var/scitran/config/uwsgi-config.ini --http [::]:9000 \
+            --env SCITRAN_COLLECT_ENDPOINTS=true \
+            --env SCITRAN_CORE_ACCESS_LOG_ENABLED=true \
+            --env SCITRAN_CORE_LOG_LEVEL=debug \
+            --env SCITRAN_RUNTIME_COVERAGE=true \
+            --processes 1 --threads 1 --enable-threads \
+            --http-keepalive --so-keepalive --add-header "Connection: Keep-Alive" \
+            --logformat '[%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) request_id=%(request_id)' \
+            >/tmp/core.log 2>&1 &
+        export CORE_PID=$!
+        export SCITRAN_SITE_API_URL=http://localhost:9000/api
 
-    log "INFO: Running unit tests ..."
-    # pytest exits with 5 when no tests were selected at all: do not exit prematurely when
-    # selecting integration tests via `pytest -k` (and thereby deselecting all unit tests)
-    py.test --exitfirst --cov=api --cov-report= tests/unit_tests/python $PYTEST_ARGS || [ $? = 5 ]
+        if [ $RUN_SHELL = true ]; then
+            log "INFO: Entering test shell ..."
+            bash
+            exit
+        fi
 
-    log "INFO: Running integration tests ..."
-    py.test --exitfirst tests/integration_tests/python $PYTEST_ARGS || tail_logs_and_exit $?
+        log "INFO: Running unit tests ..."
+        py.test --exitfirst --cov=api --cov-report= tests/unit_tests/python "$@" || allow_skip_all
 
-    log "INFO: Running pylint ..."
-    # TODO Enable Refactor and Convention reports
-    # TODO Move --disable into rc
-    pylint --rcfile=tests/.pylintrc --jobs=4 --reports=no --disable=C,R,W0312,W0141,W0110 api
+        log "INFO: Running integration tests ..."
+        py.test --exitfirst tests/integration_tests/python "$@" || allow_skip_all || tail_logs_and_exit
 
-    # log "INFO: Running pep8 ..."
-    # pep8 --max-line-length=150 --ignore=E402 api
+        log "INFO: Stopping core ..."
+        kill $CORE_PID || true
+        wait 2>/dev/null
 
-    log "INFO: Stopping core ..."
-    kill $CORE_PID || true
-    wait 2>/dev/null
+        log "INFO: Collecting coverage ..."
+        coverage combine
+        coverage html
+        coverage xml
+        coverage report --skip-covered --show-missing
 
-    log "INFO: Collecting coverage ..."
-    coverage combine
-    coverage html
-    coverage xml
-    coverage report --skip-covered --show-missing
+        touch tests/artifacts
+        chown -R $(stat -c %u:%g tests) .
+    fi
+
+    if [ "$LINT_TOGGLE" != false ]; then
+        log "INFO: Running pylint ..."
+        # TODO Enable Refactor and Convention reports
+        # TODO Move --disable into rc
+        pylint --rcfile=tests/.pylintrc --jobs=4 --reports=no --disable=C,R,W0312,W0141,W0110 api
+
+        # log "INFO: Running pep8 ..."
+        # pep8 --max-line-length=150 --ignore=E402 api
+    fi
+}
+
+
+allow_skip_all() {
+    # Allow pytest exit code 5 when no tests were selected
+    local PYTEST_EXIT_CODE=$?
+    [ $PYTEST_EXIT_CODE = 5 ] && return 0 \
+                              || return $PYTEST_EXIT_CODE
 }
 
 
 tail_logs_and_exit() {
+    local PYTEST_EXIT_CODE=$?
     log "INFO: Tailing core logs ..."
     tail --lines=10 /tmp/core.log
-    rm -f tests/running_integration
-
-    exit $1
+    exit $PYTEST_EXIT_CODE
 }
 
 

--- a/tests/bin/tests.sh
+++ b/tests/bin/tests.sh
@@ -19,11 +19,8 @@ Options:
     -- PYTEST_ARGS       Arguments passed to py.test
 
 Envvars (required for integration tests):
-    SCITRAN_SITE_API_URL            URI to a running core instance (including /api)
-    SCITRAN_CORE_DRONE_SECRET       API shared secret
     SCITRAN_PERSISTENT_DB_URI       Mongo URI to the scitran DB
     SCITRAN_PERSISTENT_DB_LOG_URI   Mongo URI to the scitran log DB
-
 "
 
 
@@ -51,32 +48,59 @@ main() {
         shift
     done
 
+    log "INFO: Cleaning pyc and previous coverage results ..."
+    find . -type d -name __pycache__ -exec rm -rf {} \;
+    find . -type f -name '*.pyc' -delete
+    rm -rf .coverage htmlcov
+
+    log "INFO: Staring core ..."
+    export SCITRAN_CORE_DRONE_SECRET=${SCITRAN_CORE_DRONE_SECRET:-change-me}
+    uwsgi --ini /var/scitran/config/uwsgi-config.ini --http [::]:9000 \
+        --env SCITRAN_COLLECT_ENDPOINTS=true \
+        --env SCITRAN_CORE_ACCESS_LOG_ENABLED=true \
+        --env SCITRAN_CORE_LOG_LEVEL=debug \
+        --env SCITRAN_RUNTIME_COVERAGE=true \
+        --processes 1 --threads 1 --enable-threads \
+        --http-keepalive --so-keepalive --add-header "Connection: Keep-Alive" \
+        --logformat '[%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) request_id=%(request_id)' \
+        >/tmp/core.log 2>&1 &
+    export CORE_PID=$!
+    export SCITRAN_SITE_API_URL=http://localhost:9000/api
+
     log "INFO: Running unit tests ..."
-    py.test --exitfirst --cov=api --cov-report= tests/unit_tests/python $PYTEST_ARGS
+    # pytest exits with 5 when no tests were selected at all: do not exit prematurely when
+    # selecting integration tests via `pytest -k` (and thereby deselecting all unit tests)
+    py.test --exitfirst --cov=api --cov-report= tests/unit_tests/python $PYTEST_ARGS || [ $? = 5 ]
 
     log "INFO: Running integration tests ..."
-    if [ "${0##*/}" = "run-tests-ubuntu.sh" ]; then
-        # Temporary fly/fly backwards compatibility workaround
-        # TODO (Ambrus) Remove together with sh symlink
-        export SCITRAN_SITE_API_URL=http://localhost:9000/api
-        uwsgi --ini /var/scitran/config/uwsgi-config.ini --http [::]:9000 \
-            --processes 1 --threads 1 --enable-threads \
-            --http-keepalive --so-keepalive --add-header "Connection: Keep-Alive" \
-            --logformat '[%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) request_id=%(request_id)' \
-        &
-    fi
-
-    touch tests/running_integration
-    py.test --exitfirst tests/integration_tests/python $PYTEST_ARGS
-    rm tests/running_integration
+    py.test --exitfirst tests/integration_tests/python $PYTEST_ARGS || tail_logs_and_exit $?
 
     log "INFO: Running pylint ..."
     # TODO Enable Refactor and Convention reports
     # TODO Move --disable into rc
     pylint --rcfile=tests/.pylintrc --jobs=4 --reports=no --disable=C,R,W0312,W0141,W0110 api
 
-    # log "Running pep8 ..."
+    # log "INFO: Running pep8 ..."
     # pep8 --max-line-length=150 --ignore=E402 api
+
+    log "INFO: Stopping core ..."
+    kill $CORE_PID || true
+    wait 2>/dev/null
+
+    log "INFO: Collecting coverage ..."
+    coverage combine
+    coverage html
+    coverage xml
+    coverage report --skip-covered --show-missing
+}
+
+
+tail_logs_and_exit() {
+    log "INFO: Tailing core logs ..."
+    tail --lines=10 /tmp/core.log
+    rm -f tests/running_integration
+
+    exit $1
 }
 
 


### PR DESCRIPTION
Some issues were introduced with the build/test refactor:
* Unable to run a single integ test @davidfarkas @ehlertjd 
* Generic storage tests rely on access to `PERSISTENT_DATA_PATH` @davidfarkas 

This PR fixes the above.
* Run uwsgi within tests.sh (fly/fly and generic storage expectation);
* Consequently move coverage collection and small cmds to tests.sh;
* Re-enable (fix) selecting a single integration test via "pytest -k";
* Improve test output (eg. print exit code last);



### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
