### PR TITLE
db upgrade for gears created timestamp

### DIFF
--- a/bin/database.py
+++ b/bin/database.py
@@ -23,7 +23,7 @@ from api.types import Origin
 from api.jobs import batch
 
 
-CURRENT_DATABASE_VERSION = 45 # An int that is bumped when a new schema change is made
+CURRENT_DATABASE_VERSION = 46 # An int that is bumped when a new schema change is made
 
 def get_db_version():
 
@@ -1557,6 +1557,13 @@ def upgrade_to_45():
 
     cursor = config.db.projects.find({'template': {'$exists': True }})
     process_cursor(cursor, upgrade_templates_to_45)
+
+def upgrade_to_46():
+    """
+    Update gears to ensure they all have the created timestamp, will be set
+    to EPOCH if they don't have it
+    """
+    config.db.gears.update_many({"created":{"$exists":False}}, {'$set': {'created': datetime.datetime(1970,1,1), 'modified': datetime.datetime(1970,1,1)}})
 
 
 


### PR DESCRIPTION
Fixes #1172

Set created and modified timestamps to epoch for gears that don't have a created timestamp

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
