### PR TITLE
Update URLs in job's request after retry

### DIFF
--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -62,7 +62,6 @@ class GearsHandler(base.RequestHandler):
         check_for_gear_insertion(self.request.json)
         return None
 
-
 class GearHandler(base.RequestHandler):
     """Provide /gears/x API routes."""
 

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -16,6 +16,7 @@ from ..auth import require_drone, require_login, require_admin, has_access
 from ..auth.apikeys import JobApiKey
 from ..dao import dbutil, hierarchy
 from ..dao.containerstorage import ProjectStorage, SessionStorage, SubjectStorage, AcquisitionStorage, AnalysisStorage, cs_factory
+from ..types import Origin
 from ..util import humanize_validation_error, set_for_download
 from ..validators import validate_data, verify_payload_exists
 from ..dao.containerutil import pluralize, singularize
@@ -474,6 +475,10 @@ class JobHandler(base.RequestHandler):
         j = Job.get(_id)
         mutation = self.request.json
 
+        if 'state' in mutation and mutation['state'] == 'running':
+            if self.origin.get('type', '') != Origin.device:
+                raise APIPermissionException('Only a drone can start a job with this endpoint')
+
         # If user is not superuser, can only cancel jobs they spawned
         if not self.superuser_request and not self.user_is_admin:
             if j.origin.get('id') != self.uid:
@@ -603,7 +608,6 @@ class JobHandler(base.RequestHandler):
         create_jobs(config.db, container_before, container, cont_name)
 
         self.log_user_access(AccessType.accept_failed_output, cont_name=j.destination.type, cont_id=j.destination.id, multifile=True)
-
 
 class BatchHandler(base.RequestHandler):
 

--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -217,7 +217,7 @@ class Job(object):
     def mongo(self):
         d = self.map()
         if d.get('id'):
-            d['id'] = bson.ObjectId(d['id'])
+            d['_id'] = bson.ObjectId(d.pop('id'))
         if d.get('inputs'):
             input_array = []
             for k, inp in d['inputs'].iteritems():
@@ -242,7 +242,7 @@ class Job(object):
     def save(self):
         self.modified = datetime.datetime.utcnow()
         update = self.mongo()
-        job_id = update.pop('id')
+        job_id = update.pop('_id')
         result = config.db.jobs.replace_one({'_id': job_id}, update)
         if result.modified_count != 1:
             raise Exception('Job modification not saved')

--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -227,12 +227,12 @@ class Job(object):
 
         return d
 
-    def insert(self):
+    def insert(self, ignore_insertion_block=False):
         """
-        Warning: this will not stop you from inserting a job for a gear that has gear.custom.flywheel.invald set to true.
+        Warning: this will not stop you from inserting a job for a gear that has gear.custom.flywheel.invalid set to true.
         """
 
-        if self.id_ is not None:
+        if self.id_ is not None and not ignore_insertion_block:
             raise Exception('Cannot insert job that has already been inserted')
 
         result = config.db.jobs.insert_one(self.mongo())

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -68,6 +68,16 @@ class Queue(object):
         if 'state' in mutation and not valid_transition(job.state, mutation['state']):
             raise Exception('Mutating job from ' + job.state + ' to ' + mutation['state'] + ' not allowed.')
 
+
+        # Special case: when starting a job, actually start it. Should not be called this way.
+        if 'state' in mutation and mutation['state'] == 'running':
+
+            # !!!
+            # !!! DUPE WITH Queue.start_job
+            # !!!
+
+            mutation['request'] = job.generate_request(get_gear(job.gear_id))
+
         # Any modification must be a timestamp update
         mutation['modified'] = datetime.datetime.utcnow()
 
@@ -337,6 +347,9 @@ class Queue(object):
             return job
 
         # Create a new request formula
+        # !!!
+        # !!! DUPE WITH Queue.mutate
+        # !!!
         request = job.generate_request(get_gear(job.gear_id))
 
         if peek:

--- a/tests/integration_tests/python/test_batch.py
+++ b/tests/integration_tests/python/test_batch.py
@@ -1,7 +1,7 @@
 import bson
 import time
 
-def test_batch(data_builder, as_user, as_admin, as_root):
+def test_batch(data_builder, as_user, as_admin, as_root, as_drone):
     gear = data_builder.create_gear()
     analysis_gear = data_builder.create_gear(category='analysis')
     invalid_gear = data_builder.create_gear(gear={'custom': {'flywheel': {'invalid': True}}})
@@ -155,9 +155,9 @@ def test_batch(data_builder, as_user, as_admin, as_root):
 
     for job in r.json()['jobs']:
         # set jobs to complete
-        r = as_root.put('/jobs/' + job, json={'state': 'running'})
+        r = as_drone.put('/jobs/' + job, json={'state': 'running'})
         assert r.ok
-        r = as_root.put('/jobs/' + job, json={'state': 'complete'})
+        r = as_drone.put('/jobs/' + job, json={'state': 'complete'})
         assert r.ok
 
     # test batch is complete
@@ -184,9 +184,9 @@ def test_batch(data_builder, as_user, as_admin, as_root):
 
     for job in r.json()['jobs']:
         # set jobs to failed
-        r = as_root.put('/jobs/' + job, json={'state': 'running'})
+        r = as_drone.put('/jobs/' + job, json={'state': 'running'})
         assert r.ok
-        r = as_root.put('/jobs/' + job, json={'state': 'failed'})
+        r = as_drone.put('/jobs/' + job, json={'state': 'failed'})
         assert r.ok
 
     # test batch is complete
@@ -212,9 +212,9 @@ def test_batch(data_builder, as_user, as_admin, as_root):
 
     for job in r.json()['jobs']:
         # set jobs to complete
-        r = as_root.put('/jobs/' + job, json={'state': 'running'})
+        r = as_drone.put('/jobs/' + job, json={'state': 'running'})
         assert r.ok
-        r = as_root.put('/jobs/' + job, json={'state': 'complete'})
+        r = as_drone.put('/jobs/' + job, json={'state': 'complete'})
         assert r.ok
 
     # test batch is complete
@@ -240,7 +240,8 @@ def test_batch(data_builder, as_user, as_admin, as_root):
 
     for job in r.json()['jobs']:
         # set jobs to failed
-        r = as_root.put('/jobs/' + job, json={'state': 'running'})
+        r = as_drone.put('/jobs/' + job, json={'state': 'running'})
+        assert r.ok
         r = as_root.put('/jobs/' + job, json={'state': 'failed'})
         assert r.ok
 
@@ -248,7 +249,7 @@ def test_batch(data_builder, as_user, as_admin, as_root):
     r = as_admin.get('/batch/' + batch_id)
     assert r.json()['state'] == 'failed'
 
-def test_no_input_batch(data_builder, default_payload, randstr, as_admin, as_root, api_db):
+def test_no_input_batch(data_builder, default_payload, randstr, as_admin, as_root, as_drone, api_db):
     project = data_builder.create_project()
     session = data_builder.create_session(project=project)
     session2 = data_builder.create_session(project=project)
@@ -318,9 +319,9 @@ def test_no_input_batch(data_builder, default_payload, randstr, as_admin, as_roo
 
     for job in jobs:
         # set jobs to failed
-        r = as_root.put('/jobs/' + job, json={'state': 'running'})
+        r = as_drone.put('/jobs/' + job, json={'state': 'running'})
         assert r.ok
-        r = as_root.put('/jobs/' + job, json={'state': 'complete'})
+        r = as_drone.put('/jobs/' + job, json={'state': 'complete'})
         assert r.ok
 
     # test batch is complete
@@ -368,9 +369,9 @@ def test_no_input_batch(data_builder, default_payload, randstr, as_admin, as_roo
 
     for job in jobs:
         # set jobs to failed
-        r = as_root.put('/jobs/' + job, json={'state': 'running'})
+        r = as_drone.put('/jobs/' + job, json={'state': 'running'})
         assert r.ok
-        r = as_root.put('/jobs/' + job, json={'state': 'complete'})
+        r = as_drone.put('/jobs/' + job, json={'state': 'complete'})
         assert r.ok
 
     # cleanup

--- a/tests/integration_tests/python/test_containers.py
+++ b/tests/integration_tests/python/test_containers.py
@@ -339,12 +339,14 @@ def test_get_container(data_builder, default_payload, file_form, as_drone, as_ad
     assert isinstance(r.json()['analyses'][1]['job'], dict)
 
     # fail and retry analysis job to test auto-updating on analysis
-    analysis_job = r.json()['analyses'][1]['job']['id']
-    r = as_drone.put('/jobs/' + analysis_job, json={'state': 'running'})
+    analysis_job = r.json()['analyses'][1]['job']
+    analysis_job_id = analysis_job['id']
+
+    r = as_drone.put('/jobs/' + analysis_job_id, json={'state': 'running'})
     assert r.ok
-    r = as_drone.put('/jobs/' + analysis_job, json={'state': 'failed'})
+    r = as_drone.put('/jobs/' + analysis_job_id, json={'state': 'failed'})
     assert r.ok
-    r = as_drone.post('/jobs/' + analysis_job + '/retry')
+    r = as_drone.post('/jobs/' + analysis_job_id + '/retry')
     assert r.ok
 
     # get session and check analyis job was updated

--- a/tests/integration_tests/python/test_containers.py
+++ b/tests/integration_tests/python/test_containers.py
@@ -340,9 +340,12 @@ def test_get_container(data_builder, default_payload, file_form, as_drone, as_ad
 
     # fail and retry analysis job to test auto-updating on analysis
     analysis_job = r.json()['analyses'][1]['job']['id']
-    as_drone.put('/jobs/' + analysis_job, json={'state': 'running'})
-    as_drone.put('/jobs/' + analysis_job, json={'state': 'failed'})
-    as_drone.post('/jobs/' + analysis_job + '/retry')
+    r = as_drone.put('/jobs/' + analysis_job, json={'state': 'running'})
+    assert r.ok
+    r = as_drone.put('/jobs/' + analysis_job, json={'state': 'failed'})
+    assert r.ok
+    r = as_drone.post('/jobs/' + analysis_job + '/retry')
+    assert r.ok
 
     # get session and check analyis job was updated
     r = as_admin.get('/sessions/' + session)

--- a/tests/integration_tests/python/test_jobs.py
+++ b/tests/integration_tests/python/test_jobs.py
@@ -156,12 +156,13 @@ def test_jobs(data_builder, default_payload, as_public, as_user, as_admin, as_ro
     # get next job with peek
     r = as_root.get('/jobs/next', params={'tags': 'test-tag', 'peek': True})
     assert r.ok
-    next_job_id = r.json()['id']
+    next_job_id_peek = r.json()['id']
 
     # get next job
     r = as_root.get('/jobs/next', params={'tags': 'test-tag'})
     assert r.ok
     next_job_id = r.json()['id']
+    assert next_job_id == next_job_id_peek
 
     # set next job to failed
     r = as_root.put('/jobs/' + next_job_id, json={'state': 'failed'})
@@ -754,8 +755,6 @@ def test_job_api_key(data_builder, default_payload, as_public, as_admin, as_root
     assert type(config['config']) is dict
     api_key = config['inputs']['api_key']['key']
 
-    print api_key
-
     # ensure api_key works
     as_job_key = as_public
     as_job_key.headers.update({'Authorization': 'scitran-user ' + api_key})
@@ -779,6 +778,7 @@ def test_job_api_key(data_builder, default_payload, as_public, as_admin, as_root
     assert r.ok
     retried_job = r.json()
     retried_job_id = retried_job['id']
+    assert retried_job['previous_job_id'] is not None
 
     # Ensure the attempt is bumped and the config uri is for the new job
     assert retried_job['attempt'] == 2

--- a/tests/integration_tests/python/test_jobs.py
+++ b/tests/integration_tests/python/test_jobs.py
@@ -799,8 +799,6 @@ def test_job_api_key(data_builder, default_payload, as_public, as_admin, as_root
     assert type(config['config']) is dict
     api_key = config['inputs']['api_key']['key']
 
-    print api_key
-
     # ensure api_key works
     as_job_key = as_public
     as_job_key.headers.update({'Authorization': 'scitran-user ' + api_key})


### PR DESCRIPTION
Fix is complete. Retried jobs were getting a copy of the previous job's request block, but the inputs that referenced a URI with the previous job id in them were not getting updated. This fixes that, as well as a bug where a job with an `_id` before insert was getting it's `_id` dropped and replaced. Confusing `id` vs `_id` vs `id_` will need to be dealt with eventually. 



### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
