### PR TITLE
Fix pagination bug for GET /cont?join=origin

### DIFF
--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -338,8 +338,9 @@ class ContainerHandler(base.RequestHandler):
         if self.is_true('counts'):
             self._add_results_counts(results, cont_name)
 
-        if self.is_true('stats'):
-            for result in results:
+        for result in results:
+            self.handle_origin(result)
+            if self.is_true('stats'):
                 containerutil.get_stats(result, cont_name)
 
         if self.is_true('join_avatars'):

--- a/tests/integration_tests/python/test_containers.py
+++ b/tests/integration_tests/python/test_containers.py
@@ -198,6 +198,11 @@ def test_get_all_containers(data_builder, as_admin, as_user, as_public, file_for
     assert r.ok
     assert all('avatar' in perm for proj in r.json() for perm in proj['permissions'])
 
+    # get all projects w/ join=origin
+    r = as_public.get('/projects', params={'join': 'origin'})
+    assert r.ok
+    assert all('join-origin' in proj for proj in r.json())
+
     # get all sessions for project w/ measurements=true and stats=true
     r = as_public.get('/projects/' + project_1 + '/sessions', params={
         'measurements': 'true',


### PR DESCRIPTION
I missed calling `handle_origins` for `get_all` in the original pagination PR. Fixed.

ProgrammerError: https://github.com/flywheel-io/core/pull/1191/files#diff-90f25ae1793437dd630278372aa93828L346

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
