### PR TITLE
Temp CI fix for avoiding prompt on docker login

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
 before_install:
 - sudo apt-get update
 - sudo apt-get -y install docker-ce realpath
-- docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASS
+- yes | docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASS
 
 install: true
 


### PR DESCRIPTION
CI broke, likely due to a docker-ce update that now prompts as [follows](https://travis-ci.org/flywheel-io/core/jobs/365013040#L551):
```
...
$ docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASS
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
WARNING! Your password will be stored unencrypted in /home/travis/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store
Are you sure you want to proceed? [y/N] 
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
...
```

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
