### PR TITLE
Bootstrap fix

### DIFF
--- a/tests/integration_tests/python/conftest.py
+++ b/tests/integration_tests/python/conftest.py
@@ -374,6 +374,8 @@ class DataBuilder(object):
                 self.delete(child_cont, child['_id'], recursive=recursive)
         if resource == 'gear':
             _api_db.jobs.remove({'gear_id': str(_id)})
+        if resource == 'user':
+            _api_db.apikeys.delete_one({'uid': _id})
         _api_db[resource + 's'].remove({'_id': _id})
 
 

--- a/tests/integration_tests/python/conftest.py
+++ b/tests/integration_tests/python/conftest.py
@@ -27,7 +27,7 @@ SCITRAN_USER_API_KEY = binascii.hexlify(os.urandom(10))
 
 
 @pytest.fixture(scope='session')
-def bootstrap_users():
+def bootstrap_users(api_db):
     """Create admin and non-admin users with api keys"""
     global SCITRAN_ADMIN_API_KEY
     session = BaseUrlSession()
@@ -38,7 +38,8 @@ def bootstrap_users():
     data_builder = DataBuilder(session)
     data_builder.create_user(_id='user@user.com', api_key=SCITRAN_USER_API_KEY)
     yield data_builder
-    data_builder.teardown()
+    api_db.users.delete_many({})
+    api_db.singletons.delete_one({'_id': 'bootstrap'})
 
 
 @pytest.fixture(scope='session')

--- a/tests/integration_tests/python/test_classification.py
+++ b/tests/integration_tests/python/test_classification.py
@@ -405,11 +405,3 @@ def test_classification_change_triggers_job(randstr, data_builder, as_admin, api
 
     # Clean up rule
     r = as_admin.delete('/site/rules/' + rule_id)
-
-
-
-
-
-
-
-

--- a/tests/integration_tests/python/test_gears.py
+++ b/tests/integration_tests/python/test_gears.py
@@ -251,6 +251,11 @@ def test_gear_invocation_and_suggest(data_builder, file_form, as_admin):
     assert len(r.json()['files']) == 1
     assert len(r.json()['parents']) == 3
 
+
+    # clean up
+    as_admin.delete('/collections/' + collection)
+
+
 def test_gear_context(data_builder, default_payload, as_admin, as_root, randstr):
     project_label = randstr()
     project_info = {

--- a/tests/integration_tests/python/test_handlers.py
+++ b/tests/integration_tests/python/test_handlers.py
@@ -20,31 +20,26 @@ def test_schemahandler(as_public):
 
 
 def test_config_version(as_user, api_db):
-    # get database version when no version document exists, It hasn;t been set yet in the tests
+    # get database version when no version document exists (hasn't been set yet)
     r = as_user.get('/version')
     assert r.status_code == 404
-    api_db.singletons.insert_one({"_id":"version","database":3})
 
-    # Start with non-existent file
-    try:
-        os.remove(release_version_file_path)
-    except:
-        pass
-
+    api_db.singletons.insert_one({'_id': 'version', 'database': 3})
     # get database schema version
     r = as_user.get('/version')
     assert r.ok
     assert r.json()['database'] == 3
-    assert r.json()['release'] == ''
 
-    # Check api version when api_version.txt does not exist
-    with open(release_version_file_path, 'w') as f:
-        f.write('2.1.0')
+    assert 'release' in r.json()
+    if r.json()['release'] == '':
+        # release not set yet
+        with open(release_version_file_path, 'w') as f:
+            f.write('2.1.0')
 
-    r = as_user.get('/version')
-    assert r.ok
-    assert r.json()['database'] == 3
-    assert r.json()['release'] == '2.1.0'
+        r = as_user.get('/version')
+        assert r.ok
+        assert r.json()['release'] == '2.1.0'
+    else:
+        assert r.json()['release'] == open(release_version_file_path).read()
 
-    api_db.singletons.find_one_and_delete({'_id':'version'})
-    os.remove(release_version_file_path)
+    api_db.singletons.find_one_and_delete({'_id': 'version'})

--- a/tests/integration_tests/python/test_upgrades.py
+++ b/tests/integration_tests/python/test_upgrades.py
@@ -185,6 +185,10 @@ def test_45(data_builder, randstr, api_db, as_admin, database, file_form):
     for p in [t_project1, t_project2]:
         assert as_admin.get('/projects/' + p).json()['template'] == template_after
 
+    ### CLEANUP
+
+    api_db.modalities.delete_many({})
+
 
 def test_47(api_db, database):
     last_seen = datetime.datetime.utcnow().replace(microsecond=0)


### PR DESCRIPTION
Fix test suite to enable re-running it multiple times against long-running API instance.
Show-stopping error was introduced via the `bootstrap` fixture that uses the new no-drone-secret-bootstrapping feature, but failed to clean up the `bootstrap` singleton from the DB thus tests could only run once.

After fixing, tried to run whole integration test suite twice, and found various similar smaller scoped cleanup errors (data leftovers after tests that result in errors on 2nd run). Started cleaning them up, but left some for the future...

Running subsets of tests multiple times is already functional, which was the original goal.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
