### PR TITLE
Use signed url in case of gear downloads

### DIFF
--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -207,9 +207,17 @@ class GearHandler(base.RequestHandler):
             '_id': gear['exchange'].get('rootfs-id', ''),
             'hash': 'v0-' + gear['exchange']['rootfs-hash'].replace(':', '-')
         })
+        signed_url = files.get_signed_url(file_path,
+                                          file_system,
+                                          filename='gear.tar',
+                                          attachment=True,
+                                          response_type='application/octet-stream')
 
-        stream = file_system.open(file_path, 'rb')
-        set_for_download(self.response, stream=stream, filename='gear.tar')
+        if signed_url:
+            self.redirect(signed_url)
+        else:
+            stream = file_system.open(file_path, 'rb')
+            set_for_download(self.response, stream=stream, filename='gear.tar')
 
     @require_admin
     def post(self, _id):


### PR DESCRIPTION
Use signed url in case of gear downloads to avoid 504 gateway timeout and improve download performance

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
