### PR TITLE
Fix pagination interference with single_input gear filter

### DIFF
--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -44,16 +44,16 @@ class GearsHandler(base.RequestHandler):
     def get(self):
         """List all gears."""
 
-        # Using pagination params and `?filter=single_input` together raises APIValidationException
-        page = get_gears(pagination=self.pagination)
-
+        # NOTE Filtering with `?filter=single_input` is not compatible with pagination
+        # because filtering after the query invalidates total and count.
+        # Ignoring any pagination headers/params for backwards compatibility.
         if 'single_input' in self.request.GET.getall('filter'):
-            page['results'] = [gear for gear in page['results'] if count_file_inputs(gear) <= 1]
+            gears = get_gears()
+            return [gear for gear in gears if count_file_inputs(gear) <= 1]
 
-            # Filtering with `?filter=single_input` invalidates the pagination total
-            del page['total']
+        gear_page = get_gears(pagination=self.pagination)
+        return self.format_page(gear_page)
 
-        return self.format_page(page)
 
     @require_login
     def check(self):

--- a/tests/integration_tests/python/test_pagination.py
+++ b/tests/integration_tests/python/test_pagination.py
@@ -215,8 +215,8 @@ def test_filter(data_builder, as_admin):
     r = as_admin.get('/acquisitions?filter=created=' + b_created)
     assert {aq['_id'] for aq in r.json()} == {b}
 
-    r = as_admin.get('/gears?filter=gear.name=a&filter=single_input')
-    assert r.status_code == 422
+    r = as_admin.get('/gears?filter=single_input')
+    assert r.ok
 
     g_a0 = data_builder.create_gear(gear={'name': 'a', 'version': '0.0.0'})
     g_a1 = data_builder.create_gear(gear={'name': 'a', 'version': '1.0.0'})

--- a/tests/integration_tests/python/test_pagination.py
+++ b/tests/integration_tests/python/test_pagination.py
@@ -182,6 +182,7 @@ def test_sort(data_builder, as_admin):
 
 def test_filter(data_builder, as_admin):
     assert as_admin.get('/acquisitions?filter=foo').status_code == 422
+    assert as_admin.get('/acquisitions?filter=label=a&filter=label=b').status_code == 422
 
     a = data_builder.create_acquisition(label='a')
     b = data_builder.create_acquisition(label='b')


### PR DESCRIPTION
Resolves #1215 

Made sure (now with test) that the original `?filter=single_input` works as intended.
Please note that this filter is incompatible with pagination altogether and now takes precedence during handling to ensure backwards compatibility.

One idea to get around that limitation is to express `single_input` in the mongo query, but that's definitely beyond my mongo-fu right now.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
