### PR TITLE
Fix docker build errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ CMD ["uwsgi", "--ini=/var/scitran/config/uwsgi-config.ini", "--http=[::]:9000", 
 FROM base as dist
 COPY requirements.txt /var/scitran/code/api/requirements.txt
 RUN set -eux \
-    && pip install -qq --requirement /var/scitran/code/api/requirements.txt
+    && pip install -qq --ignore-installed --requirement /var/scitran/code/api/requirements.txt
 
 COPY . /var/scitran/code/api/
 RUN set -eux \
@@ -88,6 +88,6 @@ COPY --from=dist /usr/local /usr/local
 
 COPY tests/requirements.txt /var/scitran/code/api/tests/requirements.txt
 RUN set -eux \
-    && pip install -qq --requirement /var/scitran/code/api/tests/requirements.txt
+    && pip install -qq --ignore-installed --requirement /var/scitran/code/api/tests/requirements.txt
 
 COPY --from=dist /var/scitran /var/scitran

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pymongo==3.2
 python-dateutil==2.4.2
 pytz==2015.7
 requests[security]==2.18.4
-rfc3987==1.3.4
+rfc3987==1.3.7
 strict-rfc3339==0.7
 unicodecsv==0.9.0
 uwsgi==2.0.13.1


### PR DESCRIPTION
@ryansanford: @zoltanr ran into this CI failure on fly/fly:
https://travis-ci.com/flywheel-io/flywheel/builds/70907001#L9584

There was a major pip overhaul, which now errs out as above because of the package conflict with the system-installed urllib3.

Long term solution will be replacing base image and using a newer python, which is in scope for "improvements-backport-2".

CI for _this PR_ fails due to PyPI [rollout issues](https://status.python.org/) like the [redirect loop in the logs](https://travis-ci.org/flywheel-io/core/jobs/367207069#L679).

Update: PyPI is back online and the restarted builds passed without fail.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
