### PR TITLE
Ensure that j_id is always a string

### DIFF
--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -148,7 +148,7 @@ class ContainerHandler(base.RequestHandler):
 
             elif join_origin:
                 j_type = f['origin']['type']
-                j_id   = f['origin']['id']
+                j_id   = str(f['origin']['id'])
                 j_id_b = j_id
 
                 # Only user table doesn't use BSON for it's primary key.


### PR DESCRIPTION
With the switch to ObjectId in the devices table, joining acquisitions was failing due to keys being ObjectIds. This ensures that the join key is always a string.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
