### PR TITLE
Analysis join avatars

### DIFF
--- a/api/dao/basecontainerstorage.py
+++ b/api/dao/basecontainerstorage.py
@@ -392,3 +392,25 @@ class ContainerStorage(object):
             update['$set']['modified'] = datetime.datetime.utcnow()
 
         return self.dbc.update_one(query, update)
+
+    @staticmethod
+    def join_avatars(containers):
+        """
+        Given a list of containers, adds avatar and name context to each member of the permissions and notes lists
+        """
+
+        # Get list of all users, hash by uid
+        # TODO: This is not an efficient solution if there are hundreds of inactive users
+        users_list = ContainerStorage.factory('users').get_all_el({}, None, None)
+        users = {user['_id']: user for user in users_list}
+
+        for container in containers:
+            permissions = container.get('permissions', [])
+            notes = container.get('notes', [])
+
+            for item in permissions + notes:
+                uid = item.get('user', item['_id'])
+                user = users[uid]
+                item['avatar'] = user.get('avatar')
+                item['firstname'] = user.get('firstname', '')
+                item['lastname'] = user.get('lastname', '')

--- a/api/handlers/collectionshandler.py
+++ b/api/handlers/collectionshandler.py
@@ -129,7 +129,7 @@ class CollectionsHandler(ContainerHandler):
         if not self.superuser_request and not self.is_true('join_avatars'):
             self._filter_all_permissions(results, self.uid)
         if self.is_true('join_avatars'):
-            ContainerHandler.join_user_info(results)
+            self.storage.join_avatars(results)
         if self.is_true('stats'):
             for result in results:
                 containerutil.get_stats(result, 'collections')

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -106,7 +106,7 @@ class ContainerHandler(base.RequestHandler):
         if not self.superuser_request and not self.is_true('join_avatars'):
             self._filter_permissions(result, self.uid)
         if self.is_true('join_avatars'):
-            self.join_user_info([result])
+            self.storage.join_avatars([result])
 
         inflate_job_info = cont_name == 'sessions'
         result['analyses'] = AnalysisStorage().get_analyses(cont_name, _id, inflate_job_info)
@@ -176,31 +176,6 @@ class ContainerHandler(base.RequestHandler):
                     result['join-origin'][j_type][j_id] = join_doc
 
         return result
-
-    @staticmethod
-    def join_user_info(results):
-        """
-        Given a list of containers, adds avatar and name context to each member of the permissions and notes lists
-        """
-
-        # Get list of all users, hash by uid
-        # TODO: This is not an efficient solution if there are hundreds of inactive users
-        users_list = containerstorage.UserStorage().get_all_el({}, None, None)
-        users = {user['_id']: user for user in users_list}
-
-        for r in results:
-            permissions = r.get('permissions', [])
-            notes = r.get('notes', [])
-
-            for p in permissions+notes:
-                uid = p['user'] if 'user' in p else p['_id']
-                user = users[uid]
-                p['avatar'] = user.get('avatar')
-                p['firstname'] = user.get('firstname', '')
-                p['lastname'] = user.get('lastname', '')
-
-
-        return results
 
     def _filter_permissions(self, result, uid):
         """
@@ -317,7 +292,7 @@ class ContainerHandler(base.RequestHandler):
                 containerutil.get_stats(result, cont_name)
 
         if self.is_true('join_avatars'):
-            self.join_user_info(results)
+            self.storage.join_avatars(results)
 
         return self.format_page(page)
 

--- a/api/handlers/grouphandler.py
+++ b/api/handlers/grouphandler.py
@@ -5,9 +5,10 @@ from .. import util
 from .. import validators
 from ..auth import groupauth, require_admin
 from ..dao import containerstorage
-from .containerhandler import ContainerHandler
+
 
 GROUP_ID_BLACKLIST = [ 'unknown', 'site' ]
+
 
 class GroupHandler(base.RequestHandler):
 
@@ -22,7 +23,7 @@ class GroupHandler(base.RequestHandler):
         if not self.superuser_request and not self.is_true('join_avatars'):
             self._filter_permissions([result], self.uid)
         if self.is_true('join_avatars'):
-            ContainerHandler.join_user_info([result])
+            self.storage.join_avatars([result])
         return result
 
     @require_admin
@@ -54,7 +55,7 @@ class GroupHandler(base.RequestHandler):
         if not self.superuser_request and not self.is_true('join_avatars') and not self.user_is_admin:
             self._filter_permissions(results, self.uid)
         if self.is_true('join_avatars'):
-            ContainerHandler.join_user_info(results)
+            self.storage.join_avatars(results)
         if 'projects' in self.request.params.getall('join'):
             for result in results:
                 self.handle_projects(result)

--- a/api/handlers/refererhandler.py
+++ b/api/handlers/refererhandler.py
@@ -131,6 +131,9 @@ class AnalysesHandler(RefererHandler):
         if self.is_true('inflate_job'):
             self.storage.inflate_job_info(analysis)
 
+        if self.is_true('join_avatars'):
+            self.storage.join_avatars([analysis])
+
         self.log_user_access(AccessType.view_container, cont_name=analysis['parent']['type'], cont_id=analysis['parent']['id'])
         return analysis
 
@@ -168,11 +171,16 @@ class AnalysesHandler(RefererHandler):
                 parents = [pid for parent in parent_tree.keys() for pid in parent_tree[parent]]
             else:
                 parents = [pid for pid in parent_tree[cont_level]]
-            # We set User to None because we check for permission when finding the parents
             query = {'parent.id': {'$in': parents}}
         else:
             query = {'parent.id': cid, 'parent.type': singularize(cont_name)}
+
+        # We set User to None because we check for permission when finding the parents
         page = self.storage.get_all_el(query, None, {'info': 0, 'files.info': 0}, pagination=self.pagination)
+
+        if self.is_true('join_avatars'):
+            self.storage.join_avatars(page['results'])
+
         return self.format_page(page)
 
 

--- a/swagger/examples/input/analysis-legacy.json
+++ b/swagger/examples/input/analysis-legacy.json
@@ -1,9 +1,6 @@
 {
     "label": "Analysis label",
     "description": "This is an analysis description",
-    "notes": [
-        {"text": "some text"}
-    ],
     "inputs": [{"name": "input.csv", "info": {"example": true}}],
     "outputs": [{"name": "output.csv", "info": {"example": true}}]
 }

--- a/swagger/examples/input/analysis.json
+++ b/swagger/examples/input/analysis.json
@@ -1,7 +1,4 @@
 {
-    "notes": [{
-        "text": "some text"
-    }],
     "description": "This is an analysis description",
     "job": {
         "gear_id": "aex",

--- a/swagger/schemas/definitions/analysis.json
+++ b/swagger/schemas/definitions/analysis.json
@@ -9,7 +9,6 @@
 					"items": {"$ref":"file.json#/definitions/file-reference"},
 					"description": "The set of inputs that this analysis is based on"
 				},
-				"notes":       {"$ref":"note.json#/definitions/notes-list-input"},
 				"description": {"$ref":"common.json#/definitions/description"},
 				"label":       {"$ref":"common.json#/definitions/label"}
 			},
@@ -21,7 +20,6 @@
 			"type":"object",
 			"properties":{
 				"job":         {"$ref":"job.json#/definitions/job-input"},
-				"notes":       {"$ref":"note.json#/definitions/notes-list-input"},
 				"description": {"$ref":"common.json#/definitions/description"},
 				"label":       {"$ref":"common.json#/definitions/label"}
 			},
@@ -41,7 +39,6 @@
 					"type": "array",
 					"items": {"$ref":"file.json#/definitions/file-input"}
 				},
-				"notes":       {"$ref":"note.json#/definitions/notes-list-input"},
 				"description": {"$ref":"common.json#/definitions/description"},
 				"label":       {"$ref":"common.json#/definitions/label"}
 			},

--- a/tests/integration_tests/python/test_analyses.py
+++ b/tests/integration_tests/python/test_analyses.py
@@ -138,6 +138,26 @@ def test_analysis_download(data_builder, as_admin, file_form, api_db):
         assert set(m.name for m in tar.getmembers()) == set(['legacy/input/input.csv', 'legacy/output/output.csv'])
 
 
+def test_analysis_join_avatars(as_admin, data_builder):
+    session = data_builder.create_session()
+    r = as_admin.post('/sessions/' + session + '/analyses', json={'label': 'join-avatars'})
+    assert r.ok
+    analysis = r.json()['_id']
+
+    r = as_admin.post('/analyses/' + analysis + '/notes', json={'text': 'test'})
+    assert r.ok
+
+    r = as_admin.get('/analyses/' + analysis + '?join_avatars=true')
+    assert r.ok
+    assert 'avatar' in r.json()['notes'][0]
+    assert 'avatar' in r.json()['permissions'][0]
+
+    r = as_admin.get('/sessions/' + session + '/analyses?join_avatars=true')
+    assert r.ok
+    assert 'avatar' in r.json()[0]['notes'][0]
+    assert 'avatar' in r.json()[0]['permissions'][0]
+
+
 def check_files(as_admin, analysis_id, filegroup, *filenames):
     # Verify that filegroup has all files, inflated
     r = as_admin.get('/analyses/' + analysis_id)


### PR DESCRIPTION
Resolves #1208 

Moved `join_avatars` from `ContainerHandler` to `ContainerStorage`, which is now used for analyses the same way as for other containers.

Found that `POST`ing an analysis with notes is swaggered, but not implemented. Assumed the intended behavior is to work the same way as other containers, where note creation is only supported for already existing containers, thus I removed swagger for it.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
