### PR TITLE
Add util function for creating Content-Range header response

### DIFF
--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -465,6 +465,7 @@ class FileListHandler(ListHandler):
                         raise util.RangeHeaderParseError('Feature flag not set')
 
                     ranges = util.parse_range_header(range_header)
+
                     for first, last in ranges:
                         if first > fileinfo['size'] - 1:
                             self.abort(416, 'Invalid range')
@@ -488,9 +489,9 @@ class FileListHandler(ListHandler):
                     else:
                         self.response.headers['Content-Type'] = str(
                             fileinfo.get('mimetype', 'application/octet-stream'))
-                        self.response.headers['Content-Range'] = 'bytes %s-%s/%s' % (str(ranges[0][0]),
-                                                                                     str(ranges[0][1]),
-                                                                                     str(fileinfo['size']))
+                        self.response.headers['Content-Range'] = util.build_content_range_header(ranges[0][0], ranges[0][1], fileinfo['size'])
+
+
                     with file_system.open(file_path, 'rb') as f:
                         for first, last in ranges:
                             mode = os.SEEK_SET
@@ -512,9 +513,7 @@ class FileListHandler(ListHandler):
                                 self.response.write('--%s\n' % self.request.id)
                                 self.response.write('Content-Type: %s\n' % str(
                                     fileinfo.get('mimetype', 'application/octet-stream')))
-                                self.response.write('Content-Range: %s' % 'bytes %s-%s/%s\n' % (str(first),
-                                                                                                str(last),
-                                                                                                str(fileinfo['size'])))
+                                self.response.write('Content-Range: %s\n' % str(util.build_content_range_header(first, last, fileinfo['size'])))
                                 self.response.write('\n')
                                 self.response.write(data)
                                 self.response.write('\n')

--- a/api/util.py
+++ b/api/util.py
@@ -317,6 +317,17 @@ class RangeHeaderParseError(ValueError):
     """Exception class representing a string parsing error."""
 
 
+def build_content_range_header(first, last, size):
+    if first == None:
+        first = 0
+    if last == None:
+        last = size-1
+
+    print 'first is {} last is {} size is {}'.format(first, last, size)
+
+    return 'bytes %s-%s/%s' % (str(first), str(last), str(size))
+
+
 def parse_range_header(range_header_val, valid_units=('bytes',)):
     """
     Range header parser according to RFC7233

--- a/api/util.py
+++ b/api/util.py
@@ -318,12 +318,8 @@ class RangeHeaderParseError(ValueError):
 
 
 def build_content_range_header(first, last, size):
-    if first == None:
-        first = 0
     if last == None:
         last = size-1
-
-    print 'first is {} last is {} size is {}'.format(first, last, size)
 
     return 'bytes %s-%s/%s' % (str(first), str(last), str(size))
 


### PR DESCRIPTION
When a client would request a byte range with no `last` byte, the `Content-Range` header generated by the API would be malformed. For example:

Client request header:
```
Range: bytes=182190080-
```

API response header:
```
Content-Range: bytes 182190080-None/318839180
```

@davidfarkas please review the changes I made and make any additional/different changes you deem fit. These changes fixed an issue with jumping to mid-video in our video viewer but I did not spend much time comparing my results to the rfc for range reads. I will send you an email will more details on how to recreate the issue locally for testing. 

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
