### PR TITLE
Fix batch jobs with context inputs not running

### DIFF
--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -362,11 +362,12 @@ class Job(object):
             for input_name in self.inputs.keys():
                 i = self.inputs[input_name]
 
-                r['inputs'].append({
-                    'type': 'scitran',
-                    'uri': i.file_uri(i.name),
-                    'location': '/flywheel/v0/input/' + input_name,
-                })
+                if hasattr(i, 'file_uri'):
+                    r['inputs'].append({
+                        'type': 'scitran',
+                        'uri': i.file_uri(i.name),
+                        'location': '/flywheel/v0/input/' + input_name,
+                    })
 
         # Log job origin if provided
         if self.id_:


### PR DESCRIPTION
Found while testing context-inputs on classification-edit branch. 

Batch scheduling a job with context-inputs results in an execution error because each input is treated as a file ref. This is a simple fix, and I verified that the jobs run successfully after this.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
