### PR TITLE
.raw doesn't work for boolean fields

### DIFF
--- a/api/handlers/dataexplorerhandler.py
+++ b/api/handlers/dataexplorerhandler.py
@@ -366,10 +366,10 @@ class DataExplorerHandler(base.RequestHandler):
             elif f.get('term'):
                 # Search raw field
                 for k,v in f['term'].iteritems():
-                    if isinstance(v, bool):
-                        modified_filters.append({'term': {k: v}})
-                    else:
+                    if isinstance(v, basestring):
                         modified_filters.append({'term': {k+'.raw': v}})
+                    else:
+                        modified_filters.append({'term': {k: v}})
             else:
                 modified_filters.append(f)
 

--- a/api/handlers/dataexplorerhandler.py
+++ b/api/handlers/dataexplorerhandler.py
@@ -366,7 +366,10 @@ class DataExplorerHandler(base.RequestHandler):
             elif f.get('term'):
                 # Search raw field
                 for k,v in f['term'].iteritems():
-                    modified_filters.append({'term': {k+'.raw': v}})
+                    if isinstance(v, bool):
+                        modified_filters.append({'term': {k: v}})
+                    else:
+                        modified_filters.append({'term': {k+'.raw': v}})
             else:
                 modified_filters.append(f)
 


### PR DESCRIPTION
Fixes #1193

Boolean fields work only without the .raw extension.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
