### PR TITLE
Place .MISSING placehorder files in the tar if not exists

### DIFF
--- a/api/download.py
+++ b/api/download.py
@@ -5,6 +5,8 @@ import tarfile
 import datetime
 import cStringIO
 
+from tarfile import TarInfo
+
 import fs.path
 import fs.errors
 from fs.iotools import RawWrapper
@@ -52,7 +54,7 @@ class Download(base.RequestHandler):
                 if filtered:
                     continue
 
-            file_path, _ = files.get_valid_file(f)
+            file_path = files.get_file_path(f)
             if file_path:  # silently skip missing files
                 if cont_name == 'analyses':
                     targets.append((file_path, '{}/{}/{}'.format(prefix, file_group, f['name']), cont_name, str(container.get('_id')), f['size']))
@@ -100,7 +102,7 @@ class Download(base.RequestHandler):
                 log.warn("Expected file {} on Container {} {} to exist but it is missing. File will be skipped in download.".format(filename, cont_name, cont_id))
                 continue
 
-            file_path, _ = files.get_valid_file(file_obj)
+            file_path = files.get_file_path(file_obj)
             if file_path:  # silently skip missing files
                 targets.append((file_path, cont_name+'/'+cont_id+'/'+file_obj['name'], cont_name, cont_id, file_obj['size']))
                 total_size += file_obj['size']
@@ -284,23 +286,31 @@ class Download(base.RequestHandler):
         stream = cStringIO.StringIO()
         with tarfile.open(mode='w|', fileobj=stream) as archive:
             for filepath, arcpath, cont_name, cont_id, _ in ticket['target']:
-                file_system = files.get_fs_by_file_path(filepath)
-                with file_system.open(filepath, 'rb') as fd:
-                    if isinstance(fd, RawWrapper) and hasattr(fd._f, 'gettarinfo'):  # pylint: disable=protected-access
-                        yield fd._f.gettarinfo(arcname=arcpath).tobuf()  # pylint: disable=protected-access
+                try:
+                    file_system = files.get_fs_by_file_path(filepath)
+                except fs.errors.ResourceNotFound:
+                    tarinfo = TarInfo()
+                    tarinfo.name = arcpath + '.MISSING'
+                    yield tarinfo.tobuf()
+                else:
+                    with file_system.open(filepath, 'rb') as fd:
+                        if isinstance(fd, RawWrapper) and hasattr(fd._f, 'gettarinfo'):  # pylint: disable=protected-access
+                            tarinfo = fd._f.gettarinfo(arcname=arcpath).tobuf()  # pylint: disable=protected-access
+                            yield tarinfo
+                            signed_url = files.get_signed_url(filepath, file_system)
 
-                        signed_url = files.get_signed_url(filepath, file_system)
-
-                        response = requests.get(signed_url, stream=True)
-                        for chunk in response.iter_content(chunk_size=CHUNKSIZE):
-                            yield chunk
-                    else:
-                        yield archive.gettarinfo(fileobj=fd, arcname=arcpath).tobuf()
-                        chunk = ''
-                        for chunk in iter(lambda: fd.read(CHUNKSIZE), ''):  # pylint: disable=cell-var-from-loop
-                            yield chunk
-                        if len(chunk) % BLOCKSIZE != 0:
-                            yield (BLOCKSIZE - (len(chunk) % BLOCKSIZE)) * b'\0'
+                            response = requests.get(signed_url, stream=True)
+                            for chunk in response.iter_content(chunk_size=CHUNKSIZE):
+                                yield chunk
+                                if len(chunk) % BLOCKSIZE != 0:
+                                    yield (BLOCKSIZE - (len(chunk) % BLOCKSIZE)) * b'\0'
+                        else:
+                            yield archive.gettarinfo(fileobj=fd, arcname=arcpath).tobuf()
+                            chunk = ''
+                            for chunk in iter(lambda: fd.read(CHUNKSIZE), ''):  # pylint: disable=cell-var-from-loop
+                                yield chunk
+                            if len(chunk) % BLOCKSIZE != 0:
+                                yield (BLOCKSIZE - (len(chunk) % BLOCKSIZE)) * b'\0'
 
                 self.log_user_access(AccessType.download_file, cont_name=cont_name, cont_id=cont_id, filename=os.path.basename(arcpath), multifile=True, origin_override=ticket['origin']) # log download
         yield stream.getvalue()  # get tar stream trailer

--- a/api/files.py
+++ b/api/files.py
@@ -200,6 +200,18 @@ def get_valid_file(file_info):
     :param file_info: dict, contains the _id and the hash of the file
     :return: (<file's path>, <filesystem>)
     """
+
+    file_path = get_file_path(file_info)
+    return file_path, get_fs_by_file_path(file_path)
+
+
+def get_file_path(file_info):
+    """
+    Get the file path. If the file has id then returns path_from_uuid otherwise path_from_hash.
+
+    :param file_info: dict, contains the _id and the hash of the file
+    :return: <file's path>
+    """
     file_id = file_info.get('_id', '')
     file_hash = file_info.get('hash', '')
     file_uuid_path = None
@@ -212,7 +224,7 @@ def get_valid_file(file_info):
         file_uuid_path = util.path_from_uuid(file_id)
 
     file_path = file_uuid_path or file_hash_path
-    return file_path, get_fs_by_file_path(file_path)
+    return file_path
 
 
 def get_signed_url(file_path, file_system, **kwargs):


### PR DESCRIPTION
To decrease the time of creating the download ticket we only check that a file exists or not during creating the archive. If it doesn't then we place an empty file which ends with `.MISSING` to indicate that we missed that.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
