### PR TITLE
Port range read and signed urls for analyses files

### DIFF
--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -446,6 +446,9 @@ class FileListHandler(ListHandler):
 
         # Authenticated or ticketed download request
         else:
+            # START of duplicated code
+            # IMPORTANT: If you modify the below code reflect the code changes in
+            # refererhandler.py:AnalysesHandler's download method
             signed_url = files.get_signed_url(file_path, file_system,
                                               filename=filename,
                                               attachment=(not self.is_true('view')),
@@ -475,7 +478,7 @@ class FileListHandler(ListHandler):
                         self.response.headers['Content-Type'] = str(fileinfo.get('mimetype', 'application/octet-stream'))
                     else:
                         self.response.headers['Content-Type'] = 'application/octet-stream'
-                        self.response.headers['Content-Disposition'] = 'attachment; filename="' + filename + '"'
+                        self.response.headers['Content-Disposition'] = 'attachment; filename="' + str(filename) + '"'
                 else:
                     self.response.status = 206
                     if len(ranges) > 1:
@@ -513,6 +516,7 @@ class FileListHandler(ListHandler):
                                 self.response.write('\n')
                             else:
                                 self.response.write(data)
+            # END of duplicated code
 
             # log download if we haven't already for this ticket
             if ticket:

--- a/api/handlers/refererhandler.py
+++ b/api/handlers/refererhandler.py
@@ -405,6 +405,9 @@ class AnalysesHandler(RefererHandler):
 
                 # Request to download the file itself
                 else:
+                    # START of duplicated code
+                    # IMPORTANT: If you modify the below code reflect the code changes in
+                    # listhandler.py:FileListHandler's download method
                     signed_url = files.get_signed_url(file_path, file_system,
                                                       filename=filename,
                                                       attachment=(not self.is_true('view')),
@@ -481,6 +484,7 @@ class AnalysesHandler(RefererHandler):
                                         self.response.write('\n')
                                     else:
                                         self.response.write(data)
+            # END of duplicated code
 
             # log download if we haven't already for this ticket
             if ticket:

--- a/api/handlers/refererhandler.py
+++ b/api/handlers/refererhandler.py
@@ -9,6 +9,7 @@ container (eg. ListHandler)
 import bson
 import zipfile
 import datetime
+import os
 from abc import ABCMeta, abstractproperty
 
 from .. import config, files, upload, util, validators
@@ -404,13 +405,82 @@ class AnalysesHandler(RefererHandler):
 
                 # Request to download the file itself
                 else:
-                    self.response.app_iter = file_system.open(file_path, 'rb')
-                    self.response.headers['Content-Length'] = str(fileinfo['size']) # must be set after setting app_iter
-                    if self.is_true('view'):
-                        self.response.headers['Content-Type'] = str(fileinfo.get('mimetype', 'application/octet-stream'))
+                    signed_url = files.get_signed_url(file_path, file_system,
+                                                      filename=filename,
+                                                      attachment=(not self.is_true('view')),
+                                                      response_type=str(
+                                                          fileinfo.get('mimetype', 'application/octet-stream')))
+                    if signed_url:
+                        self.redirect(signed_url)
+
                     else:
-                        self.response.headers['Content-Type'] = 'application/octet-stream'
-                        self.response.headers['Content-Disposition'] = 'attachment; filename=' + str(filename)
+                        range_header = self.request.headers.get('Range', '')
+                        try:
+                            if not self.is_true('view'):
+                                raise util.RangeHeaderParseError('Feature flag not set')
+
+                            ranges = util.parse_range_header(range_header)
+
+                            for first, last in ranges:
+                                if first > fileinfo['size'] - 1:
+                                    self.abort(416, 'Invalid range')
+
+                                if last > fileinfo['size'] - 1:
+                                    raise util.RangeHeaderParseError('Invalid range')
+
+                        except util.RangeHeaderParseError:
+                            self.response.app_iter = file_system.open(file_path, 'rb')
+                            self.response.headers['Content-Length'] = str(
+                                fileinfo['size'])  # must be set after setting app_iter
+
+                            if self.is_true('view'):
+                                self.response.headers['Content-Type'] = str(
+                                    fileinfo.get('mimetype', 'application/octet-stream'))
+                            else:
+                                self.response.headers['Content-Type'] = 'application/octet-stream'
+                                self.response.headers['Content-Disposition'] = 'attachment; filename="' \
+                                                                               + str(filename) + '"'
+                        else:
+                            self.response.status = 206
+                            if len(ranges) > 1:
+                                self.response.headers[
+                                    'Content-Type'] = 'multipart/byteranges; boundary=%s' % self.request.id
+                            else:
+                                self.response.headers['Content-Type'] = str(
+                                    fileinfo.get('mimetype', 'application/octet-stream'))
+                                self.response.headers['Content-Range'] = util.build_content_range_header(ranges[0][0],
+                                                                                                         ranges[0][1],
+                                                                                                         fileinfo[
+                                                                                                             'size'])
+
+                            with file_system.open(file_path, 'rb') as f:
+                                for first, last in ranges:
+                                    mode = os.SEEK_SET
+                                    if first < 0:
+                                        mode = os.SEEK_END
+                                        length = abs(first)
+                                    elif last is None:
+                                        length = fileinfo['size'] - first
+                                    else:
+                                        if last > fileinfo['size']:
+                                            length = fileinfo['size'] - first
+                                        else:
+                                            length = last - first + 1
+
+                                    f.seek(first, mode)
+                                    data = f.read(length)
+
+                                    if len(ranges) > 1:
+                                        self.response.write('--%s\n' % self.request.id)
+                                        self.response.write('Content-Type: %s\n' % str(
+                                            fileinfo.get('mimetype', 'application/octet-stream')))
+                                        self.response.write('Content-Range: %s\n' % str(
+                                            util.build_content_range_header(first, last, fileinfo['size'])))
+                                        self.response.write('\n')
+                                        self.response.write(data)
+                                        self.response.write('\n')
+                                    else:
+                                        self.response.write(data)
 
             # log download if we haven't already for this ticket
             if ticket:


### PR DESCRIPTION
The reason why analyses files weren't be redirected, because `/analyses` enpoint uses the `AnalysesHandler` and signed url redirection was only implemented in the `FileListHandler`. This is my fault, I didn't know that it uses a different handler. 
I ported the code from the `FileListHandler` because it is less risky and quicker than putting it to a common place. Also we will rewrite or refactor these handlers soon when we move the files into its own collection.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
