### PR TITLE
Extract measurements from Custom classification

### DIFF
--- a/api/dao/basecontainerstorage.py
+++ b/api/dao/basecontainerstorage.py
@@ -93,6 +93,13 @@ class ContainerStorage(object):
             parent_name = child_name
         return parent_tree
 
+    @classmethod
+    def filter_container_files(cls, cont):
+        if cont is not None and cont.get('files', []):
+            cont['files'] = [f for f in cont['files'] if 'deleted' not in f]
+            for f in cont['files']:
+                f.pop('measurements', None)
+
     def format_id(self, _id):
         if self.use_object_id:
             try:
@@ -292,8 +299,7 @@ class ContainerStorage(object):
         self._from_mongo(cont)
         if fill_defaults:
             self._fill_default_values(cont)
-        if cont is not None and cont.get('files', []):
-            cont['files'] = [f for f in cont['files'] if 'deleted' not in f]
+        self.filter_container_files(cont)
         return cont
 
     def get_all_el(self, query, user, projection, fill_defaults=False, pagination=None):
@@ -324,8 +330,7 @@ class ContainerStorage(object):
         results = page['results']
 
         for cont in results:
-            if cont.get('files', []):
-                cont['files'] = [f for f in cont['files'] if 'deleted' not in f]
+            self.filter_container_files(cont)
             self._from_mongo(cont)
             if fill_defaults:
                 self._fill_default_values(cont)

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -247,7 +247,8 @@ class Queue(object):
                 # recreate `measurements` list on object
                 # Can be removed when `classification` key has been adopted everywhere
 
-                obj_projection.setdefault('measurements', [])
+                if not obj_projection.get('measurements', None):
+                    obj_projection['measurements'] = []
                 if obj_projection.get('classification'):
                     for v in obj_projection['classification'].itervalues():
                         obj_projection['measurements'].extend(v)

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -240,14 +240,14 @@ class Queue(object):
                 cr = create_containerreference_from_filereference(inputs[x])
 
                 # Whitelist file fields passed to gear to those that are scientific-relevant
-                whitelisted_keys = ['info', 'tags', 'classification', 'mimetype', 'type', 'modality', 'size']
+                whitelisted_keys = ['info', 'tags', 'measurements', 'classification', 'mimetype', 'type', 'modality', 'size']
                 obj_projection = { key: obj.get(key) for key in whitelisted_keys }
 
                 ###
                 # recreate `measurements` list on object
                 # Can be removed when `classification` key has been adopted everywhere
 
-                obj_projection['measurements'] = []
+                obj_projection.setdefault('measurements', [])
                 if obj_projection.get('classification'):
                     for v in obj_projection['classification'].itervalues():
                         obj_projection['measurements'].extend(v)

--- a/bin/database.py
+++ b/bin/database.py
@@ -1689,6 +1689,8 @@ def upgrade_files_to_50(cont, cont_name):
 
     for f in files:
         classification = f.get('classification')
+        if not classification:
+            continue
 
         custom = classification.get('Custom', [])
         if custom:

--- a/tests/integration_tests/python/test_upgrades.py
+++ b/tests/integration_tests/python/test_upgrades.py
@@ -353,6 +353,7 @@ def test_50(data_builder, api_db, as_admin, file_form, database):
     })
     assert r.ok
 
+    r_acquisition = api_db.acquisitions.find_one({'_id': bson.ObjectId(acquisition)})
     f = r_acquisition['files'][0]
     assert f['name'] == 'test_file1.csv'
     assert f['classification'] == {

--- a/tests/integration_tests/python/test_upgrades.py
+++ b/tests/integration_tests/python/test_upgrades.py
@@ -272,3 +272,103 @@ def test_47_and_48(api_db, data_builder, as_admin, file_form, database):
         },
         added_device_id_str: added_device
     }
+
+def test_50(data_builder, api_db, as_admin, file_form, database):
+    acquisition = data_builder.create_acquisition()
+    r = as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form('test_file1.csv'))
+    r = as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form('test_file2.csv'))
+    r = as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form('test_file3.csv'))
+    assert r.ok
+
+    # Clean up modality
+    r = as_admin.delete('/modalities/MR')
+
+    payload = {
+        '_id': 'MR',
+        'classification': {
+            'Intent': ["Structural", "Functional", "Localizer"],
+            'Measurement': ["B0", "B1", "T1", "T2"]
+        }
+    }
+    r = as_admin.post('/modalities', json=payload)
+    assert r.ok
+
+    r = as_admin.post('/acquisitions/' + acquisition + '/files/test_file1.csv/classification', json={
+        'modality': 'MR',
+        'replace': {
+            'Intent': ['Structural'],
+            'Measurement': ['T1'],
+            'Custom': ['anatomy_t1w', 'foobar']
+        }
+    })
+    assert r.ok
+
+    r = as_admin.post('/acquisitions/' + acquisition + '/files/test_file2.csv/classification', json={
+        'modality': 'MR',
+        'replace': {
+            'Intent': ['Functional'],
+            'Measurement': ['T2'],
+            'Custom': ['functional']
+        }
+    })
+    assert r.ok
+
+    database.upgrade_to_50()
+
+    # Confirm that measurements is set and classification is updated
+    r_acquisition = api_db.acquisitions.find_one({'_id': bson.ObjectId(acquisition)})
+    f = r_acquisition['files'][0]
+    assert f['name'] == 'test_file1.csv'
+    assert f['classification'] == {
+        'Intent': ['Structural'],
+        'Measurement': ['T1'],
+        'Custom': ['foobar']
+    }
+    assert f['measurements'] == ['anatomy_t1w']
+
+    f = r_acquisition['files'][1]
+    assert f['name'] == 'test_file2.csv'
+    assert f['classification'] == {
+        'Intent': ['Functional'],
+        'Measurement': ['T2']
+    }
+    assert f['measurements'] == ['functional']
+
+    f = r_acquisition['files'][2]
+    assert f['name'] == 'test_file3.csv'
+    assert f['classification'] == {}
+    assert 'measurements' not in f
+
+    # Assert that changing modality resets measurements
+    r = as_admin.put('/acquisitions/' + acquisition + '/files/test_file1.csv', json={
+        'modality': None
+    })
+    assert r.ok
+
+    # Assert that changing classification resets measurements
+    r = as_admin.post('/acquisitions/' + acquisition + '/files/test_file2.csv/classification', json={
+        'add': {
+            'Custom': ['myvalue']
+        }
+    })
+    assert r.ok
+
+    f = r_acquisition['files'][0]
+    assert f['name'] == 'test_file1.csv'
+    assert f['classification'] == {
+        'Custom': ['foobar']
+    }
+    assert 'measurements' not in f
+
+    f = r_acquisition['files'][1]
+    assert f['name'] == 'test_file2.csv'
+    assert f['classification'] == {
+        'Intent': ['Functional'],
+        'Measurement': ['T2'],
+        'Custom': ['myvalue']
+    }
+    assert 'measurements' not in f
+
+    # Clean up modality
+    r = as_admin.delete('/modalities/MR')
+    assert r.ok


### PR DESCRIPTION
Per PM: 
We don't want the prior file measurements values showing in the UI, so rather than store them in the `Custom` classification array, we should keep them in the old `measurements` field.

This PR consists of:
- A database upgrade to extract the original measurements values from the 'Custom' field
- Logic to unset `measurements` if the file classification or modality ever changes
- Logic to prevent returning the `measurements` field from endpoints

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
