### PR TITLE
Fix tests for storage

### DIFF
--- a/api/auth/apikeys.py
+++ b/api/auth/apikeys.py
@@ -12,6 +12,8 @@ class APIKey(object):
     Abstract API key class
     """
 
+    key_type = None
+
     @staticmethod
     def _preprocess_key(key):
         """

--- a/api/handlers/dataexplorerhandler.py
+++ b/api/handlers/dataexplorerhandler.py
@@ -301,9 +301,6 @@ EXACT_CONTAINERS = ['file', 'collection']
 class DataExplorerHandler(base.RequestHandler):
     # pylint: disable=broad-except
 
-    def __init__(self, request=None, response=None):
-        super(DataExplorerHandler, self).__init__(request, response)
-
     def _parse_request(self, request_type='search'):
 
         try:

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -113,9 +113,6 @@ class ListHandler(base.RequestHandler):
     are specified in the routes defined in api.py
     """
 
-    def __init__(self, request=None, response=None):
-        super(ListHandler, self).__init__(request, response)
-
     def get(self, cont_name, list_name, **kwargs):
         _id = kwargs.pop('cid')
         permchecker, storage, _, _, keycheck = self._initialize_request(cont_name, list_name, _id, query_params=kwargs)
@@ -354,9 +351,6 @@ class FileListHandler(ListHandler):
     """
     This class implements a more specific logic for list of files as the api needs to interact with the filesystem.
     """
-
-    def __init__(self, request=None, response=None):
-        super(FileListHandler, self).__init__(request, response)
 
     def _check_ticket(self, ticket_id, _id, filename):
         ticket = config.db.downloads.find_one({'_id': ticket_id})

--- a/api/handlers/reporthandler.py
+++ b/api/handlers/reporthandler.py
@@ -51,9 +51,6 @@ ACCESS_LOG_FIELDS = [
 
 class ReportHandler(base.RequestHandler):
 
-    def __init__(self, request=None, response=None):
-        super(ReportHandler, self).__init__(request, response)
-
     def get_types(self):
         return AccessTypeList
 

--- a/api/handlers/schemahandler.py
+++ b/api/handlers/schemahandler.py
@@ -7,9 +7,6 @@ from .. import config
 
 class SchemaHandler(base.RequestHandler):
 
-    def __init__(self, request=None, response=None):
-        super(SchemaHandler, self).__init__(request, response)
-
     def get(self, schema):
         schema_path = os.path.join(config.schema_path, schema)
         try:

--- a/api/jobs/gears.py
+++ b/api/jobs/gears.py
@@ -165,7 +165,7 @@ def insert_gear(doc):
     result = config.db.gears.insert(doc)
 
     if config.get_item('queue', 'prefetch'):
-        log.info('Queuing prefetch job for gear ' + doc['gear']['name'])
+        log.info('Queuing prefetch job for gear %s', doc['gear']['name'])
 
         job = Job(str(doc['_id']), {}, destination={}, tags=['prefetch'], request={
             'inputs': [

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -325,7 +325,7 @@ class Queue(object):
 
         # Return if there is a job request already (probably prefetch)
         if job.request is not None:
-            log.info('Job ' + job.id_ + ' already has a request, so not generating')
+            log.info('Job %s already has a request, so not generating', job.id_)
             return job
 
         # Create a new request formula

--- a/api/upload.py
+++ b/api/upload.py
@@ -4,6 +4,7 @@ import json
 import os
 import uuid
 
+import fs.errors
 import fs.path
 
 from .web import base
@@ -262,7 +263,12 @@ class Upload(base.RequestHandler):
         folder = fs.path.join('tokens', 'packfile')
 
         util.mkdir_p(folder, config.fs)
-        paths = config.fs.listdir(folder)
+        try:
+            paths = config.fs.listdir(folder)
+        except fs.errors.ResourceNotFound:
+            # Non-local storages are used without 0-blobs for "folders" (mkdir_p is a noop)
+            paths = []
+
         cleaned = 0
 
         for token in paths:

--- a/api/upload.py
+++ b/api/upload.py
@@ -250,7 +250,7 @@ class Upload(base.RequestHandler):
 
         removed = result.deleted_count
         if removed > 0:
-            log.info('Removed ' + str(removed) + ' expired packfile tokens')
+            log.info('Removed %s expired packfile tokens', removed)
 
         # Next, find token directories and remove any that don't map to a token.
 
@@ -284,7 +284,7 @@ class Upload(base.RequestHandler):
                 pass
 
             if result is None:
-                log.info('Cleaning expired token directory ' + token)
+                log.info('Cleaning expired token directory %s', token)
                 config.fs.removetree(path)
                 cleaned += 1
 

--- a/api/web/base.py
+++ b/api/web/base.py
@@ -411,11 +411,10 @@ class RequestHandler(webapp2.RequestHandler):
     def dispatch(self):
         """dispatching and request forwarding"""
 
-
         self.request.logger.debug('from %s %s %s %s', self.uid, self.request.method, self.request.path, str(self.request.GET.mixed()))
         return super(RequestHandler, self).dispatch()
 
-
+    # pylint: disable=arguments-differ
     def abort(self, code, detail=None, **kwargs):
         if isinstance(detail, jsonschema.ValidationError):
             detail = {


### PR DESCRIPTION
For E2E-testing flywheel-io/storage-plugins#8, I updated fly/fly's `docker/run-tests.sh` to use core+, and I ran into some errors (unrelated to the referenced plugins PR) and fixed them.

Note that storage-plugins installs a newer pylint in core+, which reveals a bunch of errors. Here I only fixed the minor/obvious little lint problems.

The long-term plan is to upgrade pylint to the same version and fix remaining errors to make the images more coherent and to enable core+ integration testing via fly/fly using non-local storage.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
