### PR TITLE
Fix multi-file download

### DIFF
--- a/api/download.py
+++ b/api/download.py
@@ -283,8 +283,11 @@ class Download(base.RequestHandler):
         with tarfile.open(mode='w|', fileobj=stream) as archive:
             for filepath, arcpath, cont_name, cont_id, _ in ticket['target']:
                 file_system = files.get_fs_by_file_path(filepath)
-                with file_system.open(filepath, 'rb') as fd:
-                    yield archive.gettarinfo(fileobj=fd, arcname=arcpath).tobuf()
+                with file_system.openbin(filepath, 'rb') as fd:
+                    if hasattr(fd, 'gettarinfo'):
+                        yield fd.gettarinfo(arcname=arcpath).tobuf()
+                    else:
+                        yield archive.gettarinfo(fileobj=fd, arcname=arcpath).tobuf()
                     chunk = ''
                     for chunk in iter(lambda: fd.read(CHUNKSIZE), ''): # pylint: disable=cell-var-from-loop
                         yield chunk


### PR DESCRIPTION
* Resolves #1232
* Requires tandem storage-plugins PR flywheel-io/storage-plugins#18 (merged to master)

#### Problem
* when adding a member to a tarfile, `TarFile.gettarinfo(fileobj=member_fd)` is called
* that calls `member_fd.fileno()` for `os.stat()`-ing
* as a graceful fallback for all-around compatibility, storage files downloaded the whole thing to temp, and yielded that fileno
* thus before even starting to stream contents, the whole thing was downloaded

#### Solution
* instead of using (or monkeypatching) `TarFile.gettarinfo()` for storage files, provide custom `TarInfo`

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
