### PR TITLE
Use temp PERSISTENT_DATA_PATH in test.sh (fixes fly/fly ci)

### DIFF
--- a/tests/bin/tests.sh
+++ b/tests/bin/tests.sh
@@ -68,6 +68,7 @@ main() {
     if [ "$LINT_TOGGLE" != true ]; then
         log "INFO: Staring core ..."
         export SCITRAN_CORE_DRONE_SECRET=${SCITRAN_CORE_DRONE_SECRET:-change-me}
+        export SCITRAN_PERSISTENT_DATA_PATH=$(mktemp -d)
         uwsgi --ini /var/scitran/config/uwsgi-config.ini --http [::]:9000 \
             --env SCITRAN_COLLECT_ENDPOINTS=true \
             --env SCITRAN_CORE_ACCESS_LOG_ENABLED=true \


### PR DESCRIPTION
* uwsgi and tests are run as root within the container
* refactored `tests.sh` used the default data path `/var/scitran/persistent/data`
* that worked fine with fly/core tests
* but breaks fly/fly:
   * folder is bind-mounted via compose, inherits from dev
   * tests write files owned by root to common location
   * causes cleanup permission errors in fly/fly (see raw ci log tail of [storage integration PR](https://github.com/flywheel-io/flywheel/pull/567) below)

Relevant error in raw ci logs of example PR :
```
rm: cannot remove 'tokens/packfile': Permission denied

rm: cannot remove 'v0/sha384/8d/9c/v0-sha384-8d9c11b2ce58514ad7da2b87bfb19b12d3e1937c1d8b5fff96fc98af1bd3629b1bd1399cdc4acfccc37695e12bcf7697': Permission denied
```

Solution: use temp dir for PERSISTENT_DATA_PATH within test container, as before.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
