### PR TITLE
Prevent creation of 'unknown' or 'site' group ids

### DIFF
--- a/api/handlers/grouphandler.py
+++ b/api/handlers/grouphandler.py
@@ -7,6 +7,7 @@ from ..auth import groupauth, require_admin
 from ..dao import containerstorage
 from .containerhandler import ContainerHandler
 
+GROUP_ID_BLACKLIST = [ 'unknown', 'site' ]
 
 class GroupHandler(base.RequestHandler):
 
@@ -26,8 +27,8 @@ class GroupHandler(base.RequestHandler):
 
     @require_admin
     def delete(self, _id):
-        if _id == 'unknown':
-            self.abort(400, 'The group "unknown" can\'t be deleted as it is integral within the API')
+        if _id in GROUP_ID_BLACKLIST:
+            self.abort(400, 'The group "{}" can\'t be deleted as it is integral within the API'.format(_id))
         group = self._get_group(_id)
         permchecker = groupauth.default(self, group)
         result = permchecker(self.storage.exec_op)('DELETE', _id)
@@ -83,6 +84,8 @@ class GroupHandler(base.RequestHandler):
         payload_schema_uri = validators.schema_uri('input', 'group-new.json')
         payload_validator = validators.from_schema_path(payload_schema_uri)
         payload_validator(payload, 'POST')
+        if payload['_id'] in GROUP_ID_BLACKLIST:
+            self.abort(400, 'The group "{}" can\'t be created as it is integral within the API'.format(payload['_id']))
         payload['created'] = payload['modified'] = datetime.datetime.utcnow()
         payload['permissions'] = [{'_id': self.uid, 'access': 'admin'}] if self.uid else []
         result = mongo_validator(permchecker(self.storage.exec_op))('POST', payload=payload)

--- a/tests/integration_tests/python/test_groups.py
+++ b/tests/integration_tests/python/test_groups.py
@@ -130,3 +130,11 @@ def test_groups(as_user, as_admin, data_builder):
     r = as_admin.get('/groups', params={'join': 'projects'})
     assert r.ok
     assert r.json()[0].get('projects')[0].get('_id') == project
+
+def test_groups_blacklist(as_admin):
+    r = as_admin.post('/groups', json={'_id': 'unknown', 'label': 'Unknown group'})
+    assert r.status_code == 400
+
+    r = as_admin.post('/groups', json={'_id': 'site', 'label': 'Site group'})
+    assert r.status_code == 400
+


### PR DESCRIPTION
Prevent creation of blacklisted `site` and `unknown` groups through the API.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
