### PR TITLE
Pagination

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -134,6 +134,7 @@ endpoints = [
 
         # Jobs & gears
 
+        route( '/jobs',                    JobsHandler),
         prefix('/jobs', [
             route('/next',                 JobsHandler, h='next',       m=['GET']),
             route('/stats',                JobsHandler, h='stats',      m=['GET']),

--- a/api/auth/containerauth.py
+++ b/api/auth/containerauth.py
@@ -176,20 +176,20 @@ def public_request(handler, container=None):
 
 def list_permission_checker(handler):
     def g(exec_op):
-        def f(method, query=None, user=None, public=False, projection=None):
+        def f(method, query=None, user=None, public=False, projection=None, pagination=None):
             if user and (user['_id'] != handler.uid):
                 handler.abort(403, 'User ' + handler.uid + ' may not see the Projects of User ' + user['_id'])
             query['permissions'] = {'$elemMatch': {'_id': handler.uid}}
             if handler.is_true('public'):
                 query['$or'] = [{'public': True}, {'permissions': query.pop('permissions')}]
-            return exec_op(method, query=query, user=user, public=public, projection=projection)
+            return exec_op(method, query=query, user=user, public=public, projection=projection, pagination=pagination)
         return f
     return g
 
 
 def list_public_request(exec_op):
-    def f(method, query=None, user=None, public=False, projection=None):
+    def f(method, query=None, user=None, public=False, projection=None, pagination=None):
         if public:
             query['public'] = True
-        return exec_op(method, query=query, user=user, public=public, projection=projection)
+        return exec_op(method, query=query, user=user, public=public, projection=projection, pagination=pagination)
     return f

--- a/api/auth/groupauth.py
+++ b/api/auth/groupauth.py
@@ -27,7 +27,7 @@ def default(handler, group=None):
 
 def list_permission_checker(handler, uid=None):
     def g(exec_op):
-        def f(method, query=None, projection=None):
+        def f(method, query=None, projection=None, pagination=None):
             if uid is not None:
                 if uid != handler.uid and not handler.superuser_request and not handler.user_is_admin:
                     handler.abort(403, 'User ' + handler.uid + ' may not see the Groups of User ' + uid)
@@ -40,7 +40,6 @@ def list_permission_checker(handler, uid=None):
                     query = query or {}
                     projection = projection or {}
                     query['permissions._id'] = handler.uid
-
-            return exec_op(method, query=query, projection=projection)
+            return exec_op(method, query=query, projection=projection, pagination=pagination)
         return f
     return g

--- a/api/auth/userauth.py
+++ b/api/auth/userauth.py
@@ -30,9 +30,9 @@ def default(handler, user=None):
 
 def list_permission_checker(handler):
     def g(exec_op):
-        def f(method, query=None, projection=None):
+        def f(method, query=None, projection=None, pagination=None):
             if handler.public_request:
                 handler.abort(403, 'public request is not authorized')
-            return exec_op(method, query=query, projection=projection)
+            return exec_op(method, query=query, projection=projection, pagination=pagination)
         return f
     return g

--- a/api/dao/basecontainerstorage.py
+++ b/api/dao/basecontainerstorage.py
@@ -5,6 +5,7 @@ import pymongo.errors
 
 from . import consistencychecker
 from . import containerutil
+from . import dbutil
 from .. import config
 from .. import util
 
@@ -210,9 +211,10 @@ class ContainerStorage(object):
     def _to_mongo(self, payload):
         pass
 
+    # pylint: disable=unused-argument
     def exec_op(self, action, _id=None, payload=None, query=None, user=None,
-                public=False, projection=None, recursive=False, r_payload=None,  # pylint: disable=unused-argument
-                replace_metadata=False, unset_payload=None):
+                public=False, projection=None, recursive=False, r_payload=None,
+                replace_metadata=False, unset_payload=None, pagination=None):
         """
         Generic method to exec a CRUD operation from a REST verb.
         """
@@ -223,7 +225,7 @@ class ContainerStorage(object):
         if action == 'GET' and _id:
             return self.get_el(_id, projection=projection, fill_defaults=True)
         if action == 'GET':
-            return self.get_all_el(query, user, projection, fill_defaults=True)
+            return self.get_all_el(query, user, projection, fill_defaults=True, pagination=pagination)
         if action == 'DELETE':
             return self.delete_el(_id)
         if action == 'PUT':
@@ -294,7 +296,7 @@ class ContainerStorage(object):
             cont['files'] = [f for f in cont['files'] if 'deleted' not in f]
         return cont
 
-    def get_all_el(self, query, user, projection, fill_defaults=False):
+    def get_all_el(self, query, user, projection, fill_defaults=False, pagination=None):
         if query is None:
             query = {}
         if user:
@@ -318,7 +320,9 @@ class ContainerStorage(object):
         else:
             replace_info_with_bool = False
 
-        results = list(self.dbc.find(query, projection))
+        find_kwargs = dict(filter=query, projection=projection)
+        results = list(self.dbc.find(**dbutil.paginate_find_kwargs(find_kwargs, pagination)))
+
         for cont in results:
             if cont.get('files', []):
                 cont['files'] = [f for f in cont['files'] if 'deleted' not in f]

--- a/api/dao/basecontainerstorage.py
+++ b/api/dao/basecontainerstorage.py
@@ -320,8 +320,8 @@ class ContainerStorage(object):
         else:
             replace_info_with_bool = False
 
-        find_kwargs = dict(filter=query, projection=projection)
-        results = list(self.dbc.find(**dbutil.paginate_find_kwargs(find_kwargs, pagination)))
+        page = dbutil.paginate_find(self.dbc, {'filter': query, 'projection': projection}, pagination)
+        results = page['results']
 
         for cont in results:
             if cont.get('files', []):
@@ -345,7 +345,7 @@ class ContainerStorage(object):
                     f['info_exists'] = bool(f_info)
                     f['info'] = containerutil.sanitize_info(f_info)
 
-        return results
+        return results if pagination is None else page
 
     def modify_info(self, _id, payload, modify_subject=False):
 

--- a/api/dao/containerstorage.py
+++ b/api/dao/containerstorage.py
@@ -4,7 +4,6 @@ import bson
 import copy
 
 from . import containerutil
-from . import dbutil
 from . import hierarchy
 from .. import config
 
@@ -151,8 +150,8 @@ class SubjectStorage(ContainerStorage):
             self._fill_default_values(cont)
         return cont
 
-
-    def get_all_el(self, query, user, projection, fill_defaults=False, pagination=None):
+    # pylint: disable=arguments-differ
+    def get_all_el(self, query, user, projection, fill_defaults=False):
         if query is None:
             query = {}
         if user:
@@ -168,8 +167,7 @@ class SubjectStorage(ContainerStorage):
             a_ids = AcquisitionStorage().get_all_el({'collections': bson.ObjectId(collection_id)}, None, {'session': 1})
             query['_id'] = {'$in': list(set([a['session'] for a in a_ids]))}
 
-        find_kwargs = dict(filter=query, projection=projection)
-        results = list(self.dbc.find(**dbutil.paginate_find_kwargs(find_kwargs, pagination)))
+        results = list(self.dbc.find(query, projection))
         if not results:
             return []
 

--- a/api/dao/dbutil.py
+++ b/api/dao/dbutil.py
@@ -1,8 +1,10 @@
 import random
 import time
 
-from pymongo.errors import DuplicateKeyError
+import pymongo
+
 from ..web.errors import APIStorageException
+
 
 def try_replace_one(db, coll_name, query, update, upsert=False):
     """
@@ -14,7 +16,7 @@ def try_replace_one(db, coll_name, query, update, upsert=False):
 
     try:
         result = db[coll_name].replace_one(query, update, upsert=upsert)
-    except DuplicateKeyError:
+    except pymongo.errors.DuplicateKeyError:
         return result, False
     else:
         return result, True
@@ -39,3 +41,51 @@ def fault_tolerant_replace_one(db, coll_name, query, update, upsert=False):
             time.sleep(random.uniform(0.01,0.05))
 
     raise APIStorageException('Unable to replace object.')
+
+
+def paginate_find_kwargs(find_kwargs, pagination):
+    """
+    Modify and return find_kwargs (keyword arguments dict for `db.coll.find()`)
+    using the pagination settings.
+    """
+    if pagination:
+        if 'filter' in pagination:
+            filter_ = find_kwargs.get('filter', {})
+            filter_.update(pagination['filter'])
+            find_kwargs['filter'] = filter_
+
+        if 'sort' in pagination:
+            sort = find_kwargs.get('sort', [])
+            if isinstance(sort, basestring):
+                sort = [(sort, pymongo.ASCENDING)]
+            sort.extend(pagination['sort'])
+            find_kwargs['sort'] = sort
+
+        if 'limit' in pagination:
+            find_kwargs['limit'] = pagination['limit']
+    return find_kwargs
+
+
+def paginate_pipeline(pipeline, pagination):
+    """
+    Modify and return mongo pipeline (list of stages for `db.coll.aggregate()`)
+    using the pagination settings.
+    """
+    if pagination:
+        if 'pipe_key' in pagination:
+            pipe_key = pagination.pop('pipe_key')
+            for key in pagination.get('filter', {}).keys():
+                pagination['filter'][pipe_key(key)] = pagination['filter'].pop(key)
+            for i, key_order in enumerate(pagination.get('sort', [])):
+                key, order = key_order
+                pagination['sort'][i] = (pipe_key(key), order)
+
+        if 'filter' in pagination:
+            pipeline.append({'$match': pagination['filter']})
+
+        if 'sort' in pagination:
+            pipeline.append({'$sort': pagination['sort']})
+
+        if 'limit' in pagination:
+            pipeline.append({'$limit': pagination['limit']})
+    return pipeline

--- a/api/dao/dbutil.py
+++ b/api/dao/dbutil.py
@@ -98,7 +98,8 @@ def paginate_pipe(collection, pipeline, pagination):
 
     # total_pipeline.append({'$count': 'total'})  # mongo 3.4+
     total_pipeline.append({'$group': {'_id': None, 'total': {'$sum': 1}}})
+    total_result = list(collection.aggregate(total_pipeline))
     return {
-        'total': next(collection.aggregate(total_pipeline))['total'],
+        'total': total_result[0]['total'] if total_result else 0,
         'results': list(collection.aggregate(pipeline)),
     }

--- a/api/dao/dbutil.py
+++ b/api/dao/dbutil.py
@@ -66,7 +66,7 @@ def paginate_find(collection, find_kwargs, pagination):
             find_kwargs['limit'] = pagination['limit']
 
     return {
-        'total': collection.count(find_kwargs['filter']),
+        'total': collection.count(find_kwargs.get('filter', {})),
         'results': list(collection.find(**find_kwargs)),
     }
 

--- a/api/dao/dbutil.py
+++ b/api/dao/dbutil.py
@@ -84,7 +84,7 @@ def paginate_pipeline(pipeline, pagination):
             pipeline.append({'$match': pagination['filter']})
 
         if 'sort' in pagination:
-            pipeline.append({'$sort': pagination['sort']})
+            pipeline.append({'$sort': dict(pagination['sort'])})
 
         if 'limit' in pagination:
             pipeline.append({'$limit': pagination['limit']})

--- a/api/dao/dbutil.py
+++ b/api/dao/dbutil.py
@@ -1,3 +1,4 @@
+import collections
 import random
 import time
 
@@ -61,6 +62,9 @@ def paginate_find_kwargs(find_kwargs, pagination):
             sort.extend(pagination['sort'])
             find_kwargs['sort'] = sort
 
+        if 'skip' in pagination:
+            find_kwargs['skip'] = pagination['skip']
+
         if 'limit' in pagination:
             find_kwargs['limit'] = pagination['limit']
     return find_kwargs
@@ -84,7 +88,10 @@ def paginate_pipeline(pipeline, pagination):
             pipeline.append({'$match': pagination['filter']})
 
         if 'sort' in pagination:
-            pipeline.append({'$sort': dict(pagination['sort'])})
+            pipeline.append({'$sort': collections.OrderedDict(pagination['sort'])})
+
+        if 'skip' in pagination:
+            pipeline.append({'$skip': pagination['skip']})
 
         if 'limit' in pagination:
             pipeline.append({'$limit': pagination['limit']})

--- a/api/handlers/collectionshandler.py
+++ b/api/handlers/collectionshandler.py
@@ -124,7 +124,7 @@ class CollectionsHandler(ContainerHandler):
         else:
             permchecker = containerauth.list_permission_checker(self)
         query = {}
-        results = permchecker(self.storage.exec_op)('GET', query=query, public=self.public_request, projection=projection)
+        results = permchecker(self.storage.exec_op)('GET', query=query, public=self.public_request, projection=projection, pagination=self.pagination)
         if not self.superuser_request and not self.is_true('join_avatars'):
             self._filter_all_permissions(results, self.uid)
         if self.is_true('join_avatars'):

--- a/api/handlers/collectionshandler.py
+++ b/api/handlers/collectionshandler.py
@@ -124,15 +124,16 @@ class CollectionsHandler(ContainerHandler):
         else:
             permchecker = containerauth.list_permission_checker(self)
         query = {}
-        results = permchecker(self.storage.exec_op)('GET', query=query, public=self.public_request, projection=projection, pagination=self.pagination)
+        page = permchecker(self.storage.exec_op)('GET', query=query, public=self.public_request, projection=projection, pagination=self.pagination)
+        results = page['results']
         if not self.superuser_request and not self.is_true('join_avatars'):
             self._filter_all_permissions(results, self.uid)
         if self.is_true('join_avatars'):
-            results = ContainerHandler.join_user_info(results)
-        for result in results:
-            if self.is_true('stats'):
-                result = containerutil.get_stats(result, 'collections')
-        return self.paginate_results(results)
+            ContainerHandler.join_user_info(results)
+        if self.is_true('stats'):
+            for result in results:
+                containerutil.get_stats(result, 'collections')
+        return self.format_page(page)
 
     def curators(self):
         curator_ids = []

--- a/api/handlers/collectionshandler.py
+++ b/api/handlers/collectionshandler.py
@@ -132,7 +132,7 @@ class CollectionsHandler(ContainerHandler):
         for result in results:
             if self.is_true('stats'):
                 result = containerutil.get_stats(result, 'collections')
-        return results
+        return self.paginate_results(results)
 
     def curators(self):
         curator_ids = []

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -329,7 +329,7 @@ class ContainerHandler(base.RequestHandler):
         else:
             query = {}
         # this request executes the actual reqeust filtering containers based on the user permissions
-        results = permchecker(self.storage.exec_op)('GET', query=query, public=self.public_request, projection=projection)
+        results = permchecker(self.storage.exec_op)('GET', query=query, public=self.public_request, projection=projection, pagination=self.pagination)
         if results is None:
             self.abort(404, 'No elements found in container {}'.format(self.storage.cont_name))
         # return only permissions of the current user unless superuser or getting avatars

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -349,7 +349,7 @@ class ContainerHandler(base.RequestHandler):
         if self.is_true('join_avatars'):
             modified_results = self.join_user_info(modified_results)
 
-        return modified_results
+        return self.paginate_results(modified_results)
 
     def _filter_all_permissions(self, results, uid):
         for result in results:

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -331,8 +331,6 @@ class ContainerHandler(base.RequestHandler):
         # this request executes the actual reqeust filtering containers based on the user permissions
         page = permchecker(self.storage.exec_op)('GET', query=query, public=self.public_request, projection=projection, pagination=self.pagination)
         results = page['results']
-        if results is None:
-            self.abort(404, 'No elements found in container {}'.format(self.storage.cont_name))
         # return only permissions of the current user unless superuser or getting avatars
         if not self.superuser_request and not self.is_true('join_avatars'):
             self._filter_all_permissions(results, self.uid)

--- a/api/handlers/devicehandler.py
+++ b/api/handlers/devicehandler.py
@@ -34,11 +34,12 @@ class DeviceHandler(base.RequestHandler):
 
     @require_login
     def get_all(self):
-        devices = list(self.storage.get_all_el(None, None, None))
+        page = self.storage.get_all_el(None, None, None, pagination=self.pagination)
+        devices = page['results']
         if self.user_is_admin and self.is_true('join_keys'):
             for device in devices:
                 self.join_api_key(device)
-        return devices
+        return self.format_page(page)
 
     @staticmethod
     def join_api_key(device):

--- a/api/handlers/grouphandler.py
+++ b/api/handlers/grouphandler.py
@@ -57,7 +57,7 @@ class GroupHandler(base.RequestHandler):
         if 'projects' in self.request.params.getall('join'):
             for result in results:
                 result = self.handle_projects(result)
-        return results
+        return self.paginate_results(results)
 
     @validators.verify_payload_exists
     def put(self, _id):

--- a/api/handlers/grouphandler.py
+++ b/api/handlers/grouphandler.py
@@ -49,15 +49,16 @@ class GroupHandler(base.RequestHandler):
     def get_all(self, uid=None):
         projection = {'label': 1, 'created': 1, 'modified': 1, 'permissions': 1, 'tags': 1}
         permchecker = groupauth.list_permission_checker(self, uid)
-        results = permchecker(self.storage.exec_op)('GET', projection=projection, pagination=self.pagination)
+        page = permchecker(self.storage.exec_op)('GET', projection=projection, pagination=self.pagination)
+        results = page['results']
         if not self.superuser_request and not self.is_true('join_avatars') and not self.user_is_admin:
             self._filter_permissions(results, self.uid)
         if self.is_true('join_avatars'):
-            results = ContainerHandler.join_user_info(results)
+            ContainerHandler.join_user_info(results)
         if 'projects' in self.request.params.getall('join'):
             for result in results:
-                result = self.handle_projects(result)
-        return self.paginate_results(results)
+                self.handle_projects(result)
+        return self.format_page(page)
 
     @validators.verify_payload_exists
     def put(self, _id):

--- a/api/handlers/grouphandler.py
+++ b/api/handlers/grouphandler.py
@@ -49,7 +49,7 @@ class GroupHandler(base.RequestHandler):
     def get_all(self, uid=None):
         projection = {'label': 1, 'created': 1, 'modified': 1, 'permissions': 1, 'tags': 1}
         permchecker = groupauth.list_permission_checker(self, uid)
-        results = permchecker(self.storage.exec_op)('GET', projection=projection)
+        results = permchecker(self.storage.exec_op)('GET', projection=projection, pagination=self.pagination)
         if not self.superuser_request and not self.is_true('join_avatars') and not self.user_is_admin:
             self._filter_permissions(results, self.uid)
         if self.is_true('join_avatars'):

--- a/api/handlers/refererhandler.py
+++ b/api/handlers/refererhandler.py
@@ -155,7 +155,7 @@ class AnalysesHandler(RefererHandler):
         sub_cont_names = {'projects':0, 'sessions':1, 'acquisitions':2, 'all':3}
 
         # Check that the url is valid
-        if cont_name not in cont_names.keys():
+        if cont_name not in cont_names:
             self.abort(400, "Analysis lists not supported for {}.".format(cont_name))
         elif cont_level:
             if cont_names[cont_name] > sub_cont_names.get(cont_level, -1):
@@ -169,11 +169,10 @@ class AnalysesHandler(RefererHandler):
             else:
                 parents = [pid for pid in parent_tree[cont_level]]
             # We set User to None because we check for permission when finding the parents
-            analyses = containerstorage.AnalysisStorage().get_all_el({'parent.id':{'$in':parents}},None,{'info': 0, 'files.info': 0})
+            query = {'parent.id': {'$in': parents}}
         else:
-            analyses = containerstorage.AnalysisStorage().get_all_el({'parent.id':cid, 'parent.type':singularize(cont_name)},None,{'info': 0, 'files.info': 0})
-        return analyses
-
+            query = {'parent.id': cid, 'parent.type': singularize(cont_name)}
+        return self.storage.get_all_el(query, None, {'info': 0, 'files.info': 0}, pagination=self.pagination)
 
 
     @log_access(AccessType.delete_analysis)

--- a/api/handlers/refererhandler.py
+++ b/api/handlers/refererhandler.py
@@ -172,8 +172,8 @@ class AnalysesHandler(RefererHandler):
             query = {'parent.id': {'$in': parents}}
         else:
             query = {'parent.id': cid, 'parent.type': singularize(cont_name)}
-        results = self.storage.get_all_el(query, None, {'info': 0, 'files.info': 0}, pagination=self.pagination)
-        return self.paginate_results(results)
+        page = self.storage.get_all_el(query, None, {'info': 0, 'files.info': 0}, pagination=self.pagination)
+        return self.format_page(page)
 
 
     @log_access(AccessType.delete_analysis)

--- a/api/handlers/refererhandler.py
+++ b/api/handlers/refererhandler.py
@@ -172,7 +172,8 @@ class AnalysesHandler(RefererHandler):
             query = {'parent.id': {'$in': parents}}
         else:
             query = {'parent.id': cid, 'parent.type': singularize(cont_name)}
-        return self.storage.get_all_el(query, None, {'info': 0, 'files.info': 0}, pagination=self.pagination)
+        results = self.storage.get_all_el(query, None, {'info': 0, 'files.info': 0}, pagination=self.pagination)
+        return self.paginate_results(results)
 
 
     @log_access(AccessType.delete_analysis)

--- a/api/handlers/userhandler.py
+++ b/api/handlers/userhandler.py
@@ -55,10 +55,10 @@ class UserHandler(base.RequestHandler):
         projection = {'preferences': 0, 'api_key': 0}
         if not self.user_is_admin:
             projection['wechat'] = 0
-        results = permchecker(self.storage.exec_op)('GET', projection=projection, pagination=self.pagination)
-        if results is None:
+        page = permchecker(self.storage.exec_op)('GET', projection=projection, pagination=self.pagination)
+        if page['results'] is None:
             self.abort(404, 'Not found')
-        return self.paginate_results(results)
+        return self.format_page(page)
 
     def delete(self, _id):
         user = self._get_user(_id)

--- a/api/handlers/userhandler.py
+++ b/api/handlers/userhandler.py
@@ -55,10 +55,10 @@ class UserHandler(base.RequestHandler):
         projection = {'preferences': 0, 'api_key': 0}
         if not self.user_is_admin:
             projection['wechat'] = 0
-        result = permchecker(self.storage.exec_op)('GET', projection=projection, pagination=self.pagination)
-        if result is None:
+        results = permchecker(self.storage.exec_op)('GET', projection=projection, pagination=self.pagination)
+        if results is None:
             self.abort(404, 'Not found')
-        return result
+        return self.paginate_results(results)
 
     def delete(self, _id):
         user = self._get_user(_id)

--- a/api/handlers/userhandler.py
+++ b/api/handlers/userhandler.py
@@ -55,7 +55,7 @@ class UserHandler(base.RequestHandler):
         projection = {'preferences': 0, 'api_key': 0}
         if not self.user_is_admin:
             projection['wechat'] = 0
-        result = permchecker(self.storage.exec_op)('GET', projection=projection)
+        result = permchecker(self.storage.exec_op)('GET', projection=projection, pagination=self.pagination)
         if result is None:
             self.abort(404, 'Not found')
         return result

--- a/api/jobs/batch.py
+++ b/api/jobs/batch.py
@@ -30,7 +30,8 @@ def get_all(query, projection=None, pagination=None):
     Fetch batch objects from the database
     """
     find_kwargs = dict(filter=query, projection=projection)
-    return config.db.batch.find(**dbutil.paginate_find_kwargs(find_kwargs, pagination))
+    page = dbutil.paginate_find(config.db.batch, find_kwargs, pagination)
+    return page['results'] if pagination is None else page
 
 def get(batch_id, projection=None, get_jobs=False):
     """

--- a/api/jobs/batch.py
+++ b/api/jobs/batch.py
@@ -6,6 +6,7 @@ import copy
 import datetime
 
 from .. import config
+from ..dao import dbutil
 from ..dao.containerstorage import AcquisitionStorage, AnalysisStorage
 from .jobs import Job
 from .queue import Queue
@@ -24,11 +25,12 @@ BATCH_JOB_TRANSITIONS = {
 }
 
 
-def get_all(query, projection=None):
+def get_all(query, projection=None, pagination=None):
     """
     Fetch batch objects from the database
     """
-    return config.db.batch.find(query, projection)
+    find_kwargs = dict(filter=query, projection=projection)
+    return config.db.batch.find(**dbutil.paginate_find_kwargs(find_kwargs, pagination))
 
 def get(batch_id, projection=None, get_jobs=False):
     """

--- a/api/jobs/gears.py
+++ b/api/jobs/gears.py
@@ -11,16 +11,20 @@ import gears as gear_tools
 import pymongo
 
 from .. import config
+from ..dao import dbutil
 from .jobs import Job
 
 from ..web.errors import APIValidationException, APINotFoundException
 
 log = config.log
 
-def get_gears():
+def get_gears(pagination=None):
     """
     Fetch the install-global gears from the database
     """
+
+    if pagination:
+        pagination['pipe_key'] = lambda key: 'original.' + key
 
     pipe = [
         {'$sort': {
@@ -33,7 +37,7 @@ def get_gears():
         }}
     ]
 
-    cursor = config.mongo_pipeline('gears', pipe)
+    cursor = config.mongo_pipeline('gears', dbutil.paginate_pipeline(pipe, pagination))
 
     return map(lambda x: x['original'], cursor)
 

--- a/api/jobs/gears.py
+++ b/api/jobs/gears.py
@@ -37,9 +37,9 @@ def get_gears(pagination=None):
         }}
     ]
 
-    cursor = config.mongo_pipeline('gears', dbutil.paginate_pipeline(pipe, pagination))
-
-    return map(lambda x: x['original'], cursor)
+    page = dbutil.paginate_pipe(config.db.gears, pipe, pagination)
+    page['results'] = [r['original'] for r in page['results']]
+    return page['results'] if pagination is None else page
 
 def get_gear(_id):
     return config.db.gears.find_one({'_id': bson.ObjectId(_id)})

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -346,7 +346,7 @@ class RuleHandler(base.RequestHandler):
 class JobsHandler(base.RequestHandler):
 
     @require_admin
-    def get(self): # pragma: no cover (no route)
+    def get(self):
         """List all jobs."""
         page = dbutil.paginate_find(config.db.jobs, {}, self.pagination)
         return self.format_page(page)

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -49,7 +49,7 @@ class GearsHandler(base.RequestHandler):
         if 'single_input' in filters:
             gears = list(filter(lambda x: count_file_inputs(x) <= 1, gears))
 
-        return gears
+        return self.paginate_results(gears)
 
     @require_login
     def check(self):
@@ -241,7 +241,8 @@ class RulesHandler(base.RequestHandler):
                 raise APIPermissionException('User does not have access to project {} rules'.format(cid))
 
         find_kwargs = dict(filter={'project_id' : cid}, projection=projection)
-        return config.db.project_rules.find(**dbutil.paginate_find_kwargs(find_kwargs, self.pagination))
+        results = config.db.project_rules.find(**dbutil.paginate_find_kwargs(find_kwargs, self.pagination))
+        return self.paginate_results(results)
 
     @verify_payload_exists
     def post(self, cid):
@@ -342,7 +343,8 @@ class JobsHandler(base.RequestHandler):
     @require_admin
     def get(self): # pragma: no cover (no route)
         """List all jobs."""
-        return list(config.db.jobs.find(**dbutil.paginate_find_kwargs({}, self.pagination)))
+        results = config.db.jobs.find(**dbutil.paginate_find_kwargs({}, self.pagination))
+        return self.paginate_results(results)
 
     def add(self):
         """Add a job to the queue."""
@@ -613,7 +615,8 @@ class BatchHandler(base.RequestHandler):
             query = {}
         else:
             query = {'origin.id': self.uid}
-        return batch.get_all(query, {'proposal':0}, pagination=self.pagination)
+        results = batch.get_all(query, {'proposal':0}, pagination=self.pagination)
+        return self.paginate_results(results)
 
     @require_login
     def get(self, _id):

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -35,6 +35,7 @@ from .batch import check_state, update
 from .queue import Queue
 from .rules import create_jobs, validate_regexes
 
+
 class GearsHandler(base.RequestHandler):
 
     """Provide /gears API routes."""
@@ -57,6 +58,7 @@ class GearsHandler(base.RequestHandler):
 
         check_for_gear_insertion(self.request.json)
         return None
+
 
 class GearHandler(base.RequestHandler):
     """Provide /gears/x API routes."""

--- a/api/util.py
+++ b/api/util.py
@@ -438,7 +438,7 @@ def parse_pagination_filter_param(filter_param):
                 pagination_filter[key].update({filter_ops[op]: value})
                 break
         else:
-            raise PaginationParseError('Invalid pagination filter: {} (operator missing)')
+            raise PaginationParseError('Invalid pagination filter: {} (operator missing)'.format(filter_str))
 
     return pagination_filter
 

--- a/api/util.py
+++ b/api/util.py
@@ -112,6 +112,7 @@ def user_perm(permissions, _id):
             return perm
     return {}
 
+
 def is_user_id(uid):
     """
     Checks to make sure uid matches uid regex
@@ -127,6 +128,27 @@ def is_group_id(gid):
     """
     pattern = re.compile('^[0-9a-z][0-9a-z.@_-]{0,30}[0-9a-z]$')
     return bool(pattern.match(gid))
+
+
+def datetime_from_str(s):
+    """
+    Return datetime.datetime parsed from a string that is a prefix of isoformat.
+    Return None if the string is not such a valid prefix.
+    """
+    re_fmt = {
+        r'^\d\d\d\d$':                                        '%Y',
+        r'^\d\d\d\d-\d\d$':                                   '%Y-%m',
+        r'^\d\d\d\d-\d\d-\d\d$':                              '%Y-%m-%d',
+        r'^\d\d\d\d-\d\d-\d\dT\d\d$':                         '%Y-%m-%dT%H',
+        r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d$':                    '%Y-%m-%dT%H:%M',
+        r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d$':               '%Y-%m-%dT%H:%M:%S',
+        r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\d\d\d\d$': '%Y-%m-%dT%H:%M:%S.%f',
+    }
+    for date_re, date_fmt in re_fmt.iteritems():
+        if re.match(date_re, s):
+            return datetime.datetime.strptime(s, date_fmt)
+    return None
+
 
 def resolve_gravatar(email):
     """

--- a/api/util.py
+++ b/api/util.py
@@ -136,10 +136,7 @@ def datetime_from_str(s):
     Return None if the string is not such a valid prefix.
     """
     re_fmt = {
-        r'^\d\d\d\d$':                                        '%Y',
-        r'^\d\d\d\d-\d\d$':                                   '%Y-%m',
         r'^\d\d\d\d-\d\d-\d\d$':                              '%Y-%m-%d',
-        r'^\d\d\d\d-\d\d-\d\dT\d\d$':                         '%Y-%m-%dT%H',
         r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d$':                    '%Y-%m-%dT%H:%M',
         r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d$':               '%Y-%m-%dT%H:%M:%S',
         r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\d\d\d\d$': '%Y-%m-%dT%H:%M:%S.%f',

--- a/api/util.py
+++ b/api/util.py
@@ -10,12 +10,14 @@ import requests
 import string
 import uuid
 
-import fs.path
-import fs.errors
-
+import bson
 import django
 from django.conf import settings
 from django.template import Template, Context
+import fs.path
+import fs.errors
+import pymongo
+
 
 BYTE_RANGE_RE = re.compile(r'^(?P<first>\d+)-(?P<last>\d+)?$')
 SUFFIX_BYTE_RANGE_RE = re.compile(r'^(?P<first>-\d+)$')
@@ -400,3 +402,69 @@ def parse_range_header(range_header_val, valid_units=('bytes',)):
         ranges.append((first, last))
 
     return ranges
+
+
+class PaginationParseError(ValueError):
+    """Exception class for invalid pagination params."""
+    pass
+
+
+def parse_pagination_filter_param(filter_param):
+    """Return parsed pagination filter (dict) from filter param (str)."""
+    pagination_filter = {}
+    filter_ops = {'<':  '$lt',
+                  '<=': '$lte',
+                  '=':  '$eq',
+                  '!=': '$ne',
+                  '>=': '$gte',
+                  '>':  '$gt'}
+    for filter_str in filter_param.split(','):
+        for filter_op in sorted(filter_ops, key=len, reverse=True):
+            key, op, value = filter_str.partition(filter_op)
+            if op:
+                if key not in pagination_filter:
+                    pagination_filter[key] = {}
+                if bson.ObjectId.is_valid(value):
+                    value = bson.ObjectId(value)
+                elif datetime_from_str(value):
+                    value = datetime_from_str(value)
+                else:
+                    try:
+                        # Note: querying for floats also yields ints (=> no need for int casting here)
+                        value = float(value)
+                    except ValueError:
+                        pass
+                # TODO cast other types?
+                pagination_filter[key].update({filter_ops[op]: value})
+                break
+        else:
+            raise PaginationParseError('Invalid pagination filter: {} (operator missing)')
+
+    return pagination_filter
+
+
+def parse_pagination_sort_param(sort_param):
+    """Return parsed pagination sorting (list of (key, order) tuples) from sort param (str)."""
+    pagination_sort  = []
+    sort_orders = { '1': pymongo.ASCENDING,   'asc': pymongo.ASCENDING,
+                   '-1': pymongo.DESCENDING, 'desc': pymongo.DESCENDING}
+    for sort_str in sort_param.split(','):
+        key, _, order = sort_str.partition(':')
+        order = order.lower() or 'asc'
+        if order not in sort_orders:
+            raise PaginationParseError('Invalid pagination sort: {} (unknown order)'.format(sort_str))
+        pagination_sort.append((key, sort_orders[order]))
+
+    return pagination_sort
+
+
+def parse_pagination_int_param(int_param):
+    """Return positive int parsed from string."""
+    try:
+        pagination_int = int(int_param)
+        if pagination_int <= 0:
+            raise ValueError('expected positive integer, got {}'.format(pagination_int))
+    except ValueError as e:
+        raise PaginationParseError('Invalid pagination int: {}'.format(e.message))
+
+    return pagination_int

--- a/api/web/base.py
+++ b/api/web/base.py
@@ -348,6 +348,16 @@ class RequestHandler(webapp2.RequestHandler):
 
         return pagination
 
+    def paginate_results(self, results):
+        """
+        Return result list wrapped in a dict to allow passing additional meta like count.
+        URL param `?page=1` acts as a feature toggle to maintain backwards-compatibility.
+        """
+        if self.is_true('page'):
+            results = list(results)
+            results = {'count': len(results), 'results': results}
+        return results
+
     def handle_exception(self, exception, debug, return_json=False): # pylint: disable=arguments-differ
         """
         Send JSON response for exception

--- a/api/web/base.py
+++ b/api/web/base.py
@@ -330,10 +330,13 @@ class RequestHandler(webapp2.RequestHandler):
 
     def format_page(self, page):
         """
-        Return page (dict with total and results) if `pagination` feature is enabled,
-        `page['results']` (list) otherwise, for backwards compatibility.`
+        Return page (dict with total and results) if `pagination` feature is enabled.
+        Return `page['results']` (list) otherwise, for backwards compatibility.
         """
-        return page if self.is_enabled('pagination') else page['results']
+        if not self.is_enabled('pagination'):
+            return page['results']
+        page['count'] = len(page['results'])
+        return page
 
     def handle_exception(self, exception, debug, return_json=False): # pylint: disable=arguments-differ
         """

--- a/tests/integration_tests/python/conftest.py
+++ b/tests/integration_tests/python/conftest.py
@@ -128,7 +128,7 @@ def default_payload():
                 'config': {},
                 'description': 'test',
                 'inputs': {
-                    'text files (max 100K)': {
+                    'text': {
                         'base': 'file',
                         'name': {'pattern': '^.*.txt$'},
                         'size': {'maximum': 100000}
@@ -316,7 +316,7 @@ class DataBuilder(object):
             for i in payload.get('inputs', {}).keys():
                 gear_inputs[i] = {'base': 'file'}
 
-            gear_doc = _default_payload['gear']['gear']
+            gear_doc = copy.deepcopy(_default_payload['gear']['gear'])
             gear_doc['inputs'] = gear_inputs
             payload['gear_id'] = self.create('gear', gear=gear_doc)
 

--- a/tests/integration_tests/python/test_pagination.py
+++ b/tests/integration_tests/python/test_pagination.py
@@ -1,3 +1,16 @@
+def test_count(data_builder, as_admin):
+    a = data_builder.create_acquisition(label='a')
+    b = data_builder.create_acquisition(label='b')
+
+    r = as_admin.get('/acquisitions?page=true')
+    assert r.ok
+    data = r.json()
+    assert 'count' in data
+    assert 'results' in data
+    assert data['count'] == len(data['results'])
+    assert data['results'] == as_admin.get('/acquisitions').json()
+
+
 def test_limit(data_builder, as_admin, file_form):
     assert as_admin.get('/users?limit=foo').status_code == 422
     assert as_admin.get('/users?limit=-1').status_code == 422

--- a/tests/integration_tests/python/test_pagination.py
+++ b/tests/integration_tests/python/test_pagination.py
@@ -1,0 +1,121 @@
+def test_limit(data_builder, as_admin, file_form):
+    assert as_admin.get('/users?limit=foo').status_code == 422
+    assert as_admin.get('/users?limit=-1').status_code == 422
+
+    u1 = data_builder.create_user()
+    u2 = data_builder.create_user()
+    assert len(as_admin.get('/users').json()) > 1
+    assert len(as_admin.get('/users?limit=1').json()) == 1
+
+    g1 = data_builder.create_group()
+    g2 = data_builder.create_group()
+    assert len(as_admin.get('/groups').json()) > 1
+    assert len(as_admin.get('/groups?limit=1').json()) == 1
+
+    p1 = data_builder.create_project()
+    p2 = data_builder.create_project()
+    assert len(as_admin.get('/projects').json()) > 1
+    assert len(as_admin.get('/projects?limit=1').json()) == 1
+    assert len(as_admin.get('/groups/' + g1 + '/projects').json()) > 1
+    assert len(as_admin.get('/groups/' + g1 + '/projects?limit=1').json()) == 1
+
+    s1 = data_builder.create_session()
+    s2 = data_builder.create_session()
+    assert len(as_admin.get('/sessions').json()) > 1
+    assert len(as_admin.get('/sessions?limit=1').json()) == 1
+    assert len(as_admin.get('/projects/' + p1 + '/sessions').json()) > 1
+    assert len(as_admin.get('/projects/' + p1 + '/sessions?limit=1').json()) == 1
+
+    aq1 = data_builder.create_acquisition()
+    aq2 = data_builder.create_acquisition()
+    assert len(as_admin.get('/acquisitions').json()) > 1
+    assert len(as_admin.get('/acquisitions?limit=1').json()) == 1
+    assert len(as_admin.get('/sessions/' + s1 + '/acquisitions').json()) > 1
+    assert len(as_admin.get('/sessions/' + s1 + '/acquisitions?limit=1').json()) == 1
+
+    an1 = as_admin.post('/sessions/' + s1 + '/analyses', files=file_form(
+        'a.csv', meta={'label': 'no-job', 'inputs': [{'name': 'a.csv'}]})).json()['_id']
+    an2 = as_admin.post('/sessions/' + s1 + '/analyses', files=file_form(
+        'b.csv', meta={'label': 'no-job', 'inputs': [{'name': 'b.csv'}]})).json()['_id']
+    assert len(as_admin.get('/sessions/' + s1 + '/analyses').json()) > 1
+    assert len(as_admin.get('/sessions/' + s1 + '/analyses?limit=1').json()) == 1
+
+    c1 = data_builder.create_collection()
+    c2 = data_builder.create_collection()
+    assert len(as_admin.get('/collections').json()) > 1
+    assert len(as_admin.get('/collections?limit=1').json()) == 1
+
+    gear1 = data_builder.create_gear()
+    gear2 = data_builder.create_gear()
+    assert len(as_admin.get('/gears').json()) > 1
+    assert len(as_admin.get('/gears?limit=1').json()) == 1
+
+    rule_doc = {'alg': as_admin.get('/gears/' + gear1).json()['gear']['name'],
+                'name': 'foo', 'any': [], 'all': []}
+    r1 = as_admin.post('/site/rules', json=rule_doc).json()['_id']
+    r2 = as_admin.post('/site/rules', json=rule_doc).json()['_id']
+    assert len(as_admin.get('/site/rules').json()) > 1
+    assert len(as_admin.get('/site/rules?limit=1').json()) == 1
+    assert as_admin.delete('/site/rules/' + r1).ok
+    assert as_admin.delete('/site/rules/' + r2).ok
+
+    # TODO batch, job
+
+
+def test_sort(data_builder, as_admin):
+    assert as_admin.get('/acquisitions?sort=label:foo').status_code == 422
+
+    a1 = data_builder.create_acquisition(label='a')
+    b1 = data_builder.create_acquisition(label='b')
+    c1 = data_builder.create_acquisition(label='c')
+
+    r = as_admin.get('/acquisitions?sort=label:1')
+    assert [a['_id'] for a in r.json()] == [a1, b1, c1]
+    assert as_admin.get('/acquisitions?sort=label:asc').json() == r.json()
+
+    r = as_admin.get('/acquisitions?sort=label:-1')
+    assert [a['_id'] for a in r.json()] == [c1, b1, a1]
+    assert as_admin.get('/acquisitions?sort=label:desc').json() == r.json()
+
+    a2 = data_builder.create_acquisition(label='a')
+    b2 = data_builder.create_acquisition(label='b')
+    c2 = data_builder.create_acquisition(label='c')
+
+    r = as_admin.get('/acquisitions?sort=label:1,created:-1')
+    assert [a['_id'] for a in r.json()] == [a2, a1, b2, b1, c2, c1]
+
+
+def test_filter(data_builder, as_admin):
+    assert as_admin.get('/acquisitions?filter=foo').status_code == 422
+
+    a = data_builder.create_acquisition(label='a')
+    b = data_builder.create_acquisition(label='b')
+    c = data_builder.create_acquisition(label='c')
+
+    r = as_admin.get('/acquisitions?filter=label<b')
+    assert {aq['_id'] for aq in r.json()} == {a}
+
+    r = as_admin.get('/acquisitions?filter=label<=b')
+    assert {aq['_id'] for aq in r.json()} == {a, b}
+
+    r = as_admin.get('/acquisitions?filter=label=b')
+    assert {aq['_id'] for aq in r.json()} == {b}
+
+    r = as_admin.get('/acquisitions?filter=label!=b')
+    assert {aq['_id'] for aq in r.json()} == {a, c}
+
+    r = as_admin.get('/acquisitions?filter=label>=b')
+    assert {aq['_id'] for aq in r.json()} == {b, c}
+
+    r = as_admin.get('/acquisitions?filter=label>b')
+    assert {aq['_id'] for aq in r.json()} == {c}
+
+    r = as_admin.get('/acquisitions?filter=label>a,label<c')
+    assert {aq['_id'] for aq in r.json()} == {b}
+
+    r = as_admin.get('/acquisitions?filter=_id=' + b)
+    assert {aq['_id'] for aq in r.json()} == {b}
+
+    b_created = as_admin.get('/acquisitions/' + b).json()['created'][:-6]
+    r = as_admin.get('/acquisitions?filter=created=' + b_created)
+    assert {aq['_id'] for aq in r.json()} == {b}

--- a/tests/integration_tests/python/test_pagination.py
+++ b/tests/integration_tests/python/test_pagination.py
@@ -15,6 +15,10 @@ def test_total(data_builder, as_admin):
     assert page['total'] == len(acqs)
     assert page['results'] == acqs
 
+    r = as_admin.get('/gears', headers={'X-Accept-Feature': 'pagination'})
+    assert r.ok
+    assert r.json()['total'] == 0
+
     g_a0 = data_builder.create_gear(gear={'name': 'a', 'version': '0.0.0'})
     g_a1 = data_builder.create_gear(gear={'name': 'a', 'version': '1.0.0'})
     g_b0 = data_builder.create_gear(gear={'name': 'b', 'version': '0.0.0'})

--- a/tests/integration_tests/python/test_pagination.py
+++ b/tests/integration_tests/python/test_pagination.py
@@ -106,15 +106,14 @@ def test_limit(data_builder, as_admin, file_form):
     assert len(as_admin.get('/batch').json()) > 1
     assert len(as_admin.get('/batch?limit=1').json()) == 1
 
-    ## `GET /jobs` is not exposed (yet)
-    # job_json = {
-    #     'gear_id': gear1,
-    #     'inputs': {'text': {'type': 'analysis', 'id': an1, 'name': 'a.txt'}},
-    #     'destination': {'type': 'acquisition', 'id': aq1}}
-    # j1 = as_admin.post('/jobs/add', json=job_data).json()['_id']
-    # j2 = as_admin.post('/jobs/add', json=job_data).json()['_id']
-    # assert len(as_admin.get('/jobs').json()) > 1
-    # assert len(as_admin.get('/jobs?limit=1').json()) == 1
+    job_json = {
+        'gear_id': g_a1,
+        'inputs': {'text': {'type': 'acquisition', 'id': aq1, 'name': 'test.txt'}},
+        'destination': {'type': 'acquisition', 'id': aq2}}
+    j1 = as_admin.post('/jobs/add', json=job_json).json()['_id']
+    j2 = as_admin.post('/jobs/add', json=job_json).json()['_id']
+    assert len(as_admin.get('/jobs').json()) > 1
+    assert len(as_admin.get('/jobs?limit=1').json()) == 1
 
     assert as_admin.delete('/site/rules/' + r1).ok
     assert as_admin.delete('/site/rules/' + r2).ok

--- a/tests/integration_tests/python/test_pagination.py
+++ b/tests/integration_tests/python/test_pagination.py
@@ -93,6 +93,20 @@ def test_limit(data_builder, as_admin, file_form):
     assert as_admin.delete('/site/rules/' + r2).ok
 
 
+def test_skip(data_builder, as_admin):
+    assert as_admin.get('/users?skip=foo').status_code == 422
+    assert as_admin.get('/users?skip=-1').status_code == 422
+
+    a = data_builder.create_acquisition(label='a')
+    b = data_builder.create_acquisition(label='b')
+
+    r = as_admin.get('/acquisitions')
+    assert {aq['_id'] for aq in r.json()} == {a, b}
+
+    r = as_admin.get('/acquisitions?skip=1')
+    assert {aq['_id'] for aq in r.json()} == {b}
+
+
 def test_sort(data_builder, as_admin):
     assert as_admin.get('/acquisitions?sort=label:foo').status_code == 422
 


### PR DESCRIPTION
Resolves #1187 

### Summary
__All*__ list endpoints now handle the following URL params:
* `?filter=expr[,expr...]` where `expr` is  `KEY OP VALUE`
   * example: `?filter=label=my-label,created>2018-09-22`
   * keys get into the query as-is
   * supported operators: <, <=, =, !=, =>, >
   * value casting: if it looks like an instance of _type_, then cast it (obj-id, datetime, float - in this order)
   * Note that `?filter=_id>X` is the current idiom for after_id
* `?sort=expr[,expr...]` where `expr` is `KEY [ : ORDER ]`
   * example: `?sort=label:asc,created:desc`
   * keys get into the query as-is
   * supported order values: `1`, `asc` -> ascending, `-1`, `desc` -> descending
   * default order if only key given: `asc`
* `?skip=N` where `N` is a positive integer
* `?page=N` where `N` is a positive integer (mutually exclusive with skip, requires limit)
* `?limit=N` where `N` is a positive integer
* Header `X-Accept-Feature: pagination` is a feature toggle for returning new-style list results
   * old: `[{"_id": "X"  "label": "my-acquisition", ...}, ...]`
   * new: `{"total": 42, "count": 10, "results": [{"_id": "X"  "label": "my-acquisition", ...}, ...]}`
* TODO swagger

*List endpoints (`GET`):
* `/devices` (new)
* `/users`
* `/groups`
* `/projects`
* `/sessions`
* `/acquisitions`
* `/analyses`
* `/collections`
* `/gears`
* `/site/rules`
* `/batch`
* and `/jobs` which is not yet exposed

### Review Checklist
- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
