### PR TITLE
Turn off buffering and add socket-timeout

### DIFF
--- a/api/download.py
+++ b/api/download.py
@@ -325,7 +325,6 @@ class Download(base.RequestHandler):
                 self.response.app_iter = self.archivestream(ticket)
             self.response.headers['Content-Type'] = 'application/octet-stream'
             self.response.headers['Content-Disposition'] = 'attachment; filename=' + ticket['filename'].encode('ascii', errors='ignore')
-            util.enable_response_buffering(self.response)
         else:
 
             req_spec = self.request.json_body

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -430,7 +430,6 @@ class FileListHandler(ListHandler):
             try:
                 with file_system.open(file_path, 'rb') as f:
                     with zipfile.ZipFile(f) as zf:
-                        util.enable_response_buffering(self.response)
                         self.response.headers['Content-Type'] = util.guess_mimetype(zip_member)
                         self.response.write(zf.open(zip_member).read())
             except zipfile.BadZipfile:
@@ -471,7 +470,6 @@ class FileListHandler(ListHandler):
                 except util.RangeHeaderParseError:
                     self.response.app_iter = file_system.open(file_path, 'rb')
                     self.response.headers['Content-Length'] = str(fileinfo['size'])  # must be set after setting app_iter
-                    util.enable_response_buffering(self.response)
 
                     if self.is_true('view'):
                         self.response.headers['Content-Type'] = str(fileinfo.get('mimetype', 'application/octet-stream'))
@@ -488,7 +486,6 @@ class FileListHandler(ListHandler):
                         self.response.headers['Content-Range'] = util.build_content_range_header(ranges[0][0], ranges[0][1], fileinfo['size'])
 
 
-                    util.enable_response_buffering(self.response)
                     with file_system.open(file_path, 'rb') as f:
                         for first, last in ranges:
                             mode = os.SEEK_SET

--- a/api/handlers/refererhandler.py
+++ b/api/handlers/refererhandler.py
@@ -381,7 +381,6 @@ class AnalysesHandler(RefererHandler):
                         with file_system.open(file_path, 'rb') as f:
                             with zipfile.ZipFile(f) as zf:
                                 self.response.headers['Content-Type'] = util.guess_mimetype(zip_member)
-                                util.enable_response_buffering(self.response)
                                 self.response.write(zf.open(zip_member).read())
                     except zipfile.BadZipfile:
                         self.abort(400, 'not a zip file')
@@ -399,7 +398,6 @@ class AnalysesHandler(RefererHandler):
                 else:
                     self.response.app_iter = file_system.open(file_path, 'rb')
                     self.response.headers['Content-Length'] = str(fileinfo['size']) # must be set after setting app_iter
-                    util.enable_response_buffering(self.response)
                     if self.is_true('view'):
                         self.response.headers['Content-Type'] = str(fileinfo.get('mimetype', 'application/octet-stream'))
                     else:

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -209,7 +209,7 @@ class GearHandler(base.RequestHandler):
         })
 
         stream = file_system.open(file_path, 'rb')
-        set_for_download(self.response, stream=stream, filename='gear.tar', enable_buffering=True)
+        set_for_download(self.response, stream=stream, filename='gear.tar')
 
     @require_admin
     def post(self, _id):

--- a/api/util.py
+++ b/api/util.py
@@ -229,7 +229,7 @@ def obj_from_map(_map):
 
     return type('',(object,),_map)()
 
-def set_for_download(response, stream=None, filename=None, length=None, enable_buffering=False):
+def set_for_download(response, stream=None, filename=None, length=None):
     """Takes a self.response, and various download options."""
 
     # If an app_iter is to be set, it MUST be before these other headers are set.
@@ -243,17 +243,6 @@ def set_for_download(response, stream=None, filename=None, length=None, enable_b
 
     if length is not None:
         response.headers['Content-Length'] = str(length)
-
-    if enable_buffering:
-        enable_response_buffering(response)
-
-def enable_response_buffering(response):
-    """Takes a self.response and enables buffering.
-
-    Should be set for large transfers (i.e. downloads)
-    NOTE: Must be called before sending data!
-    """
-    response.headers['X-Accel-Buffering'] = 'yes'
 
 def format_hash(hash_alg, hash_):
     """

--- a/docker/uwsgi-config.ini
+++ b/docker/uwsgi-config.ini
@@ -4,3 +4,4 @@ master = true
 module = api.wsgi
 processes = 4
 threads = 2
+socket-timeout = 60


### PR DESCRIPTION
This turns off file-buffering for large requests, instead adding a `socket-timeout` of 60s to `uwsgi-config.ini`. This should resolve truncated downloads without introducing additional side-effects.

CC: @gsfr 

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
