### PR TITLE
Prevent adding permissions for unknown users

### DIFF
--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -211,8 +211,7 @@ class PermissionsListHandler(ListHandler):
         _id = kwargs.get('cid')
 
         payload = self.request.json_body
-        user_ids = [user['_id'] for user in containerstorage.ContainerStorage('users', use_object_id=False).get_all_el({}, None, None)]
-        if payload.get('_id') not in user_ids:
+        if not self._user_exists(payload.get('_id')):
             raise APIUnknownUserException('Cannot add permission for unknown user {}'.format(payload.get('_id')))
 
         result = super(PermissionsListHandler, self).post(cont_name, list_name, **kwargs)
@@ -266,6 +265,11 @@ class PermissionsListHandler(ListHandler):
             except APIStorageException:
                 self.abort(500, 'permissions not propagated from {} {} down hierarchy'.format(cont_name, _id))
 
+    def _user_exists(self, uid):
+        """
+        Checks if user exists
+        """
+        return bool(containerstorage.ContainerStorage('users', use_object_id=False).get_all_el({'_id': uid}, None, {'_id':1}))
 
 class NotesListHandler(ListHandler):
     """

--- a/tests/integration_tests/python/test_groups.py
+++ b/tests/integration_tests/python/test_groups.py
@@ -6,6 +6,7 @@ def test_groups(as_user, as_admin, data_builder):
     assert r.status_code == 404
 
     group = data_builder.create_group()
+    user_id = data_builder.create_user(_id='test-user@user.com')
 
     # Able to find new group
     r = as_admin.get('/groups/' + group)
@@ -66,7 +67,7 @@ def test_groups(as_user, as_admin, data_builder):
     assert d5 > d4
 
     # Add a permission to the group
-    user = {'access': 'rw', '_id': 'newUser@fakeuser.com'}
+    user = {'access': 'rw', '_id': user_id}
     r = as_admin.post('/groups/' + group + '/permissions', json=user)
     assert r.ok
 
@@ -78,7 +79,7 @@ def test_groups(as_user, as_admin, data_builder):
     assert d6 > d5
 
     # Edit a permission in the group
-    user = {'access': 'ro', '_id': 'newUser@fakeuser.com'}
+    user = {'access': 'ro', '_id': user_id}
     r = as_admin.put('/groups/' + group + '/permissions/' + user['_id'], json=user)
     assert r.ok
 

--- a/tests/integration_tests/python/test_permissions.py
+++ b/tests/integration_tests/python/test_permissions.py
@@ -11,6 +11,13 @@ def test_permissions(data_builder, as_admin):
     r = as_admin.get(permissions_path)
     assert r.status_code == 405
 
+    # Try to add permission for unknown user
+    r = as_admin.post(permissions_path, json={
+        '_id': 'fake_user@yahoo.com',
+        'access': 'admin'
+        })
+    assert r.status_code == 402
+
     # Add permissions for user 1
     r = as_admin.post(permissions_path, json={
         '_id': user_1,

--- a/tests/integration_tests/python/test_propagation.py
+++ b/tests/integration_tests/python/test_propagation.py
@@ -73,7 +73,7 @@ def test_add_and_remove_user_for_project_permissions(data_builder, as_admin):
     session = data_builder.create_session()
     acquisition = data_builder.create_acquisition()
 
-    user_id = 'propagation@user.com'
+    user_id = data_builder.create_user(_id='propagation@user.com')
 
     # Add user to project permissions
     payload = {'_id': user_id, 'access': 'admin'}
@@ -154,7 +154,7 @@ def test_add_and_remove_user_group_permission(data_builder, as_admin):
     session = data_builder.create_session()
     acquisition = data_builder.create_acquisition()
 
-    user_id = 'propagation@user.com'
+    user_id = data_builder.create_user(_id='propagation@user.com')
 
     # Add user to group permissions
     payload = {'_id': user_id, 'access': 'admin'}


### PR DESCRIPTION
Fixes #1143 

Prevent adding permissions for users that don't exists.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
