### PR TITLE
Fix SSE by bypassing webapp2 handling

### DIFF
--- a/api/web/start.py
+++ b/api/web/start.py
@@ -82,6 +82,9 @@ def dispatcher(router, request, response):
     try:
         rv = router.default_dispatcher(request, response)
         if rv is not None:
+            # Bypass webapp2 handler, rv will be called with (environ, start_response)
+            if callable(rv):
+                return rv
             response.write(json.dumps(rv, default=encoder.custom_json_serializer))
             response.headers['Content-Type'] = 'application/json; charset=utf-8'
     except webapp2.HTTPException as e:


### PR DESCRIPTION
SSE Fix, now with 20% more sanity than #1132 ! 

By returning a callable from our request handler, we can take over sending SSE events with the `start_response` call. Tested with a 6-minute long SSE stream. Also tested that client disconnect does not interrupt handling.

Closes #946.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
