### PR TITLE
Performance refactor on GET /gears and /sessions/x/jobs

### DIFF
--- a/api/dao/dbutil.py
+++ b/api/dao/dbutil.py
@@ -66,10 +66,11 @@ def paginate_find(collection, find_kwargs, pagination):
             find_kwargs['limit'] = pagination['limit']
 
     results = collection.find(**find_kwargs)
-    return {
+    page = {
         'total': results.count(),  # count ignores limit and skip by default
         'results': list(results),
     }
+    return page
 
 
 def paginate_pipe(collection, pipeline, pagination):
@@ -104,5 +105,4 @@ def paginate_pipe(collection, pipeline, pagination):
             pipeline.append({'$project': {'total': 1, 'results': {'$slice': ['$results'] + slice_args}}})
 
     page = next(collection.aggregate(pipeline), {'total': 0, 'results': []})
-    page['results'] = list(page['results'])
     return page

--- a/api/dao/dbutil.py
+++ b/api/dao/dbutil.py
@@ -65,15 +65,15 @@ def paginate_find(collection, find_kwargs, pagination):
         if 'limit' in pagination:
             find_kwargs['limit'] = pagination['limit']
 
+    results = collection.find(**find_kwargs)
     return {
-        'total': collection.count(find_kwargs.get('filter', {})),
-        'results': list(collection.find(**find_kwargs)),
+        'total': results.count(),  # count ignores limit and skip by default
+        'results': list(results),
     }
 
 
 def paginate_pipe(collection, pipeline, pagination):
     """Return paginated `db.coll.aggregate()` results."""
-    total_pipeline = pipeline[:]
     if pagination:
         if 'pipe_key' in pagination:
             pipe_key = pagination.pop('pipe_key')
@@ -85,21 +85,24 @@ def paginate_pipe(collection, pipeline, pagination):
 
         if 'filter' in pagination:
             pipeline.append({'$match': pagination['filter']})
-            total_pipeline = pipeline[:]
 
         if 'sort' in pagination:
             pipeline.append({'$sort': collections.OrderedDict(pagination['sort'])})
 
-        if 'skip' in pagination:
-            pipeline.append({'$skip': pagination['skip']})
+    pipeline.append({'$group': {'_id': None, 'total': {'$sum': 1}, 'results': {'$push': '$$ROOT'}}})
 
-        if 'limit' in pagination:
-            pipeline.append({'$limit': pagination['limit']})
+    if pagination:
+        slice_args = None
+        if 'skip' in pagination and 'limit' in pagination:
+            slice_args = [pagination['skip'], pagination['limit']]
+        elif 'limit' in pagination:
+            slice_args = [pagination['limit']]
+        elif 'skip' in pagination:
+            # NOTE aggregation + pagination.skip without limit not supported
+            pass
+        if slice_args:
+            pipeline.append({'$project': {'total': 1, 'results': {'$slice': ['$results'] + slice_args}}})
 
-    # total_pipeline.append({'$count': 'total'})  # mongo 3.4+
-    total_pipeline.append({'$group': {'_id': None, 'total': {'$sum': 1}}})
-    total_result = list(collection.aggregate(total_pipeline))
-    return {
-        'total': total_result[0]['total'] if total_result else 0,
-        'results': list(collection.aggregate(pipeline)),
-    }
+    page = next(collection.aggregate(pipeline), {'total': 0, 'results': []})
+    page['results'] = list(page['results'])
+    return page

--- a/api/util.py
+++ b/api/util.py
@@ -21,6 +21,13 @@ import pymongo
 
 BYTE_RANGE_RE = re.compile(r'^(?P<first>\d+)-(?P<last>\d+)?$')
 SUFFIX_BYTE_RANGE_RE = re.compile(r'^(?P<first>-\d+)$')
+DATETIME_RE = {
+    re.compile(r'^\d\d\d\d-\d\d-\d\d$'):                              '%Y-%m-%d',
+    re.compile(r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d$'):                    '%Y-%m-%dT%H:%M',
+    re.compile(r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d$'):               '%Y-%m-%dT%H:%M:%S',
+    re.compile(r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\d\d\d\d$'): '%Y-%m-%dT%H:%M:%S.%f',
+}
+
 
 # If this is not called before templating, django throws a hissy fit
 settings.configure(
@@ -137,14 +144,8 @@ def datetime_from_str(s):
     Return datetime.datetime parsed from a string that is a prefix of isoformat.
     Return None if the string is not such a valid prefix.
     """
-    re_fmt = {
-        r'^\d\d\d\d-\d\d-\d\d$':                              '%Y-%m-%d',
-        r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d$':                    '%Y-%m-%dT%H:%M',
-        r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d$':               '%Y-%m-%dT%H:%M:%S',
-        r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.\d\d\d\d\d\d$': '%Y-%m-%dT%H:%M:%S.%f',
-    }
-    for date_re, date_fmt in re_fmt.iteritems():
-        if re.match(date_re, s):
+    for date_re, date_fmt in DATETIME_RE.iteritems():
+        if date_re.match(s):
             return datetime.datetime.strptime(s, date_fmt)
     return None
 


### PR DESCRIPTION
Closes #1227 
TLDR; potentially not solving actual problem

* improved pagination performance (/gears)
   * detail: getting the total _AND_ the (filtered/limited) results is non-trivial
   * used to do 2 separate queries, now avoiding that with more advanced mongo-fu
* refactored `/sessions/x/jobs` - now using significantly less mongo queries

Used `cProfile` and _synthetic data_:
```
gear.name:a-z, gear.version:0-9 (260 gears total)
5(analysis+job) and 5(acquisition+job) PER gear_id (5200 jobs total)

time (s) spent in handler according to cProf:

           GET /gears      GET /sessions/x/jobs?join=gears
(master)   0.006           3.589
(pr)       0.003           1.587
```

**However**, testing via the UI showed that actual E2E performance was not improved that much, the requests from the issue are easily getting to ~1s still. I need further input if this doesn't fully solve the problem. My next idea would be to reduce response size by trimming anything not explicitly used, but maybe others can chime in with better approaches.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
