### PR TITLE
Add log statement counters to metrics

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -27,6 +27,10 @@ logging.getLogger('urllib3').setLevel(logging.WARNING) # silence urllib3 library
 logging.getLogger('boto3').setLevel(logging.WARNING) # silence boto3 library
 logging.getLogger('botocore').setLevel(logging.WARNING) # silence botocore library
 
+# Increment counters for root logger. Increments for warning and higher
+from .metrics.log_handler import MetricsLogHandler
+logging.getLogger().addHandler(MetricsLogHandler())
+
 # NOTE: Keep in sync with environment variables in sample.config file.
 DEFAULT_CONFIG = {
     'core': {

--- a/api/metrics/log_handler.py
+++ b/api/metrics/log_handler.py
@@ -1,0 +1,16 @@
+import logging
+from .values import LOG_MESSAGE_COUNT
+
+class MetricsLogHandler(logging.Handler):
+	"""Log handler that increments a logging metrics counter"""
+	def __init__(self, level=logging.WARN):
+		"""Create a new MetricsLogHandler
+
+		Arguments:
+			level (int): The log-level threshold
+		"""
+		super(MetricsLogHandler, self).__init__(level)
+
+	def emit(self, record):
+		"""Increment the counter"""
+		LOG_MESSAGE_COUNT.labels(record.name, record.levelname).inc()

--- a/api/metrics/values.py
+++ b/api/metrics/values.py
@@ -10,6 +10,8 @@ RESPONSE_TIME = Counter('fw_core_response_time_seconds_sum', 'Observed time to c
 RESPONSE_SIZE = Counter('fw_core_response_size_bytes_sum', 'Observed response size, in bytes', ['method', 'template', 'status'])
 # Response Count
 RESPONSE_COUNT = Counter('fw_core_response_count', 'Observed response counts', ['method', 'template', 'status'])
+# Log Counter
+LOG_MESSAGE_COUNT = Counter('fw_core_log_message_count', 'Observed log statement counts', ['name', 'level'])
 
 # ===== UWSGI Workers ======
 # Labels: PID


### PR DESCRIPTION
Counters are labeled by logger name and log level (e.g. `scitran.api` and `CRITICAL`)
Log messages at `WARN` and higher are counted.

cc @ryansanford 

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
