### PR TITLE
Remove permissions from analyses

### DIFF
--- a/api/dao/containerstorage.py
+++ b/api/dao/containerstorage.py
@@ -488,8 +488,7 @@ class AnalysisStorage(ContainerStorage):
             },
             'created': datetime.datetime.utcnow(),
             'modified': datetime.datetime.utcnow(),
-            'user': origin.get('id'),
-            'permissions': parent['permissions'],
+            'user': origin.get('id')
         }
 
         for key in defaults:

--- a/api/download.py
+++ b/api/download.py
@@ -1,5 +1,6 @@
 import os
 import bson
+import copy
 import pytz
 import tarfile
 import datetime
@@ -219,9 +220,10 @@ class Download(base.RequestHandler):
                 total_size, file_cnt = self._append_targets(targets, 'acquisitions', acq, prefix, total_size, file_cnt, req_spec.get('filters'))
 
             elif item['level'] == 'analysis':
-                perm_query = base_query.pop('permissions._id')
-                analysis = config.db.analyses.find_one(base_query, ['parent', 'label', 'inputs', 'files', 'uid', 'timestamp'])
-                base_query["permissions._id"] = perm_query
+                analysis_query = copy.deepcopy(base_query)
+                perm_query = analysis_query.pop('permissions._id')
+                analysis = config.db.analyses.find_one(analysis_query, ['parent', 'label', 'inputs', 'files', 'uid', 'timestamp'])
+                analysis_query["permissions._id"] = perm_query
                 if analysis:
                     parent = config.db[pluralize(analysis.get('parent', {}).get('type'))].find_one({'deleted': {'$exists': False},
                                                                                          "_id": analysis.get('parent', {}).get('id'),

--- a/api/download.py
+++ b/api/download.py
@@ -219,8 +219,14 @@ class Download(base.RequestHandler):
                 total_size, file_cnt = self._append_targets(targets, 'acquisitions', acq, prefix, total_size, file_cnt, req_spec.get('filters'))
 
             elif item['level'] == 'analysis':
+                perm_query = base_query.pop('permissions._id')
                 analysis = config.db.analyses.find_one(base_query, ['parent', 'label', 'inputs', 'files', 'uid', 'timestamp'])
-                if not analysis:
+                base_query["permissions._id"] = perm_query
+                if analysis:
+                    parent = config.db[pluralize(analysis.get('parent', {}).get('type'))].find_one({'deleted': {'$exists': False},
+                                                                                         "_id": analysis.get('parent', {}).get('id'),
+                                                                                         "permissions._id": perm_query})
+                if not analysis or not parent:
                     # silently(while logging it) skip missing objects/objects user does not have access to
                     log.warn("Expected anaylysis {} to exist but it is missing. Node will be skipped".format(item_id))
                     continue

--- a/bin/database.py
+++ b/bin/database.py
@@ -23,7 +23,7 @@ from api.types import Origin
 from api.jobs import batch
 
 
-CURRENT_DATABASE_VERSION = 50 # An int that is bumped when a new schema change is made
+CURRENT_DATABASE_VERSION = 51 # An int that is bumped when a new schema change is made
 
 def get_db_version():
 
@@ -1721,6 +1721,11 @@ def upgrade_to_50():
         cursor = config.db[cont_name].find({'files.classification.Custom': {'$exists': True, '$ne': []}})
         process_cursor(cursor, upgrade_files_to_50, context=cont_name)
 
+def upgrade_to_51():
+    """
+    Get rid of permissions on analyses
+    """
+    config.db.analyses.update_many({}, {"$unset": {"permissions": ""}})
 ###
 ### BEGIN RESERVED UPGRADE SECTION
 ###

--- a/tests/integration_tests/python/test_analyses.py
+++ b/tests/integration_tests/python/test_analyses.py
@@ -150,12 +150,10 @@ def test_analysis_join_avatars(as_admin, data_builder):
     r = as_admin.get('/analyses/' + analysis + '?join_avatars=true')
     assert r.ok
     assert 'avatar' in r.json()['notes'][0]
-    assert 'avatar' in r.json()['permissions'][0]
 
     r = as_admin.get('/sessions/' + session + '/analyses?join_avatars=true')
     assert r.ok
     assert 'avatar' in r.json()[0]['notes'][0]
-    assert 'avatar' in r.json()[0]['permissions'][0]
 
 
 def check_files(as_admin, analysis_id, filegroup, *filenames):


### PR DESCRIPTION
### Changes
- Downloading analysis nodes uses parent permissions
- Permissions list is never created
- DB upgrade to remove current permissions lists (Most likely they are all out of date anyways as the propagate changes function doesn't propagate to analyses)

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
