### PR TITLE
Add device CRUD handlers and device key auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .cache
 .DS_Store
 /.coverage*
+/.pytest_cache
 /bin/accesslog.csv
 /htmlcov
 /persistent

--- a/api/dao/containerstorage.py
+++ b/api/dao/containerstorage.py
@@ -176,8 +176,6 @@ class SubjectStorage(ContainerStorage):
         return SessionStorage().get_all_el(query, None, projection)
 
 
-
-
 class SessionStorage(ContainerStorage):
 
     def __init__(self):
@@ -343,7 +341,6 @@ class SessionStorage(ContainerStorage):
             raise ValueError('Cannot get all sessions from target container {}'.format(target_type))
 
         return self.get_all_el(query, user, projection)
-
 
 
 class AcquisitionStorage(ContainerStorage):

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -151,8 +151,8 @@ class ContainerHandler(base.RequestHandler):
                 j_id   = f['origin']['id']
                 j_id_b = j_id
 
-                # Some tables don't use BSON for their primary keys.
-                if j_type not in (Origin.user, Origin.device):
+                # Only user table doesn't use BSON for it's primary key.
+                if j_type != Origin.user:
                     j_id_b = bson.ObjectId(j_id)
 
                 # Join from database if we haven't for this origin before

--- a/api/handlers/devicehandler.py
+++ b/api/handlers/devicehandler.py
@@ -4,8 +4,9 @@ from ..web import base
 from .. import config
 from .. import util
 from ..auth import require_drone, require_login, require_superuser
+from ..auth.apikeys import DeviceApiKey
 from ..dao import containerstorage
-from ..web.errors import APINotFoundException
+from ..web.errors import APINotFoundException, APIValidationException
 from ..validators import validate_data
 
 log = config.log
@@ -22,63 +23,84 @@ class DeviceHandler(base.RequestHandler):
 
     def __init__(self, request=None, response=None):
         super(DeviceHandler, self).__init__(request, response)
-        self.storage = containerstorage.ContainerStorage('devices', use_object_id=False)
+        self.storage = containerstorage.ContainerStorage('devices', use_object_id=True)
 
     @require_login
     def get(self, device_id):
-        return self.storage.get_container(device_id)
+        device = self.storage.get_container(device_id)
+        if self.user_is_admin:
+            self.join_api_key(device)
+        return device
 
     @require_login
     def get_all(self):
-        return self.storage.get_all_el(None, None, None)
+        devices = list(self.storage.get_all_el(None, None, None))
+        if self.user_is_admin and self.is_true('join_keys'):
+            for device in devices:
+                self.join_api_key(device)
+        return devices
 
-    @require_drone
-    def get_self(self):
-        device_id = self.origin.get('id', '')
-        return self.storage.get_container(device_id)
+    @staticmethod
+    def join_api_key(device):
+        api_key = DeviceApiKey.get(device['_id'])
+        device['key'] = api_key['_id'] if api_key else DeviceApiKey.generate(device['_id'])
 
-    @require_drone
+    @require_superuser
     def post(self):
-        device_id = self.origin.get('id', '')
-        payload = self.request.json_body
-        # Clean this up when validate_data method is fixed to use new schemas
-        # POST unnecessary, used to avoid run-time modification of schema
+        payload = self.request.json_body if self.request.body else {}
+
+        # Temp device check-in backwards-compatibility
+        if self.origin.get('type') == 'device':
+            return self.put_self()
+
         validate_data(payload, 'device.json', 'input', 'POST', optional=True)
+        result = self.storage.create_el(payload)
+        if not result.acknowledged:
+            raise APINotFoundException('Device not created')
+        key = DeviceApiKey.generate(result.inserted_id)
+        return {'_id': result.inserted_id, 'key': key}
+
+    @require_superuser
+    def delete(self, device_id):
+        result = self.storage.delete_el(device_id)
+        if result.deleted_count != 1:
+            raise APINotFoundException('Device not found')
+        return {'deleted': result.deleted_count}
+
+    @require_login
+    def get_status(self):
+        now = dt.datetime.now()
+        statuses = {}
+        for device in self.storage.get_all_el(None, None, None):
+            status = {'last_seen': device.get('last_seen')}
+            if device.get('errors'):
+                status['status'] = str(Status.error)
+                status['errors'] = device['errors']
+            elif not device.get('interval') or not device.get('last_seen'):
+                status['status'] = str(Status.unknown)
+            elif (now - device['last_seen']).seconds > device['interval']:
+                status['status'] = str(Status.missing)
+            else:
+                status['status'] = str(Status.ok)
+            statuses[str(device['_id'])] = status
+
+        return statuses
+
+    @require_drone
+    def put_self(self):
+        device_id = self.origin.get('id', '')
+        device = self.storage.get_container(device_id)
+
+        if not self.request.body:
+            return {'modified': 0}
+
+        payload = self.request.json_body
+        validate_data(payload, 'device-update.json', 'input', 'PUT', optional=True)
+
+        # New devices created via POST may have `type` not set. Devices are allowed to initialize
+        # the field themselves, but not allowed to change it (which implies a different device).
+        if 'type' in payload and device.get('type') not in (None, payload['type']):
+            raise APIValidationException({'reason': 'Cannot change device type'})
 
         result = self.storage.update_el(device_id, payload)
-        if result.matched_count == 1:
-            return {'modified': result.modified_count}
-        else:
-            raise APINotFoundException('Device with id {} not found, state not updated'.format(device_id))
-
-    # NOTE method not routed in api.py
-    @require_superuser
-    def delete(self, device_id): # pragma: no cover
-        raise NotImplementedError()
-
-    def get_status(self):
-        devices = self.storage.get_all_el(None, None, None)
-        response = {}
-        now = dt.datetime.now()
-        for d in devices:
-            d_obj = {}
-            d_obj['last_seen'] = d.get('last_seen')
-
-            if d.get('errors'):
-                d_obj['status'] = str(Status.error)
-                d_obj['errors'] = d.get('errors')
-                response[d.get('_id')] = d_obj.copy()
-
-            elif not d.get('interval'):
-                d_obj['status'] = str(Status.unknown)
-                response[d.get('_id')] = d_obj.copy()
-
-            elif (now-d.get('last_seen', now)).seconds > d.get('interval'):
-                d_obj['status'] = str(Status.missing)
-                response[d.get('_id')] = d_obj.copy()
-
-            else:
-                d_obj['status'] = str(Status.ok)
-                response[d.get('_id')] = d_obj.copy()
-
-        return response
+        return {'modified': result.modified_count}

--- a/swagger/examples/output/device-list.json
+++ b/swagger/examples/output/device-list.json
@@ -1,45 +1,45 @@
 [
   {
-    "errors": null,
-    "method": "bootstrapper",
-    "interval": 500,
-    "_id": "bootstrapper_Bootstrapper",
+    "_id": "000000000000000000000000",
+    "type": "bootstrapper",
     "name": "Bootstrapper",
+    "errors": null,
+    "interval": 500,
     "last_seen": "2016-11-28T18:54:11.880000+00:00"
   },
   {
-    "errors": null,
+    "_id": "000000000000000000000001",
+    "type": "gear-register",
     "name": "flywheel-utility",
+    "errors": null,
     "interval": 700,
-    "_id": "gear-register_flywheel-utility",
-    "method": "gear-register",
     "last_seen": "2016-11-29T18:51:39.836000+00:00"
   },
   {
-    "errors": null,
-    "method": "importer",
-    "_id": "importer_admin_import",
+    "_id": "000000000000000000000002",
+    "type": "importer",
     "name": "admin import",
+    "errors": null,
     "last_seen": "2016-11-28T18:57:27.104000+00:00"
   },
   {
-    "errors": null,
+    "_id": "000000000000000000000003",
+    "type": "cron",
     "name": "Cron",
-    "_id": "cron_Cron",
-    "method": "cron",
+    "errors": null,
     "last_seen": "2016-11-28T23:17:01.261000+00:00"
   },
   {
+    "_id": "000000000000000000000004",
+    "type": "test_type",
+    "name": "example_drone",
     "info": {
       "basic": "info"
     },
     "errors": [
       "An Error"
     ],
-    "name": "example_drone",
     "interval": 400,
-    "_id": "test_method_megans_drone",
-    "method": "test_method",
     "last_seen": "2016-11-28T23:14:06.004000+00:00"
   }
 ]

--- a/swagger/examples/output/device.json
+++ b/swagger/examples/output/device.json
@@ -1,13 +1,13 @@
 {
+  "_id": "000000000000000000000000",
+  "type": "reaper",
+  "name": "FolderReaper_tmp",
   "info": {
     "basic": "info"
   },
   "errors": [
     "An Error"
   ],
-  "name": "example_drone",
   "interval": 400,
-  "_id": "test_method_megans_drone",
-  "method": "test_method",
   "last_seen": "2016-11-28T23:14:06.004000+00:00"
 }

--- a/swagger/paths/devices.yaml
+++ b/swagger/paths/devices.yaml
@@ -14,11 +14,11 @@
           response:
             $ref: examples/output/device-list.json
   post:
-    summary: Modify a device's interval, info or set errors.
+    summary: Create a new device.
     description: |
-      Will modify the device record of device making the request.
-      Request must be drone request.
-    operationId: update_device
+      Will create a new device record together with an api key.
+      Request must be an admin request.
+    operationId: create_device
     tags:
     - devices
     responses:
@@ -34,10 +34,13 @@
         schema:
           $ref: schemas/input/device.json
 /devices/self:
-  get:
-    summary: Get device document for device making the request.
-    description: Request must be a drone request.
-    operationId: get_current_device
+  put:
+    summary: Modify a device's type, name, interval, info or set errors.
+    description: |
+      Will modify the device record of the device making the request.
+      Type may only be set once if not already specified at creation.
+      Request must be a drone request.
+    operationId: update_device
     tags:
     - devices
     responses:
@@ -48,6 +51,12 @@
         examples:
           response:
               $ref: examples/output/device.json
+    parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: schemas/input/device-update.json
 /devices/status:
   get:
     summary: Get status for all known devices.

--- a/swagger/schemas/definitions/device.json
+++ b/swagger/schemas/definitions/device.json
@@ -25,9 +25,12 @@
     "device": {
       "type": "object",
       "properties": {
-        "_id":       {"type":"string"},
-        "method":    {"type":"string"},
+        "_id":       {"$ref":"common.json#/definitions/objectid"},
+        "label":     {"type":"string"},
+        "type":      {"type":"string"},
+        "version":   {"type":"string"},
         "name":      {"type":"string"},
+        "key":       {"type":"string"},
         "errors":    {"$ref":"#/definitions/errors"},
         "info":      {"$ref":"common.json#/definitions/info"},
         "interval":  {"$ref":"#/definitions/interval"},
@@ -36,12 +39,24 @@
       "x-sdk-model": "device",
       "additionalProperties": false
     },
-    "device-input":{
+    "device-input": {
       "type": "object",
       "properties": {
-        "interval":       {"$ref":"#/definitions/interval"},
-        "errors":         {"$ref":"#/definitions/errors"},
-        "info":           {"$ref":"common.json#/definitions/info"}
+        "label": {"type":"string"},
+        "type":  {"type":"string"}
+      },
+      "x-sdk-model": "device",
+      "additionalProperties": false
+    },
+    "device-update": {
+      "type": "object",
+      "properties": {
+        "type":     {"type":"string"},
+        "version":  {"type":"string"},
+        "name":     {"type":"string"},
+        "interval": {"$ref":"#/definitions/interval"},
+        "errors":   {"$ref":"#/definitions/errors"},
+        "info":     {"$ref":"common.json#/definitions/info"}
       },
       "x-sdk-model": "device",
       "additionalProperties": false
@@ -49,15 +64,15 @@
     "device-output": {
       "type": "object",
       "allOf": [{"$ref":"#/definitions/device"}],
-      "required": ["_id", "name", "method", "last_seen"],
+      "required": ["_id", "type", "name", "last_seen"],
       "x-sdk-model": "device"
     },
     "device-status": {
       "type":"object",
       "patternProperties": {
-        "^[0-9a-z.@_-]*$":{
+        "^[a-fA-F0-9]{24}$": {
           "$ref": "#/definitions/device-status-entry"
-        }      
+        }
       }
     }
   }

--- a/swagger/schemas/input/device-update.json
+++ b/swagger/schemas/input/device-update.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "allOf": [{"$ref":"../definitions/device.json#/definitions/device-update"}],
+  "example": {
+    "info": {
+      "basic": "info"
+    },
+    "errors": [
+      "An Error"
+    ],
+    "interval": 400
+  }
+}

--- a/swagger/schemas/input/device.json
+++ b/swagger/schemas/input/device.json
@@ -1,13 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "allOf":[{"$ref":"../definitions/device.json#/definitions/device-input"}],
+  "allOf": [{"$ref":"../definitions/device.json#/definitions/device-input"}],
   "example": {
-	  "info": {
-	    "basic": "info"
-	  },
-	  "errors": [
-	    "An Error"
-	  ],
-	  "interval": 400
-	}
+    "type": "reaper",
+    "label": "UI-friendly Reaper Name"
+  }
 }

--- a/swagger/schemas/output/device.json
+++ b/swagger/schemas/output/device.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "allOf":[{"$ref":"../definitions/device.json#/definitions/device-output"}]
+  "allOf": [{"$ref":"../definitions/device.json#/definitions/device-output"}]
 }

--- a/tests/integration_tests/python/test_devices.py
+++ b/tests/integration_tests/python/test_devices.py
@@ -1,0 +1,119 @@
+import datetime
+
+import bson
+
+
+def test_devices(as_public, as_user, as_admin, as_root, as_drone, api_db):
+    # try to get all devices w/o logging in
+    r = as_public.get('/devices')
+    assert r.status_code == 403
+
+    # get all devices
+    r = as_user.get('/devices?join_keys=true')
+    assert r.ok
+
+    # bw-comp: verify test bootstrapper exists and has uid
+    assert r.json()
+    drone = r.json()[0]
+    drone_id = drone['_id']
+
+    # bw-comp: verify test bootstrapper has api key after first get
+    assert as_admin.get('/devices/' + drone_id).ok
+    assert api_db.apikeys.count({'uid': bson.ObjectId(drone_id), 'type': 'device'}) == 1
+
+    # verify users don't have access to device keys, but admins do
+    assert 'key' not in drone
+    r = as_admin.get('/devices?join_keys=true')
+    assert r.ok
+    assert 'key' in r.json()[0]
+
+    # try to get devices w/o logging in
+    r = as_public.get('/devices/' + drone_id)
+    assert r.status_code == 403
+
+    # try to get non-existent device
+    r = as_user.get('/devices/000000000000000000000000')
+    assert r.status_code == 404
+
+    # get device
+    r = as_user.get('/devices/' + drone_id)
+    assert r.ok
+
+    # bw-comp: verify devices using secret have type instead of method
+    drone = r.json()
+    assert 'type' in drone
+    assert 'method' not in drone
+
+    # verify users don't have access to device keys, but admins do
+    assert 'key' not in drone
+    r = as_admin.get('/devices/' + drone_id)
+    assert r.ok
+    assert 'key' in r.json()
+
+    # try to do device check-in as user
+    r = as_root.put('/devices/self')
+    assert r.status_code == 403
+
+    # do empty device check-in (implicit last_seen update)
+    r = as_drone.put('/devices/self')
+    assert r.ok
+
+    # verify last_seen was updated
+    r = as_user.get('/devices/' + drone_id)
+    assert r.ok
+    drone_ = r.json()
+    assert drone_['last_seen'] > drone['last_seen']
+    del drone['last_seen']
+    del drone_['last_seen']
+    assert drone_ == drone
+
+    # try to get device statuses w/o logging in
+    r = as_public.get('/devices/status')
+    assert r.status_code == 403
+
+    # get device statuses
+    r = as_user.get('/devices/status')
+    assert r.ok
+    assert drone_id in r.json()
+
+    # try to create device w/o root
+    r = as_admin.post('/devices')
+    assert r.status_code == 403
+
+    # create device
+    r = as_root.post('/devices', json={'type': 'test'})
+    assert r.ok
+    device_id = r.json()['_id']
+    assert api_db.apikeys.count({'uid': bson.ObjectId(device_id), 'type': 'device'}) == 1
+    r = as_admin.get('/devices/' + device_id)
+    assert r.ok
+    device_key = r.json()['key']
+
+    # no check-in interval or last_seen not set => unknown
+    assert as_user.get('/devices/status').json()[device_id]['status'] == 'unknown'
+
+    # update device - self-set check-in interval (also implicitly updates last_seen)
+    as_device = as_public
+    as_device.headers.update({'Authorization': 'scitran-user {}'.format(device_key)})
+    r = as_device.put('/devices/self', json={'interval': 60})
+    assert r.ok
+
+    # check-in interval set + last_seen new => ok
+    assert as_user.get('/devices/status').json()[device_id]['status'] == 'ok'
+
+    # check-in interval set + last_seen old => missing
+    api_db.devices.update({'_id': bson.ObjectId(device_id)},
+        {'$set': {'last_seen': datetime.datetime.now() - datetime.timedelta(seconds=61)}})
+    assert as_user.get('/devices/status').json()[device_id]['status'] == 'missing'
+
+    # has errors => error
+    r = as_device.put('/devices/self', json={'errors': ['does. not. compute.']})
+    assert r.ok
+    assert as_user.get('/devices/status').json()[device_id]['status'] == 'error'
+
+    # delete device
+    r = as_root.delete('/devices/' + device_id)
+    assert r.ok
+
+    r = as_user.get('/devices/' + device_id)
+    assert r.status_code == 404

--- a/tests/integration_tests/python/test_handlers.py
+++ b/tests/integration_tests/python/test_handlers.py
@@ -1,7 +1,7 @@
-import datetime
 import os
 
 from api.config import release_version_file_path
+
 
 def test_roothandler(as_public):
     r = as_public.get('')
@@ -17,69 +17,6 @@ def test_schemahandler(as_public):
     assert r.ok
     schema = r.json()
     assert all(attr in schema['definitions'] for attr in ('email', 'firstname', 'lastname'))
-
-
-def test_devicehandler(as_user, as_root, as_drone, api_db):
-    # get all devices
-    r = as_user.get('/devices')
-    assert r.ok
-
-    # test that drone is listed
-    drone_id = as_drone.headers['X-SciTran-Method'] + '_' + as_drone.headers['X-SciTran-Name']
-    assert sum(device['_id'] == drone_id for device in r.json()) == 1
-
-    # try to get non-existent device
-    r = as_user.get('/devices/these_arent_the_droids_you_are_looking_for')
-    assert r.status_code == 404
-
-    # get device
-    r = as_user.get('/devices/' + drone_id)
-    assert r.ok
-
-    # get device self
-    r = as_drone.get('/devices/self')
-    assert r.ok
-
-    # get device status list
-    # NOTE unprotected handler method - shouldn't it require_login?
-    r = as_user.get('/devices/status')
-    assert r.ok
-
-    # try to update drone w/o perms (require_drone)
-    r = as_user.post('/devices')
-    assert r.status_code == 403
-
-    # update drone - set check-in interval
-    r = as_drone.post('/devices', json={'interval': 60})
-    assert r.ok
-
-    # inject test device for status checks
-    api_db.devices.insert({
-        '_id': 'test_drone',
-        'last_seen': datetime.datetime.now(),
-        'method': 'test',
-        'name': 'drone',
-        'errors': [],
-    })
-
-    # no check-in interval => unknown
-    assert as_user.get('/devices/status').json()['test_drone']['status'] == 'unknown'
-
-    # check-in interval set => ok
-    api_db.devices.update({'_id': 'test_drone'}, {'$set': {'interval': 60}})
-    assert as_user.get('/devices/status').json()['test_drone']['status'] == 'ok'
-
-    # check-in interval set + last_seen too old => missing
-    api_db.devices.update({'_id': 'test_drone'},
-        {'$set': {'last_seen': datetime.datetime.now() - datetime.timedelta(seconds=61)}})
-    assert as_user.get('/devices/status').json()['test_drone']['status'] == 'missing'
-
-    # has errors => error
-    api_db.devices.update({'_id': 'test_drone'}, {'$set': {'errors': ['does not compute']}})
-    assert as_user.get('/devices/status').json()['test_drone']['status'] == 'error'
-
-    # clean up
-    api_db.devices.remove({'_id': 'test_drone'})
 
 
 def test_config_version(as_user, api_db):

--- a/tests/integration_tests/python/test_upgrades.py
+++ b/tests/integration_tests/python/test_upgrades.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import sys
 
@@ -183,3 +184,28 @@ def test_45(data_builder, randstr, api_db, as_admin, database, file_form):
     }
     for p in [t_project1, t_project2]:
         assert as_admin.get('/projects/' + p).json()['template'] == template_after
+
+
+def test_47(api_db, database):
+    last_seen = datetime.datetime.utcnow().replace(microsecond=0)
+    api_db.devices.insert_one({
+        '_id': 'method_name',
+        'method': 'method',
+        'name': 'name',
+        'last_seen': last_seen,
+        'errors': [],
+    })
+    database.upgrade_to_47()
+    device = api_db.devices.find_one({'type': 'method', 'name': 'name'})
+
+    assert device
+    new_id = device.get('_id')
+    assert isinstance(new_id, bson.ObjectId)
+    assert device == {
+        '_id': new_id,
+        'label': 'method_name',
+        'type': 'method',
+        'name': 'name',
+        'last_seen': last_seen,
+        'errors': [],
+    }


### PR DESCRIPTION
Resolves #1127 

Changes backwards-compatible with shared secret **auth headers**
**Breaking changes** on the device db schema and on `/devices` API endpoints
* rename `._id(str)` to `.label`, `.method` to `.type` (eg. engine, reaper, etc. - not an enum _yet_)
* `._id(ObjectId)` is generated for new and existing devices alike
* Relevant PRs:
   * flywheel-io/reaper#130
   * flywheel-io/flywheel#573 (prometheus dev integration)
   * engine _insert link_

#### New device workflow
* Admins can `POST /devices {"type": str(opt), "label": str(opt)}`
* ApiKey auto-generated and shown _for admins_ `GET /devices` and `/devices/<device_id>`
* Device key usage == user api key usage == `Authorization: scitran-user <device_key>`
* Grants same privileges as old `drone_request` _for backward comp. for now_
* Devices can check in via `PUT /devices/self` (payload and all keys are optional)
```{"type": str, "name": str, "interval": int, "info": object, "errors": list(str)}```

Pending review:
* [ ] flywheel-io/flywheel#573 @ryansanford 
* [x] flywheel-io/reaper#130 @gsfr 
