### PR TITLE
[FLYW-51] User _id switch to bson.ObjectId

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -34,8 +34,8 @@ routing_regexes = {
     # Group ID: 2-32 characters of form [0-9a-z.@_-]. Start and ends with alphanum.
     'gid': '[0-9a-z][0-9a-z.@_-]{0,30}[0-9a-z]',
 
-    # User ID: any length, [0-9a-z.@_-]
-    'uid': '[0-9a-zA-Z.@_-]*',
+    # User ID: 24-character hex
+    'uid': '[0-9a-f]{24}',
 
     # Object ID: 24-character hex
     'oid': '[0-9a-f]{24}',

--- a/api/auth/apikeys.py
+++ b/api/auth/apikeys.py
@@ -52,6 +52,8 @@ class APIKey(object):
 
     @classmethod
     def generate_api_key(cls, uid):
+        if not isinstance(uid, bson.ObjectId):
+            uid = bson.ObjectId(uid)
         return {
             '_id': util.create_nonce(),
             'created': datetime.datetime.utcnow(),

--- a/api/auth/containerauth.py
+++ b/api/auth/containerauth.py
@@ -181,8 +181,8 @@ def list_permission_checker(handler):
             if handler.scope:
                 query['$or'] = [{'parents.{}'.format(handler.scope['level']): handler.scope['id']},
                                 {'_id': handler.scope['id']}, {'public': True}]
-            elif user and (user['_id'] != handler.uid):
-                handler.abort(403, 'User ' + handler.uid + ' may not see the Projects of User ' + user['_id'])
+            elif user and (user['_id'] != str(handler.uid)):
+                handler.abort(403, 'User {} may not see the Projects of User {}'.format(handler.uid, user['_id']))
             else:
                 query['permissions'] = {'$elemMatch': {'_id': handler.uid}}
             if handler.is_true('public'):

--- a/api/auth/groupauth.py
+++ b/api/auth/groupauth.py
@@ -28,7 +28,7 @@ def list_permission_checker(handler, uid=None):
         def f(method, query=None, projection=None, pagination=None):
             if uid is not None:
                 if uid != handler.uid and not handler.user_is_admin:
-                    handler.abort(403, 'User ' + handler.uid + ' may not see the Groups of User ' + uid)
+                    handler.abort(403, 'User {} may not see the Groups of User {}'.format(handler.uid, uid))
                 query = query or {}
                 query['permissions._id'] = uid
                 projection = projection or {}

--- a/api/config.py
+++ b/api/config.py
@@ -174,6 +174,7 @@ def initialize_db():
 
     db.users.create_index('api_key.key', **kwargs)
     db.users.create_index('deleted', **kwargs)
+    db.users.create_index('email', unique=True)
     db.apikeys.create_index([('type', 1), ('origin.id', 1)], **kwargs)
     db.queries.create_index('creator', **kwargs)
     db.projects.create_index([('group', 1), ('label', 1)], **kwargs)

--- a/api/dao/basecontainerstorage.py
+++ b/api/dao/basecontainerstorage.py
@@ -463,7 +463,7 @@ class ContainerStorage(object):
             notes = container.get('notes', [])
 
             for item in permissions + notes:
-                uid = item.get('user', item['_id'])
+                uid = bson.ObjectId(item.get('user', item['_id']))
                 user = users[uid]
                 item['avatar'] = user.get('avatar')
                 item['firstname'] = user.get('firstname', '')

--- a/api/dao/containerstorage.py
+++ b/api/dao/containerstorage.py
@@ -51,7 +51,7 @@ class GroupStorage(ContainerStorage):
 class UserStorage(ContainerStorage):
 
     def __init__(self):
-        super(UserStorage,self).__init__('users', use_object_id=False)
+        super(UserStorage,self).__init__('users', use_object_id=True)
 
     def cleanup_ancillary_data(self, _id):
         safe_cleanup_views(_id)

--- a/api/handlers/dataexplorerhandler.py
+++ b/api/handlers/dataexplorerhandler.py
@@ -384,7 +384,7 @@ class DataExplorerHandler(base.RequestHandler):
             if not self.user_is_admin:
                 raise APIPermissionException("Must have site admin privileges to search across all data")
         else:
-            modified_filters.append({'term': {'permissions._id': self.uid}})
+            modified_filters.append({'term': {'permissions._id': str(self.uid) if self.uid else None}})
 
         # Only return objects that have not been marked as deleted
         modified_filters.append({'term': {'deleted': False}})
@@ -443,7 +443,7 @@ class DataExplorerHandler(base.RequestHandler):
             self.abort(400, 'Field name is required')
         filters = [{'term': {'deleted': False}}]
         if not self.user_is_admin:
-            filters.append({'term': {'permissions._id': self.uid}})
+            filters.append({'term': {'permissions._id': str(self.uid) if self.uid else None}})
         try:
             field = config.es.get(index='data_explorer_fields', id=field_name, doc_type='flywheel_field')
         except TransportError as e:

--- a/api/handlers/grouphandler.py
+++ b/api/handlers/grouphandler.py
@@ -1,4 +1,5 @@
 import datetime
+import bson
 
 from ..web import base
 from .. import util
@@ -50,6 +51,8 @@ class GroupHandler(base.RequestHandler):
         return result
 
     def get_all(self, uid=None):
+        if uid:
+            uid = bson.ObjectId(uid)
         projection = {'label': 1, 'created': 1, 'modified': 1, 'permissions': 1, 'tags': 1}
         permchecker = groupauth.list_permission_checker(self, uid)
         page = permchecker(self.storage.exec_op)('GET', projection=projection, pagination=self.pagination)

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -938,7 +938,7 @@ class JobHandler(base.RequestHandler):
         for x in gear['gear'].get('inputs', {}).keys():
             input_ = gear['gear']['inputs'][x]
             if input_.get('base') == 'api-key':
-                if not self.user_is_admin and self.uid != j.origin['id']:
+                if not self.user_is_admin and str(self.uid) != j.origin['id']:
                     raise APIPermissionException('Only original scheduler or root user can retry a gear requiring an api key input')
 
         new_id = Queue.retry(j, force=True, only_failed=not self.is_true('ignoreState'))
@@ -1001,7 +1001,7 @@ class BatchHandler(base.RequestHandler):
             # Don't enforce permissions for site admin requests or drone requests
             query = {}
         else:
-            query = {'origin.id': self.uid}
+            query = {'origin.id': str(self.uid)}
         page = batch.get_all(query, {'proposal': 0}, pagination=self.pagination)
         return self.format_page(page)
 
@@ -1225,5 +1225,5 @@ class BatchHandler(base.RequestHandler):
 
     def _check_permission(self, batch_job):
         if not self.user_is_admin:
-            if batch_job['origin'].get('id') != self.uid:
+            if batch_job['origin'].get('id') != str(self.uid):
                 raise APIPermissionException('User does not have permission to access batch {}'.format(batch_job.get('_id')))

--- a/api/reports/access_log_report.py
+++ b/api/reports/access_log_report.py
@@ -33,6 +33,7 @@ class AccessLogReport(Report):
         "ip",
         "access_type",
         "origin.id",
+        "origin.email",
         "origin.method",
         "origin.name",
         "origin.type",

--- a/api/util.py
+++ b/api/util.py
@@ -103,7 +103,7 @@ def deep_update(d, u):
 
 def user_perm(permissions, _id):
     for perm in permissions:
-        if perm['_id'] == _id:
+        if str(perm['_id']) == str(_id):
             return perm
     return {}
 
@@ -112,8 +112,8 @@ def is_user_id(uid):
     """
     Checks to make sure uid matches uid regex
     """
-    pattern = re.compile('^[0-9a-zA-Z.@_-]*$')
-    return bool(pattern.match(uid))
+    pattern = re.compile('^[0-9a-f]{24}$')
+    return bool(pattern.match(str(uid)))
 
 
 # NOTE unused function

--- a/sdk/src/python/test-drive.py
+++ b/sdk/src/python/test-drive.py
@@ -42,7 +42,6 @@ assert len(users) >= 1
 
 email = rand_string() + '@' + rand_string() + '.com'
 userId = fw.add_user({
-    '_id':       email,
     'email':     email,
     'firstname': rand_string(),
     'lastname':  rand_string(),

--- a/sdk/src/python/tests/integration_tests/init_db.py
+++ b/sdk/src/python/tests/integration_tests/init_db.py
@@ -5,20 +5,19 @@ import datetime
 SCITRAN_PERSISTENT_DB_URI = os.environ.get('SCITRAN_PERSISTENT_DB_URI')
 SCITRAN_ADMIN_API_KEY = binascii.hexlify(os.urandom(10)).decode('utf-8')
 
-def create_user(db, _id, api_key, **kwargs):
+def create_user(db, email, api_key, **kwargs):
     payload = {
-        '_id': _id, 
-        'email': _id,
+        'email': email,
         'created': datetime.datetime.utcnow(),
         'modified': datetime.datetime.utcnow(),
-        'firstname': 'test', 
+        'firstname': 'test',
         'lastname': 'user'
     }
     payload.update(kwargs)
 
     # Create user
     print('Create user...')
-    db.users.replace_one({'_id': _id}, payload, upsert=True)
+    _id = db.users.replace_one({'email': email}, payload, upsert=True).upserted_id
 
     # Insert API Key
     print('Create API Key...')

--- a/sdk/src/python/tests/integration_tests/test_users.py
+++ b/sdk/src/python/tests/integration_tests/test_users.py
@@ -46,10 +46,10 @@ class UsersTestCases(SdkTestCase):
     def test_add_modify_delete_user(self):
         fw = self.fw
         email = self.rand_string() + '@' + self.rand_string() + '.io'
-        
-        user = flywheel.User(id=email, email=email, 
+
+        user = flywheel.User(email=email,
             firstname=self.rand_string(), lastname=self.rand_string())
-        
+
         # Add
         user_id = fw.add_user(user)
         self.assertNotEmpty(user_id)

--- a/swagger/examples/input/group-add-permission.json
+++ b/swagger/examples/input/group-add-permission.json
@@ -1,1 +1,1 @@
-{"access": "admin", "_id": "coltonlw@flywheel.io", "site":"local"}
+{"access": "admin", "_id": "1234567890abc7654321abc4", "site":"local"}

--- a/swagger/examples/input/group-add-role.json
+++ b/swagger/examples/input/group-add-role.json
@@ -1,1 +1,1 @@
-{"access": "admin", "_id": "coltonlw@flywheel.io", "site":"local"}
+{"access": "admin", "_id": "1234567890abc7654321abc4", "site":"local"}

--- a/swagger/examples/input/permission-update.json
+++ b/swagger/examples/input/permission-update.json
@@ -1,4 +1,4 @@
 {
-	"access": "ro", 
-	"_id": "coltonlw@flywheel.io"
+	"access": "ro",
+	"_id": "1234567890abc7654321abc4"
 }

--- a/swagger/examples/output/acquisition-list.json
+++ b/swagger/examples/output/acquisition-list.json
@@ -35,7 +35,7 @@
     "permissions": [
       {
         "access": "admin",
-        "_id": "coltonlw@flywheel.io"
+        "_id": "1234567890abc7654321abc4"
       }
     ]
   },
@@ -75,7 +75,7 @@
     "permissions": [
       {
         "access": "admin",
-        "_id": "coltonlw@flywheel.io"
+        "_id": "1234567890abc7654321abc4"
       }
     ]
   },
@@ -115,7 +115,7 @@
     "permissions": [
       {
         "access": "admin",
-        "_id": "coltonlw@flywheel.io"
+        "_id": "1234567890abc7654321abc4"
       }
     ]
   }

--- a/swagger/examples/output/acquisition.json
+++ b/swagger/examples/output/acquisition.json
@@ -35,7 +35,7 @@
   "permissions": [
     {
       "access": "admin",
-      "_id": "coltonlw@flywheel.io"
+      "_id": "1234567890abc7654321abc4"
     }
   ]
 }

--- a/swagger/examples/output/collection-curators-list.json
+++ b/swagger/examples/output/collection-curators-list.json
@@ -1,7 +1,7 @@
 [
   {
     "lastname": "LW",
-    "_id": "coltonlw@flywheel.io",
+    "_id": "1234567890abc7654321abc4",
     "firstname": "Colton"
   }
 ]

--- a/swagger/examples/output/collection-list.json
+++ b/swagger/examples/output/collection-list.json
@@ -1,11 +1,11 @@
 [{
 	"created": "2016-08-30T17:22:05.299000+00:00",
-	"curator": "user@test.com",
+	"curator": "1234567890abc7654321abc4",
 	"label": "test",
 	"modified": "2016-08-30T17:22:05.299000+00:00",
 	"_id": "57c5c0bd9e512c606dd3df09",
 	"permissions": [{
 		"access": "admin",
-		"_id": "user@test.com"
+		"_id": "1234567890abc7654321abc4"
 	}]
 }]

--- a/swagger/examples/output/collection.json
+++ b/swagger/examples/output/collection.json
@@ -1,12 +1,12 @@
 {
 	"created": "2016-08-30T17:22:05.299000+00:00",
-	"curator": "user@test.com",
+	"curator": "1234567890abc7654321abc4",
 	"label": "test",
 	"description": "Test collection",
 	"modified": "2016-08-30T17:22:05.299000+00:00",
 	"_id": "57c5c0bd9e512c606dd3df09",
 	"permissions": [{
 		"access": "admin",
-		"_id": "user@test.com"
+		"_id": "1234567890abc7654321abc4"
 	}]
 }

--- a/swagger/examples/output/group.json
+++ b/swagger/examples/output/group.json
@@ -3,15 +3,15 @@
   "permissions": [
     {
       "access": "admin",
-      "_id": "group_admin@fakeuser.com"
+      "_id": "1234567890abc7654321abc4"
     },
     {
       "access": "rw",
-      "_id": "group_member_read-write@fakeuser.com"
+      "_id": "1234567890abc7654321abc5"
     },
     {
       "access": "ro",
-      "_id": "group_member_read-only@fakeuser.com"
+      "_id": "1234567890abc7654321abc6"
     }
   ],
   "created": "2016-08-19T11:41:15.360000+00:00",

--- a/swagger/examples/output/groups-list.json
+++ b/swagger/examples/output/groups-list.json
@@ -4,15 +4,15 @@
       "permissions": [
         {
           "access": "admin",
-          "_id": "group_admin@fakeuser.com"
+          "_id": "1234567890abc7654321abc4"
         },
         {
           "access": "rw",
-          "_id": "group_member_read-write@fakeuser.com"
+          "_id": "1234567890abc7654321abc5"
         },
         {
           "access": "ro",
-          "_id": "group_member_read-only@fakeuser.com"
+          "_id": "1234567890abc7654321abc6"
         }
       ],
       "created": "2016-08-19T11:41:15.360000+00:00",

--- a/swagger/examples/output/note.json
+++ b/swagger/examples/output/note.json
@@ -3,5 +3,5 @@
     "text":"some text",
     "created": "2016-10-21T17:19:40.899000+00:00",
     "modified": "2016-10-21T17:19:40.899000+00:00",
-    "user": "coltonlw@flywheel.io"
+    "user": "1234567890abc7654321abc4"
 }

--- a/swagger/examples/output/permission.json
+++ b/swagger/examples/output/permission.json
@@ -1,4 +1,4 @@
 {
 	"access": "admin",
-	"_id": "coltonlw@flywheel.io"
+	"_id": "1234567890abc7654321abc4"
 }

--- a/swagger/examples/output/project-list.json
+++ b/swagger/examples/output/project-list.json
@@ -7,7 +7,7 @@
 	"public": false,
 	"permissions": [{
 		"access": "admin",
-		"_id": "coltonlw@flywheel.io"
+		"_id": "1234567890abc7654321abc4"
 	}]
 }, {
 	"group": "scitran",
@@ -18,7 +18,7 @@
 	"public": false,
 	"permissions": [{
 		"access": "admin",
-		"_id": "coltonlw@flywheel.io"
+		"_id": "1234567890abc7654321abc4"
 	}]
 }, {
 	"group": "scitran",
@@ -29,7 +29,7 @@
 	"public": false,
 	"permissions": [{
 		"access": "admin",
-		"_id": "coltonlw@flywheel.io"
+		"_id": "1234567890abc7654321abc4"
 	}]
 }, {
 	"group": "test-group",
@@ -41,7 +41,7 @@
 	"public": false,
 	"permissions": [{
 		"access": "admin",
-		"_id": "coltonlw@flywheel.io"
+		"_id": "1234567890abc7654321abc4"
 	}]
 }, {
 	"group": "scitran",
@@ -52,6 +52,6 @@
 	"_id": "57ed6312466d8e01c91ee427",
 	"permissions": [{
 		"access": "admin",
-		"_id": "coltonlw@flywheel.io"
+		"_id": "1234567890abc7654321abc4"
 	}]
 }]

--- a/swagger/examples/output/project.json
+++ b/swagger/examples/output/project.json
@@ -8,6 +8,6 @@
 	"public": false,
 	"permissions": [{
 		"access": "admin",
-		"_id": "coltonlw@flywheel.io"
+		"_id": "1234567890abc7654321abc4"
 	}]
 }

--- a/swagger/examples/output/save-query-list.json
+++ b/swagger/examples/output/save-query-list.json
@@ -3,13 +3,13 @@
         "_id": "57e34f8afab726054f7ec6b2",
         "label": "Search_1",
         "search": {"return_type": "session"},
-        "uid": "coltonlw@flywheel.io",
+        "uid": "1234567890abc7654321abc4",
         "created": "2016-09-21T14:56:09.943000+00:00",
         "modified": "2016-09-21T14:56:09.943000+00:00",
         "permissions": [
           {
             "access": "admin",
-            "_id": "coltonlw@flywheel.io"
+            "_id": "1234567890abc7654321abc4"
           }
         ]
     },
@@ -17,13 +17,13 @@
         "_id": "57e34f8aeab726002d7ec6b2",
         "label": "Search_2",
         "search": {"return_type": "acquisition"},
-        "uid": "coltonlw@flywheel.io",
+        "uid": "1234567890abc7654321abc4",
         "created": "2016-09-21T14:56:09.943000+00:00",
         "modified": "2016-09-21T14:56:09.943000+00:00",
         "permissions": [
           {
             "access": "admin",
-            "_id": "coltonlw@flywheel.io"
+            "_id": "1234567890abc7654321abc4"
           }
         ]
     }

--- a/swagger/examples/output/save-query.json
+++ b/swagger/examples/output/save-query.json
@@ -2,13 +2,13 @@
   "_id": "57e34f8aeab726000f7ec6b2",
   "label": "Search_2",
   "search": {"return_type": "acquisition"},
-  "uid": "coltonlw@flywheel.io",
+  "uid": "1234567890abc7654321abc4",
   "created": "2016-09-21T14:56:09.943000+00:00",
   "modified": "2016-09-21T14:56:09.943000+00:00",
   "permissions": [
     {
       "access": "admin",
-      "_id": "coltonlw@flywheel.io"
+      "_id": "1234567890abc7654321abc4"
     }
   ]
 }

--- a/swagger/examples/output/session-list.json
+++ b/swagger/examples/output/session-list.json
@@ -12,7 +12,7 @@
 	"public": false,
 	"permissions": [{
 		"access": "admin",
-		"_id": "coltonlw@flywheel.io"
+		"_id": "1234567890abc7654321abc4"
 	}]
 }, {
 	"group": "scitran",
@@ -28,7 +28,7 @@
 	"public": false,
 	"permissions": [{
 		"access": "admin",
-		"_id": "coltonlw@flywheel.io"
+		"_id": "1234567890abc7654321abc4"
 	}]
 }, {
 	"group": "scitran",
@@ -44,6 +44,6 @@
 	"public": false,
 	"permissions": [{
 		"access": "admin",
-		"_id": "coltonlw@flywheel.io"
+		"_id": "1234567890abc7654321abc4"
 	}]
 }]

--- a/swagger/examples/output/session.json
+++ b/swagger/examples/output/session.json
@@ -12,6 +12,6 @@
 	"public": false,
 	"permissions": [{
 		"access": "admin",
-		"_id": "coltonlw@flywheel.io"
+		"_id": "1234567890abc7654321abc4"
 	}]
 }

--- a/swagger/examples/output/subject-list.json
+++ b/swagger/examples/output/subject-list.json
@@ -10,7 +10,7 @@
     "public": false,
     "permissions": [{
         "access": "admin",
-        "_id": "coltonlw@flywheel.io"
+        "_id": "57e01cccf6b5d5ed2cb4e182"
     }]
 }, {
     "_id": "57e01cccb1dc04000fb83f56",
@@ -24,6 +24,6 @@
     "public": true,
     "permissions": [{
         "access": "admin",
-        "_id": "coltonlw@flywheel.io"
+        "_id": "57e01cccf6b5d5ed2cb4e182"
     }]
 }]

--- a/swagger/examples/output/subject.json
+++ b/swagger/examples/output/subject.json
@@ -16,6 +16,6 @@
     "public": false,
     "permissions": [{
         "access": "admin",
-        "_id": "coltonlw@flywheel.io"
+        "_id": "57e01cccf6b5d5ed2cb4e182"
     }]
 }

--- a/swagger/examples/user-list.json
+++ b/swagger/examples/user-list.json
@@ -1,5 +1,5 @@
 [{
-	"_id": "jane.doe@gmail.com",
+	"_id": "1234567890abc7654321abc4",
 	"firstname": "Jane",
 	"lastname": "Doe",
 	"email": "jane.doe@gmail.com",

--- a/swagger/examples/user_jane_doe.json
+++ b/swagger/examples/user_jane_doe.json
@@ -1,5 +1,5 @@
 {
-	"_id": "jane.doe@gmail.com",
+	"_id": "1234567890abc7654321abc4",
 	"firstname": "Jane",
 	"lastname": "Doe",
 	"email": "jane.doe@gmail.com",

--- a/swagger/schemas/definitions/common.json
+++ b/swagger/schemas/definitions/common.json
@@ -27,9 +27,9 @@
             "pattern": "^[0-9a-z][0-9a-z.@_-]{0,30}[0-9a-z]$"
         },
 		"user-id": {
-			"type": "string",
-			"format": "email",
-            "description": "Database ID of a user"
+            "type": "string",
+            "pattern": "^[a-fA-F0-9]{24}$",
+            "description": "Unique database ID"
 		},
         "info": {
             "type": "object",

--- a/swagger/schemas/definitions/file.json
+++ b/swagger/schemas/definitions/file.json
@@ -34,6 +34,7 @@
                   "type":"string",
                   "description": "Database ID of joined name and method"
                 },
+                "email":  {"$ref": "user.json#/definitions/email"},
                 "method": {
                   "type":"string",
                   "description": "Method of file origin"

--- a/swagger/schemas/definitions/job.json
+++ b/swagger/schemas/definitions/job.json
@@ -61,6 +61,7 @@
         "type": {
           "type": "string"
         },
+        "email":  {"$ref": "user.json#/definitions/email"},
         "id": {
           "type": ["string", "null"]
         }

--- a/swagger/schemas/definitions/user.json
+++ b/swagger/schemas/definitions/user.json
@@ -27,7 +27,7 @@
                           "type": "string",
                           "description": "Avatar image URL"
                         },
-    "root":             { 
+    "root":             {
                           "type": "boolean",
                           "description": "Super admin flag"
                         },
@@ -51,7 +51,6 @@
     "user-input":{
       "type":"object",
       "properties":{
-        "_id":{"$ref":"common.json#/definitions/user-id"},
         "firstname":{"$ref":"#/definitions/firstname"},
         "lastname":{"$ref":"#/definitions/lastname"},
         "email":{"$ref":"#/definitions/email"},
@@ -112,7 +111,7 @@
          "_id", "firstname", "lastname",
          "root", "email", "created", "modified"
       ],
-      "x-sdk-model": "user"      
+      "x-sdk-model": "user"
     }
   }
 }

--- a/swagger/schemas/input/permission.json
+++ b/swagger/schemas/input/permission.json
@@ -5,7 +5,7 @@
   "key_fields": ["_id"],
   "required": ["_id", "access"],
   "example": {
-	    "_id":"coltonlw@flywheel.io",
+	    "_id":"1234567890abc7654321abc4",
 	    "access":"admin"
 	}
 }

--- a/swagger/schemas/input/user-new.json
+++ b/swagger/schemas/input/user-new.json
@@ -2,9 +2,8 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "allOf":[{"$ref":"../definitions/user.json#/definitions/user-input"}],
-  "required":["_id", "firstname", "lastname"],
+  "required":["email", "firstname", "lastname"],
   "example": {
-		"_id": "jane.doe@gmail.com",
 		"firstname": "Jane",
 		"lastname": "Doe",
 		"email": "jane.doe@gmail.com",

--- a/swagger/schemas/mongo/analysis.json
+++ b/swagger/schemas/mongo/analysis.json
@@ -27,7 +27,7 @@
         "job":			{"type": "string"},
         "label":    	{"type": "string", "minLength": 1, "maxLength": 256},
         "user":     	{"type": "string"},
-        "permissions":  {"type": "array",  "items": {"$ref": "../definitions/permission.json#/definitions/permission"}},
+        "permissions":  {"type": "array",  "items": {"$ref": "permission.json"}},
         "public":       {"type": "boolean"}
     }
 }

--- a/swagger/schemas/mongo/collection.json
+++ b/swagger/schemas/mongo/collection.json
@@ -15,7 +15,7 @@
         "info": {},
         "description": {},
 
-        "curator": {"type": "string"}
+        "curator": {}
     },
     "additionalProperties": false
 }

--- a/swagger/schemas/mongo/container.json
+++ b/swagger/schemas/mongo/container.json
@@ -6,7 +6,7 @@
         "created":      {},
         "modified":     {},
         "notes":        {"type": "array",  "items": {"$ref": "note.json"}},
-        "permissions":  {"type": "array",  "items": {"$ref": "../definitions/permission.json#/definitions/permission"}},
+        "permissions":  {"type": "array",  "items": {"$ref": "permission.json"}},
         "files":        {"type": "array",  "items": {"$ref": "file.json"}},
         "public":       {"type": "boolean"},
         "label":        {"type": "string"},

--- a/swagger/schemas/mongo/group.json
+++ b/swagger/schemas/mongo/group.json
@@ -12,7 +12,7 @@
     "label":             {},
     "permissions":            {
                           "type": "array",
-                          "items": {"$ref": "../definitions/permission.json#/definitions/permission"},
+                          "items": {"$ref": "permission.json"},
                           "title": "Permissions",
                           "default": [],
                           "uniqueItems": true

--- a/swagger/schemas/mongo/note.json
+++ b/swagger/schemas/mongo/note.json
@@ -5,7 +5,7 @@
     "_id":              {"type": "string"},
     "created":          {},
     "modified":         {},
-    "user":             {"type": "string"},
+    "user":             {},
     "text":             {"type": "string"}
   },
   "required": ["_id", "user", "created", "modified", "text"],

--- a/swagger/schemas/mongo/permission.json
+++ b/swagger/schemas/mongo/permission.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "allOf":[{"$ref":"../definitions/permission.json#/definitions/permission"}],
-  "required": ["_id", "access"],
-  "key_fields": ["_id"]
+  "properties": {
+  	"_id":      {},
+  	"access": {"enum": ["admin", "rw", "ro"]}
+  }
 }

--- a/swagger/schemas/mongo/user.json
+++ b/swagger/schemas/mongo/user.json
@@ -44,5 +44,5 @@
     "wechat": {}
   },
   "additionalProperties": false,
-  "required":["_id", "firstname", "lastname", "created", "modified", "root"]
+  "required":["email", "firstname", "lastname", "created", "modified", "root"]
 }

--- a/swagger/schemas/output/user-new.json
+++ b/swagger/schemas/output/user-new.json
@@ -2,6 +2,6 @@
 	"$schema": "http://json-schema.org/draft-04/schema#",
 	"allOf": [{"$ref": "../definitions/common.json#/definitions/object-created"}],
 	"example": {
-		"_id": "jane.doe@gmail.com"
+		"_id": "1234567890abc7654321abc4"
 	}
 }

--- a/tests/integration_tests/python/test_access_log.py
+++ b/tests/integration_tests/python/test_access_log.py
@@ -35,13 +35,13 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
         'code': api_key
     })
     assert r.ok
-
+    admin_id = as_admin.get('/users/self').json()['_id']
     log_records_count_after = log_db.access_log.count({})
     assert log_records_count_before+1 == log_records_count_after
 
     most_recent_log = log_db.access_log.find({}).sort([('_id', -1)]).limit(1)[0]
     assert most_recent_log['access_type'] == AccessType.user_login.value
-    assert most_recent_log['origin']['id'] == 'admin@user.com'
+    assert str(most_recent_log['origin']['id']) == admin_id
 
 
     ###
@@ -58,7 +58,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
 
     most_recent_log = log_db.access_log.find({}).sort([('_id', -1)]).limit(1)[0]
     assert most_recent_log['access_type'] == AccessType.user_logout.value
-    assert most_recent_log['origin']['id'] == 'admin@user.com'
+    assert str(most_recent_log['origin']['id']) == admin_id
 
 
     ###
@@ -77,7 +77,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
 
     assert most_recent_log['context']['project']['id'] == project
     assert most_recent_log['access_type'] == AccessType.view_container.value
-    assert most_recent_log['origin']['id'] == 'admin@user.com'
+    assert str(most_recent_log['origin']['id']) == admin_id
 
 
     ###
@@ -96,7 +96,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
 
     assert most_recent_log['context']['session']['id'] == session
     assert most_recent_log['access_type'] == AccessType.view_container.value
-    assert most_recent_log['origin']['id'] == 'admin@user.com'
+    assert str(most_recent_log['origin']['id']) == admin_id
 
 
     ###
@@ -115,7 +115,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
 
     assert most_recent_log['context']['acquisition']['id'] == acquisition
     assert most_recent_log['access_type'] == AccessType.view_container.value
-    assert most_recent_log['origin']['id'] == 'admin@user.com'
+    assert str(most_recent_log['origin']['id']) == admin_id
 
 
     ###
@@ -147,7 +147,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
     assert most_recent_log['context']['session']['id'] == session
     assert most_recent_log['context']['subject']['label'] == subject_code
     assert most_recent_log['access_type'] == AccessType.view_subject.value
-    assert most_recent_log['origin']['id'] == 'admin@user.com'
+    assert str(most_recent_log['origin']['id']) == admin_id
 
 
     ###
@@ -166,7 +166,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
 
     assert most_recent_log['context']['subject']['label'] == subject_code
     assert most_recent_log['access_type'] == AccessType.view_subject.value
-    assert most_recent_log['origin']['id'] == 'admin@user.com'
+    assert most_recent_log['origin']['id'] == admin_id
 
 
     # Upload files
@@ -196,7 +196,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
     assert most_recent_log['context']['project']['id'] == project
     assert most_recent_log['context']['file']['name'] == file_name
     assert most_recent_log['access_type'] == AccessType.download_file.value
-    assert most_recent_log['origin']['id'] == 'admin@user.com'
+    assert str(most_recent_log['origin']['id']) == admin_id
 
 
     ###
@@ -225,7 +225,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
     assert most_recent_log['context']['file']['name'] == file_name
     assert most_recent_log['context']['ticket_id'] == ticket_id
     assert most_recent_log['access_type'] == AccessType.download_file.value
-    assert most_recent_log['origin']['id'] == 'admin@user.com'
+    assert str(most_recent_log['origin']['id']) == admin_id
 
 
     # Upload another file
@@ -254,7 +254,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
     for l in most_recent_logs:
         assert l['context']['file']['name'] == file_name
         assert l['access_type'] == AccessType.download_file.value
-        assert l['origin']['id'] == 'admin@user.com'
+        assert str(l['origin']['id']) == admin_id
 
     ###
     # Test search bulk download
@@ -277,7 +277,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
     for l in most_recent_logs:
         assert l['context']['file']['name'] == file_name
         assert l['access_type'] == AccessType.download_file.value
-        assert l['origin']['id'] == 'admin@user.com'
+        assert str(l['origin']['id']) == admin_id
 
 
     ###
@@ -298,7 +298,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
     assert most_recent_log['context']['project']['id'] == project
     assert most_recent_log['context']['file']['name'] == file_name
     assert most_recent_log['access_type'] == AccessType.view_file.value
-    assert most_recent_log['origin']['id'] == 'admin@user.com'
+    assert str(most_recent_log['origin']['id']) == admin_id
 
 
     ###
@@ -321,7 +321,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
     assert most_recent_log['context']['project']['id'] == project
     assert most_recent_log['context']['file']['name'] == file_name
     assert most_recent_log['access_type'] == AccessType.replace_file.value
-    assert most_recent_log['origin']['id'] == 'admin@user.com'
+    assert str(most_recent_log['origin']['id']) == admin_id
 
 
     ###
@@ -341,7 +341,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
     assert most_recent_log['context']['project']['id'] == project
     assert most_recent_log['context']['file']['name'] == file_name
     assert most_recent_log['access_type'] == AccessType.delete_file.value
-    assert most_recent_log['origin']['id'] == 'admin@user.com'
+    assert str(most_recent_log['origin']['id']) == admin_id
 
 
     ###
@@ -360,7 +360,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
 
     assert most_recent_log['context']['acquisition']['id'] == acquisition
     assert most_recent_log['access_type'] == AccessType.delete_container.value
-    assert most_recent_log['origin']['id'] == 'admin@user.com'
+    assert str(most_recent_log['origin']['id']) == admin_id
 
 
     ###
@@ -379,7 +379,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
 
     assert most_recent_log['context']['session']['id'] == session
     assert most_recent_log['access_type'] == AccessType.delete_container.value
-    assert most_recent_log['origin']['id'] == 'admin@user.com'
+    assert str(most_recent_log['origin']['id']) == admin_id
 
 
     ###
@@ -398,7 +398,7 @@ def test_access_log_succeeds(data_builder, as_admin, log_db):
 
     assert most_recent_log['context']['project']['id'] == project
     assert most_recent_log['access_type'] == AccessType.delete_container.value
-    assert most_recent_log['origin']['id'] == 'admin@user.com'
+    assert str(most_recent_log['origin']['id']) == admin_id
 
 
 
@@ -430,7 +430,7 @@ def test_access_log_fails(data_builder, as_admin, log_db):
 def test_create_entry_validation():
     # Could be a unit test?
     req = MockRequest('GET', '/test')
-    origin = { 'type': 'user', 'id': 'admin@user.com' }
+    origin = { 'type': 'user', 'id': '000000000000000000000000' }
 
     try:
         # Invalid access type
@@ -462,8 +462,10 @@ def test_bulk_access(data_builder, as_admin, log_db):
 
     log_records_count_before = log_db.access_log.count({})
 
+    admin_id = as_admin.get('/users/self').json()['_id']
+
     req = MockRequest('GET', '/test/bulk_log_access')
-    origin = { 'type': 'user', 'id': 'admin@user.com' }
+    origin = { 'type': 'user', 'id': admin_id }
 
     entries = [
         (AccessType.view_container, {
@@ -493,13 +495,13 @@ def test_bulk_access(data_builder, as_admin, log_db):
         log2 = most_recent_logs[1]
 
     assert log1['access_type'] == AccessType.view_container.value
-    assert log1['origin']['id'] == 'admin@user.com'
+    assert log1['origin']['id'] == admin_id
     assert log1['request_method'] == 'GET'
     assert log1['request_path'] == '/test/bulk_log_access'
     assert log1['context']['group']['id'] == 'test'
 
     assert log2['access_type'] == AccessType.view_file.value
-    assert log2['origin']['id'] == 'admin@user.com'
+    assert log2['origin']['id'] == admin_id
     assert log2['request_method'] == 'GET'
     assert log2['request_path'] == '/test/bulk_log_access'
     assert log2['context']['file']['name'] == 'example.csv'
@@ -516,6 +518,8 @@ def test_job_access(data_builder, as_admin, as_drone, log_db, default_payload,
         }
     }
     gear = data_builder.create_gear(gear=gear_doc)
+
+    admin_id = as_admin.get('/users/self').json()['_id']
 
     project = data_builder.create_project()
     session = data_builder.create_session(project=project)
@@ -568,12 +572,12 @@ def test_job_access(data_builder, as_admin, as_drone, log_db, default_payload,
         job_log = most_recent_logs[0]
 
     assert input_log['access_type'] == AccessType.view_file.value
-    assert input_log['origin']['id'] == 'admin@user.com'
+    assert input_log['origin']['id'] == admin_id
     assert input_log['request_method'] == 'GET'
     assert input_log['context']['file']['name'] == 'test.zip'
 
     assert job_log['access_type'] == AccessType.view_job.value
-    assert job_log['origin']['id'] == 'admin@user.com'
+    assert job_log['origin']['id'] == admin_id
     assert job_log['request_method'] == 'GET'
     assert job_log['context']['job']['id'] == job_id
 
@@ -639,7 +643,7 @@ def test_job_access(data_builder, as_admin, as_drone, log_db, default_payload,
         if log['access_type'] == 'view_subject':
             logs_tested += 1
             assert log['context']['subject']['id'] == subject
-            assert log['origin']['id'] == 'admin@user.com'
+            assert log['origin']['id'] == admin_id
         if log['access_type'] == 'view_container':
             logs_tested += 1
             assert log['context']['subject']['id'] == subject
@@ -679,7 +683,7 @@ def test_job_access(data_builder, as_admin, as_drone, log_db, default_payload,
     most_recent_log = log_db.access_log.find({}).sort([('timestamp', -1)]).limit(1)[0]
     assert most_recent_log['access_type'] == 'view_job_logs'
     assert most_recent_log['context']['job']['id'] == job_id
-    assert most_recent_log['origin']['id'] == 'admin@user.com'
+    assert most_recent_log['origin']['id'] == admin_id
 
     # Access the logs for the job as text
     r = as_admin.get('/jobs/' + job_id + '/logs/text')
@@ -692,7 +696,7 @@ def test_job_access(data_builder, as_admin, as_drone, log_db, default_payload,
     most_recent_log = log_db.access_log.find({}).sort([('timestamp', -1)]).limit(1)[0]
     assert most_recent_log['access_type'] == 'view_job_logs'
     assert most_recent_log['context']['job']['id'] == job_id
-    assert most_recent_log['origin']['id'] == 'admin@user.com'
+    assert most_recent_log['origin']['id'] == admin_id
 
     # Access the logs for the job as html
     r = as_admin.get('/jobs/' + job_id + '/logs/html')
@@ -705,7 +709,7 @@ def test_job_access(data_builder, as_admin, as_drone, log_db, default_payload,
     most_recent_log = log_db.access_log.find({}).sort([('timestamp', -1)]).limit(1)[0]
     assert most_recent_log['access_type'] == 'view_job_logs'
     assert most_recent_log['context']['job']['id'] == job_id
-    assert most_recent_log['origin']['id'] == 'admin@user.com'
+    assert most_recent_log['origin']['id'] == admin_id
 
     # Unset config
     api_db.jobs.update_one({'_id': bson.ObjectId(job_id)}, {'$unset': {'config': ''}})

--- a/tests/integration_tests/python/test_download.py
+++ b/tests/integration_tests/python/test_download.py
@@ -40,10 +40,13 @@ def test_download_k(data_builder, file_form, as_admin, as_user, api_db, legacy_c
     acquisition3 = data_builder.create_acquisition(session=session3)
     acquisition4 = data_builder.create_acquisition(session=session4)
 
+    user_id = as_user.get('/users/self').json()['_id']
+
     # upload the same file to each container created and use different tags to
     # facilitate download filter tests:
     # acquisition: [], session: ['plus'], project: ['plus', 'minus']
-    as_admin.post('/projects/' + project + '/permissions', json={'_id': 'user@user.com', 'access': 'admin'})
+    assert as_admin.post('/projects/' + project + '/permissions',
+                         json={'_id': user_id, 'access': 'admin'}).ok
     file_name = 'test.csv'
     as_user.post('/acquisitions/' + acquisition + '/files', files=file_form(
         file_name, meta={'name': file_name, 'type': 'csv'}))
@@ -211,7 +214,8 @@ def test_download_k(data_builder, file_form, as_admin, as_user, api_db, legacy_c
     (project_legacy, file_name_legacy, file_content) = legacy_cas_file
 
     # Add user to leagcy project permissions
-    as_admin.post('/projects/' + project_legacy + '/permissions', json={'_id': 'user@user.com', 'access': 'admin'})
+    assert as_admin.post('/projects/' + project_legacy + '/permissions',
+                         json={'_id': user_id, 'access': 'admin'}).ok
     r = as_user.post('/download', json={
         'optional': False,
         'nodes': [
@@ -268,8 +272,10 @@ def test_filelist_download(data_builder, file_form, as_user, as_admin, legacy_ca
     project = data_builder.create_project()
     session = data_builder.create_session(project=project)
 
+    user_id = as_user.get('/users/self').json()['_id']
+
     # Add User to permissions
-    as_admin.post('/projects/' + project + '/permissions', json={'_id': 'user@user.com', 'access': 'admin'})
+    assert as_admin.post('/projects/' + project + '/permissions', json={'_id': user_id, 'access': 'admin'}).ok
 
     zip_cont = cStringIO.StringIO()
     with zipfile.ZipFile(zip_cont, 'w') as zip_file:
@@ -328,7 +334,7 @@ def test_filelist_download(data_builder, file_form, as_user, as_admin, legacy_ca
     # test legacy cas file handling
     (project, file_name, file_content) = legacy_cas_file
     # Add User to permissions
-    as_admin.post('/projects/' + project + '/permissions', json={'_id': 'user@user.com', 'access': 'admin'})
+    assert as_admin.post('/projects/' + project + '/permissions', json={'_id': user_id, 'access': 'admin'}).ok
     r = as_user.get('/projects/' + project + '/files/' + file_name, params={'ticket': ''})
     assert r.ok
 
@@ -343,8 +349,10 @@ def test_filelist_range_download(data_builder, as_user, as_admin, file_form):
     project = data_builder.create_project()
     session = data_builder.create_session(project=project)
 
+    user_id = as_user.get('/users/self').json()['_id']
+
     # Add user to permissions
-    as_admin.post('/projects/' + project + '/permissions', json={'_id': 'user@user.com', 'access': 'admin'})
+    assert as_admin.post('/projects/' + project + '/permissions', json={'_id': user_id, 'access': 'admin'}).ok
 
     session_files = '/sessions/' + session + '/files'
     as_user.post(session_files, files=file_form(('one.csv', '123456789')))
@@ -452,8 +460,10 @@ def test_filelist_advanced_range_download(data_builder, as_user, as_admin, file_
     project = data_builder.create_project()
     session = data_builder.create_session(project=project)
 
+    user_id = as_user.get('/users/self').json()['_id']
+
     # Add User to permissions
-    as_admin.post('/projects/' + project + '/permissions', json={'_id': 'user@user.com', 'access': 'admin'})
+    assert as_admin.post('/projects/' + project + '/permissions', json={'_id': user_id, 'access': 'admin'}).ok
 
     session_files = '/sessions/' + session + '/files'
     as_user.post(session_files, files=file_form(('one.csv', '123456789')))
@@ -706,7 +716,8 @@ def test_analyses_range_download(data_builder, as_user, as_admin, file_form):
     project = data_builder.create_project()
     session = data_builder.create_session(project=project)
     # Add User to permissions
-    as_admin.post('/projects/' + project + '/permissions', json={'_id': 'user@user.com', 'access': 'admin'})
+    user_id = as_user.get('/users/self').json()['_id']
+    assert as_admin.post('/projects/' + project + '/permissions', json={'_id': user_id, 'access': 'admin'}).ok
     zip_cont = cStringIO.StringIO()
     with zipfile.ZipFile(zip_cont, 'w') as zip_file:
         zip_file.writestr('two.csv', 'sample\ndata\n')
@@ -799,8 +810,9 @@ def test_filters(data_builder, file_form, as_user, as_admin):
     acquisition = data_builder.create_acquisition()
     acquisition2 = data_builder.create_acquisition()
 
+    user_id = as_user.get('/users/self').json()['_id']
     # Add User to permissions
-    as_admin.post('/projects/' + project + '/permissions', json={'_id': 'user@user.com', 'access': 'admin'})
+    assert as_admin.post('/projects/' + project + '/permissions', json={'_id': user_id, 'access': 'admin'}).ok
 
     as_user.post('/acquisitions/' + acquisition + '/files', files=file_form(
         "test.csv", meta={'name': "test.csv", 'type': 'csv', 'tags': ['red', 'blue']}))

--- a/tests/integration_tests/python/test_errors.py
+++ b/tests/integration_tests/python/test_errors.py
@@ -19,7 +19,7 @@ def test_error_response(as_admin, as_user, as_public, as_root, data_builder, api
     project = data_builder.create_project()
 
     # Test dao exception
-    r = as_admin.post('/users', json={'_id': "admin@user.com", 'firstname': "Firstname", 'lastname': "Lastname"})
+    r = as_admin.post('/users', json={'email': "admin@user.com", 'firstname': "Firstname", 'lastname': "Lastname"})
     assert r.status_code == 409
     assert r.json().get('request_id')
 

--- a/tests/integration_tests/python/test_jobs.py
+++ b/tests/integration_tests/python/test_jobs.py
@@ -731,7 +731,7 @@ def test_jobs_ask(data_builder, default_payload, as_public, as_user, as_admin, a
     assert r.status_code == 403
 
     # try to update job (user may only cancel)
-    api_db.jobs.update_one({'_id': bson.ObjectId(job1_id)}, {'$set': {'origin.id': 'user@user.com'}})
+    api_db.jobs.update_one({'_id': bson.ObjectId(job1_id)}, {'$set': {'origin.id': user_id}})
     r = as_user.put('/jobs/' + job1_id, json={'test': 'invalid'})
     assert r.status_code == 403
 
@@ -2349,6 +2349,7 @@ def test_config_values(data_builder, default_payload, as_admin, file_form):
     assert r.ok
 
 def test_job_detail(data_builder, default_payload, as_admin, as_user, as_drone, as_public, file_form):
+    user_id = as_user.get('/users/self').json()['_id']
     # Dupe of test_queue.py
     gear_doc = default_payload['gear']['gear']
     gear_doc['inputs'] = {
@@ -2504,7 +2505,7 @@ def test_job_detail(data_builder, default_payload, as_admin, as_user, as_drone, 
 
     # Add permission and verify access
     assert as_admin.post('/projects/' + project + '/permissions', json={
-        '_id': 'user@user.com',
+        '_id': user_id,
         'access': 'ro'
     }).ok
     r = as_user.get('/jobs/' + job + '/detail')
@@ -2669,4 +2670,3 @@ def test_failed_rule_execution(data_builder, default_payload, as_user, as_admin,
     r = as_admin.get('/jobs/' + job + '/logs')
     assert r.ok
     assert r.json()['logs'] == expected_job_logs
-

--- a/tests/integration_tests/python/test_permissions.py
+++ b/tests/integration_tests/python/test_permissions.py
@@ -1,7 +1,7 @@
 def test_permissions(data_builder, as_admin):
     project = data_builder.create_project()
-    user_1 = data_builder.create_user(_id='test-permissions-1@user.com')
-    user_2 = data_builder.create_user(_id='test-permissions-2@user.com')
+    user_1 = data_builder.create_user(email='test-permissions-1@user.com')
+    user_2 = data_builder.create_user(email='test-permissions-2@user.com')
 
     permissions_path = '/projects/' + project + '/permissions'
     user_1_path = permissions_path + '/' + user_1
@@ -13,7 +13,7 @@ def test_permissions(data_builder, as_admin):
 
     # Try to add permission for unknown user
     r = as_admin.post(permissions_path, json={
-        '_id': 'fake_user@yahoo.com',
+        '_id': '000000000000000000000000',
         'access': 'admin'
         })
     assert r.status_code == 402

--- a/tests/integration_tests/python/test_propagation.py
+++ b/tests/integration_tests/python/test_propagation.py
@@ -73,7 +73,7 @@ def test_add_and_remove_user_for_project_permissions(data_builder, as_admin):
     session = data_builder.create_session()
     acquisition = data_builder.create_acquisition()
 
-    user_id = data_builder.create_user(_id='propagation@user.com')
+    user_id = data_builder.create_user(email='propagation@user.com')
 
     # Add user to project permissions
     payload = {'_id': user_id, 'access': 'admin'}
@@ -154,7 +154,7 @@ def test_add_and_remove_user_group_permission(data_builder, as_admin):
     session = data_builder.create_session()
     acquisition = data_builder.create_acquisition()
 
-    user_id = data_builder.create_user(_id='propagation@user.com')
+    user_id = data_builder.create_user(email='propagation@user.com')
 
     # Add user to group permissions
     payload = {'_id': user_id, 'access': 'admin'}

--- a/tests/integration_tests/python/test_reports.py
+++ b/tests/integration_tests/python/test_reports.py
@@ -183,7 +183,7 @@ def test_access_log_report(data_builder, with_user, as_user, as_admin):
 
     r = as_admin.get('/report/accesslog', params={'subject': 'compliant5'})
     assert r.ok
-    for count,log in enumerate(r.json(), start = 1):
+    for count, log in enumerate(r.json(), start = 1):
         assert log.get('context', {}).get('subject', {}).get('label') == 'compliant5'
     assert count == 2
     r = as_admin.delete('/sessions/' + session)

--- a/tests/integration_tests/python/test_saving_search_queries.py
+++ b/tests/integration_tests/python/test_saving_search_queries.py
@@ -1,5 +1,7 @@
 
-def test_saving_search_queries(as_admin, data_builder):
+def test_saving_search_queries(as_admin, as_user, data_builder):
+
+    user_id = as_user.get('/users/self').json()["_id"]
 
     # Try posting a malformed search
     r = as_admin.post('/dataexplorer/queries', json={"not-label":"random-string"})
@@ -42,21 +44,21 @@ def test_saving_search_queries(as_admin, data_builder):
     assert r.json()['label'] == 'newSearch'
 
     # Add permission to search
-    r = as_admin.post('/dataexplorer/queries/' + search + '/permissions', json={'access': 'admin', '_id': 'user@user.com'})
+    r = as_admin.post('/dataexplorer/queries/' + search + '/permissions', json={'access': 'admin', '_id': user_id})
     assert r.ok
     r = as_admin.get('/dataexplorer/queries/' + search)
     assert r.ok
-    assert r.json()['permissions'][1]['_id'] == 'user@user.com'
+    assert r.json()['permissions'][1]['_id'] == user_id
 
     # Modify permission
-    r = as_admin.put('/dataexplorer/queries/' + search + '/permissions/user@user.com', json={'access': 'ro'})
+    r = as_admin.put('/dataexplorer/queries/' + search + '/permissions/' + user_id, json={'access': 'ro'})
     assert r.ok
     r = as_admin.get('/dataexplorer/queries/' + search)
     assert r.ok
     assert r.json()['permissions'][1]['access'] == 'ro'
 
     # Remove permission
-    r = as_admin.delete('/dataexplorer/queries/' + search + '/permissions/user@user.com')
+    r = as_admin.delete('/dataexplorer/queries/' + search + '/permissions/' + user_id)
     assert r.ok
     r = as_admin.get('/dataexplorer/queries/' + search)
     assert r.ok

--- a/tests/integration_tests/python/test_tags.py
+++ b/tests/integration_tests/python/test_tags.py
@@ -1,7 +1,8 @@
 def test_tags(data_builder, as_admin, as_user):
     project = data_builder.create_project()
-    r = as_admin.post('/projects/' + project + '/permissions', json={'_id': 'user@user.com', 'access': 'rw'})
-    assert r.ok
+
+    user_id = as_user.get('/users/self').json()['_id']
+    assert as_admin.post('/projects/' + project + '/permissions', json={'_id': user_id, 'access': 'rw'}).ok
 
     tag = 'test_tag'
     new_tag = 'new_test_tag'

--- a/tests/integration_tests/python/test_users.py
+++ b/tests/integration_tests/python/test_users.py
@@ -32,7 +32,6 @@ def test_users(data_builder, as_admin, as_user, as_public):
 
     # Try adding new user missing required attr
     r = as_admin.post('/users', json={
-        '_id': 'jane.doe@gmail.com',
         'lastname': 'Doe',
         'email': 'jane.doe@gmail.com',
     })
@@ -40,24 +39,26 @@ def test_users(data_builder, as_admin, as_user, as_public):
     assert "'firstname' is a required property" in r.text
 
     # Add new user
-    new_user_id = 'new@user.com'
+    new_user_email = 'new@user.com'
     r = as_admin.post('/users', json={
-        '_id': new_user_id,
+        'email': new_user_email,
         'firstname': 'New',
         'lastname': 'User',
     })
     assert r.ok
+    new_user_id = r.json()["_id"]
     r = as_admin.get('/users/' + new_user_id)
     assert r.ok
 
     # Add new user as admin
-    new_user_id_admin = 'new2@user.com'
+    new_user_email_admin = 'new2@user.com'
     r = as_admin.post('/users', json={
-        '_id': new_user_id_admin,
+        'email': new_user_email_admin,
         'firstname': 'New2',
         'lastname': 'User2',
     })
     assert r.ok
+    new_user_id_admin = r.json()["_id"]
     r = as_admin.get('/users/' + new_user_id)
     assert r.ok
 
@@ -74,7 +75,7 @@ def test_users(data_builder, as_admin, as_user, as_public):
     assert r.ok
 
     # Try to update non-existent user
-    r = as_admin.put('/users/nonexistent@user.com', json={'firstname': 'Realname'})
+    r = as_admin.put('/users/000000000000000000000000', json={'firstname': 'Realname'})
     assert r.status_code == 404
 
     # Try empty update
@@ -120,13 +121,14 @@ def test_users(data_builder, as_admin, as_user, as_public):
     assert r.ok
 
     # Test HTTPS enforcement on avatar urls
-    new_user_id = 'new@user.com'
+    new_user_email = 'new@user.com'
     r = as_admin.post('/users', json={
-        '_id': new_user_id,
+        'email': new_user_email,
         'firstname': 'New',
         'lastname': 'User',
     })
     assert r.ok
+    new_user_id = r.json()['_id']
     r = as_admin.get('/users/' + new_user_id)
     assert r.ok
 
@@ -168,5 +170,5 @@ def test_reset_wechat_registration(data_builder, as_admin):
 
 def test_bootstrap_not_allowed_twice(bootstrap_users, as_public):
     # Verify that public user creation is only allowed once (used in bootstrap_users)
-    r = as_public.post('/users', json={'_id': 'h@cker.man', 'firstname': 'Hax0r', 'lastname': 'Wannabe'})
+    r = as_public.post('/users', json={'email': 'h@cker.man', 'firstname': 'Hax0r', 'lastname': 'Wannabe'})
     assert r.status_code == 403


### PR DESCRIPTION
### Changes
- User id is an ObjectId
- handler.uid is an ObjectId
- origin.id for is still a string to match the ids of other origin.types
- permissions use ObjectId
- Collection curator is ObjectId
- `_id` is not a valid input for user, `email` is required for posts (Frontend change needed)
- when viewing access_logs that are of origin.type=="user", the frontend will need to display the origin.email field instead of _id
### Todo
- [x] DB update
- [ ] Figure out Frontend changes
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
