### PR TITLE
Change from MATLAB comment to Python comment

### DIFF
--- a/sdk/src/python/sphinx/source/getting_started.rst
+++ b/sdk/src/python/sphinx/source/getting_started.rst
@@ -61,7 +61,7 @@ you can either specify the path to the input file, or you can specify some in-me
 	file_spec = flywheel.FileSpec('hello.txt', 'Hello World!\n', 'text/plain')
 	fw.upload_file_to_project(project_id, file_spec)
 
-	% Some endpoints allow multiple file uploads:
+	# Some endpoints allow multiple file uploads:
 	fw.upload_output_to_analysis(analysis_id, ['/tmp/hello1.txt', '/tmp/hello2.txt'])
 
 When downloading, you specify the destination file, or you can download directly to memory


### PR DESCRIPTION
Small change to update a minor syntax issue in documentation examples. Looking forward to testing out the sdk!