### PR TITLE
Formalize UserStorage and add ancillary cleanup

### DIFF
--- a/api/dao/basecontainerstorage.py
+++ b/api/dao/basecontainerstorage.py
@@ -275,9 +275,14 @@ class ContainerStorage(object):
 
     def delete_el(self, _id):
         _id = self.format_id(_id)
+        self.cleanup_ancillary_data(_id)
         if self.use_delete_tag:
             return self.dbc.update_one({'_id': _id}, {'$set': {'deleted': datetime.datetime.utcnow()}})
         return self.dbc.delete_one({'_id':_id})
+
+    def cleanup_ancillary_data(self, _id):
+        """Optional cleanup of other data that may be associated with this container"""
+        pass
 
     def get_el(self, _id, projection=None, fill_defaults=False):
         _id = self.format_id(_id)

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -190,7 +190,7 @@ class ContainerHandler(base.RequestHandler):
 
         # Get list of all users, hash by uid
         # TODO: This is not an efficient solution if there are hundreds of inactive users
-        users_list = containerstorage.ContainerStorage('users', use_object_id=False).get_all_el({}, None, None)
+        users_list = containerstorage.UserStorage().get_all_el({}, None, None)
         users = {user['_id']: user for user in users_list}
 
         for r in results:

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -269,7 +269,7 @@ class PermissionsListHandler(ListHandler):
         """
         Checks if user exists
         """
-        return bool(containerstorage.ContainerStorage('users', use_object_id=False).get_all_el({'_id': uid}, None, {'_id':1}))
+        return bool(containerstorage.UserStorage().get_all_el({'_id': uid}, None, {'_id':1}))
 
 class NotesListHandler(ListHandler):
     """


### PR DESCRIPTION
Added a `cleanup_ancillary_data` function to the `ContainerStorage` class that gets called during `delete_el`. This will allow containers to specify what, if any, extra data to delete.

This also formalizes the UserStorage class, which makes use of this function to cleanup user permissions.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
