### PR TITLE
Improve API Exception classes

### DIFF
--- a/api/dao/containerstorage.py
+++ b/api/dao/containerstorage.py
@@ -499,7 +499,7 @@ class AnalysisStorage(ContainerStorage):
         job = analysis.pop('job', None)
         if job is not None:
             if parent_type != 'session':
-                raise APIValidationException({'reason': 'Analysis created via a job must be at the session level'})
+                raise APIValidationException(reason='Analysis created via a job must be at the session level')
             analysis.setdefault('inputs', [])
             for key, fileref_dict in job['inputs'].iteritems():
                 analysis['inputs'].append(fileref_dict)

--- a/api/files.py
+++ b/api/files.py
@@ -170,9 +170,6 @@ def get_single_file_field_storage(file_system, use_filepath=False):
 
     return SingleFileFieldStorage
 
-class FileStoreException(Exception):
-    pass
-
 # File extension --> scitran file type detection hueristics.
 # Listed in precendence order.
 with open(os.path.join(os.path.dirname(__file__), 'filetypes.json')) as fd:

--- a/api/handlers/devicehandler.py
+++ b/api/handlers/devicehandler.py
@@ -104,7 +104,7 @@ class DeviceHandler(base.RequestHandler):
         # New devices created via POST may have `type` not set. Devices are allowed to initialize
         # the field themselves, but not allowed to change it (which implies a different device).
         if 'type' in payload and device.get('type') not in (None, payload['type']):
-            raise APIValidationException({'reason': 'Cannot change device type'})
+            raise APIValidationException(reason='Cannot change device type')
 
         result = self.storage.update_el(device_id, payload)
         return {'modified': result.modified_count}

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -118,10 +118,7 @@ class ListHandler(base.RequestHandler):
     def get(self, cont_name, list_name, **kwargs):
         _id = kwargs.pop('cid')
         permchecker, storage, _, _, keycheck = self._initialize_request(cont_name, list_name, _id, query_params=kwargs)
-        try:
-            result = keycheck(permchecker(storage.exec_op))('GET', _id, query_params=kwargs)
-        except APIStorageException as e:
-            self.abort(400, e.message)
+        result = keycheck(permchecker(storage.exec_op))('GET', _id, query_params=kwargs)
 
         if result is None:
             self.abort(404, 'Element not found in list {} of container {} {}'.format(storage.list_name, storage.cont_name, _id))
@@ -146,10 +143,7 @@ class ListHandler(base.RequestHandler):
 
         payload = self.request.json_body
         payload_validator(payload, 'PUT')
-        try:
-            result = keycheck(mongo_validator(permchecker(storage.exec_op)))('PUT', _id=_id, query_params=kwargs, payload=payload)
-        except APIStorageException as e:
-            self.abort(400, e.message)
+        result = keycheck(mongo_validator(permchecker(storage.exec_op)))('PUT', _id=_id, query_params=kwargs, payload=payload)
         # abort if the query of the update wasn't able to find any matching documents
         if result.matched_count == 0:
             self.abort(404, 'Element not updated in list {} of container {} {}'.format(storage.list_name, storage.cont_name, _id))
@@ -159,10 +153,7 @@ class ListHandler(base.RequestHandler):
     def delete(self, cont_name, list_name, **kwargs):
         _id = kwargs.pop('cid')
         permchecker, storage, _, _, keycheck = self._initialize_request(cont_name, list_name, _id, query_params=kwargs)
-        try:
-            result = keycheck(permchecker(storage.exec_op))('DELETE', _id, query_params=kwargs)
-        except APIStorageException as e:
-            self.abort(400, e.message)
+        result = keycheck(permchecker(storage.exec_op))('DELETE', _id, query_params=kwargs)
         if result.modified_count == 1:
             return {'modified': result.modified_count}
         else:
@@ -250,10 +241,7 @@ class PermissionsListHandler(ListHandler):
         method to propagate permissions from a container/group to its sessions and acquisitions
         """
         if cont_name == 'groups':
-            try:
-                containerutil.propagate_changes(cont_name, _id, query, update)
-            except APIStorageException as e:
-                self.abort(400, e.message)
+            containerutil.propagate_changes(cont_name, _id, query, update)
         elif cont_name == 'projects':
             try:
                 oid = bson.ObjectId(_id)
@@ -432,10 +420,7 @@ class FileListHandler(ListHandler):
             permchecker = always_ok
 
         # Grab fileinfo from db
-        try:
-            fileinfo = keycheck(permchecker(storage.exec_op))('GET', _id, query_params=kwargs)
-        except APIStorageException as e:
-            self.abort(400, e.message)
+        fileinfo = keycheck(permchecker(storage.exec_op))('GET', _id, query_params=kwargs)
         if not fileinfo:
             self.abort(404, 'no such file')
 
@@ -579,11 +564,8 @@ class FileListHandler(ListHandler):
 
         validators.validate_data(payload, 'info_update.json', 'input', 'POST')
 
-        try:
-            permchecker(noop)('PUT', _id=_id, query_params=kwargs, payload=payload)
-            result = storage.modify_info(_id, kwargs, payload)
-        except APIStorageException as e:
-            self.abort(400, e.message)
+        permchecker(noop)('PUT', _id=_id, query_params=kwargs, payload=payload)
+        result = storage.modify_info(_id, kwargs, payload)
         return result
 
 
@@ -659,10 +641,7 @@ class FileListHandler(ListHandler):
                 errors={'reason': 'analysis_conflict'})
 
         self.log_user_access(AccessType.delete_file, cont_name=cont_name, cont_id=_id, filename=filename)
-        try:
-            result = keycheck(storage.exec_op)('DELETE', _id, query_params=kwargs)
-        except APIStorageException as e:
-            self.abort(400, e.message)
+        result = keycheck(storage.exec_op)('DELETE', _id, query_params=kwargs)
         if result.modified_count == 1:
             return {'modified': result.modified_count}
         else:

--- a/api/handlers/modalityhandler.py
+++ b/api/handlers/modalityhandler.py
@@ -54,8 +54,7 @@ class APIClassificationException(APIValidationException):
         else:
             error_msg = 'Classification does not match format for modality {}. Unallowable key-value pairs: {}'.format(modality, errors)
 
-        super(APIClassificationException, self).__init__(error_msg)
-        self.errors = {'unaccepted_keys': errors}
+        super(APIClassificationException, self).__init__(error_msg, unaccepted_keys=errors)
 
 
 def case_insensitive_search(classifications, proposed_key, proposed_value):

--- a/api/handlers/refererhandler.py
+++ b/api/handlers/refererhandler.py
@@ -18,7 +18,7 @@ from ..dao import containerstorage, noop
 from ..dao.basecontainerstorage import ContainerStorage
 from ..dao.containerutil import singularize
 from ..web import base
-from ..web.errors import APIStorageException, InputValidationException
+from ..web.errors import InputValidationException
 from ..web.request import log_access, AccessType
 from .listhandler import FileListHandler
 
@@ -191,10 +191,7 @@ class AnalysesHandler(RefererHandler):
         permchecker = self.get_permchecker(parent)
         permchecker(noop)('DELETE')
 
-        try:
-            result = self.storage.delete_el(_id)
-        except APIStorageException as e:
-            self.abort(400, e.message)
+        result = self.storage.delete_el(_id)
         if result.modified_count == 1:
             return {'deleted': result.modified_count}
         else:

--- a/api/handlers/reporthandler.py
+++ b/api/handlers/reporthandler.py
@@ -60,10 +60,7 @@ class ReportHandler(base.RequestHandler):
 
         if report_type in ReportTypes:
             report_class = ReportTypes[report_type]
-            try:
-                report = report_class(self.request.params)
-            except APIReportParamsException as e:
-                self.abort(400, e.message)
+            report = report_class(self.request.params)
         else:
             raise NotImplementedError('Report type {} is not supported'.format(report_type))
 

--- a/api/jobs/gears.py
+++ b/api/jobs/gears.py
@@ -122,15 +122,7 @@ def validate_gear_config(gear, config_):
         try:
             validator.validate(config_)
         except ValidationError as err:
-            key = None
-            if len(err.relative_path) > 0:
-                key = err.relative_path[0]
-
-            raise APIValidationException({
-                'reason': 'config did not match manifest',
-                'error': err.message.replace("u'", "'"),
-                'key': key
-            })
+            raise APIValidationException(reason='config did not match manifest', cause=err)
     return True
 
 def fill_gear_default_values(gear, config_):

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -17,7 +17,7 @@ from ..auth.apikeys import JobApiKey
 from ..dao import dbutil, hierarchy
 from ..dao.containerstorage import ProjectStorage, SessionStorage, SubjectStorage, AcquisitionStorage, AnalysisStorage, cs_factory
 from ..types import Origin
-from ..util import humanize_validation_error, set_for_download
+from ..util import set_for_download
 from ..validators import validate_data, verify_payload_exists
 from ..dao.containerutil import pluralize, singularize
 from ..web import base
@@ -231,7 +231,7 @@ class GearHandler(base.RequestHandler):
             return { '_id': str(result) }
 
         except ValidationError as err:
-            raise InputValidationException(humanize_validation_error(err))
+            raise InputValidationException(cause=err)
 
     @require_admin
     def delete(self, _id):

--- a/api/jobs/rules.py
+++ b/api/jobs/rules.py
@@ -313,7 +313,7 @@ def validate_regexes(rule):
             except re.error:
                 invalid_patterns.add(pattern)
     if invalid_patterns:
-        raise APIValidationException({
+        raise APIValidationException(errors={
             'reason': 'Cannot compile regex patterns',
             'patterns': sorted(invalid_patterns),
         })

--- a/api/jobs/rules.py
+++ b/api/jobs/rules.py
@@ -313,7 +313,7 @@ def validate_regexes(rule):
             except re.error:
                 invalid_patterns.add(pattern)
     if invalid_patterns:
-        raise APIValidationException(errors={
-            'reason': 'Cannot compile regex patterns',
-            'patterns': sorted(invalid_patterns),
-        })
+        raise APIValidationException(
+            reason='Cannot compile regex patterns', 
+            patterns=sorted(invalid_patterns)
+        )

--- a/api/upload.py
+++ b/api/upload.py
@@ -8,7 +8,7 @@ import fs.errors
 import fs.path
 
 from .web import base
-from .web.errors import FileStoreException, FileFormException
+from .web.errors import FileFormException
 from . import config
 from . import files
 from . import placer as pl
@@ -98,7 +98,7 @@ def process_upload(request, strategy, access_logger, container_type=None, id_=No
             try:
                 metadata = json.loads(form['metadata'].value)
             except Exception:
-                raise FileStoreException('wrong format for field "metadata"')
+                raise FileFormException('wrong format for field "metadata"')
             if isinstance(metadata, dict):
                 for f in metadata.get(container_type, {}).get('files', []):
                     f['name'] = name_fn(f['name'])

--- a/api/util.py
+++ b/api/util.py
@@ -225,18 +225,6 @@ def sanitize_path(filepath):
     """
     return os.path.normpath('/'+filepath).lstrip('/')
 
-def humanize_validation_error(val_err):
-    """
-    Takes a jsonschema.ValidationError, returns a human-friendly string
-    """
-
-    key = 'none'
-    if len(val_err.relative_path) > 0:
-        key = val_err.relative_path[0]
-    message = val_err.message.replace("u'", "'")
-
-    return 'Object does not match schema on key ' + key + ': ' + message
-
 def obj_from_map(_map):
     """
     Creates an anonymous object with properties determined by the passed (shallow) map.

--- a/api/util.py
+++ b/api/util.py
@@ -266,19 +266,21 @@ def format_hash(hash_alg, hash_):
     """
     return '-'.join(('v0', hash_alg, hash_))
 
-def create_json_http_exception_response(message, code, request_id, custom=None):
+def create_json_http_exception_response(message, code, request_id, core_status_code=None, custom=None):
     content = {
         'message': message,
         'status_code': code,
         'request_id': request_id
     }
+    if core_status_code:
+        content['core_status_code'] = core_status_code
     if custom:
         content.update(custom)
     return content
 
-def send_json_http_exception(response, message, code, request_id, custom=None):
+def send_json_http_exception(response, message, code, request_id, core_status_code=None, custom=None):
     response.set_status(code)
-    json_content = json.dumps(create_json_http_exception_response(message, code, request_id, custom))
+    json_content = json.dumps(create_json_http_exception_response(message, code, request_id, core_status_code, custom))
     response.headers['Content-Type'] = 'application/json; charset=utf-8'
     response.write(json_content)
 

--- a/api/validators.py
+++ b/api/validators.py
@@ -79,7 +79,7 @@ def from_schema_path(schema_url):
             try:
                 _validate_json(payload, _schema, resolver)
             except jsonschema.ValidationError as e:
-                raise InputValidationException(str(e))
+                raise InputValidationException(cause=e)
     return g
 
 def key_check(schema_url):
@@ -108,7 +108,7 @@ def key_check(schema_url):
                 try:
                     exclude_params = _post_exclude_params(schema.get('key_fields', []), payload)
                 except KeyError as e:
-                    raise InputValidationException('missing key {} in payload'.format(e.args))
+                    raise InputValidationException('missing key {} in payload'.format(e.args), reason='missing key', key=str(e.args))
             else:
                 _check_query_params(schema.get('key_fields'), query_params)
                 if method == 'PUT' and schema.get('key_fields'):

--- a/api/web/base.py
+++ b/api/web/base.py
@@ -310,20 +310,20 @@ class RequestHandler(webapp2.RequestHandler):
         for param_name in ('filter', 'sort', 'page', 'skip', 'limit'):
             param_count = len(self.request.GET.getall(param_name))
             if param_count > 1:
-                raise errors.APIValidationException({'error': 'Multiple "{}" query params not allowed'.format(param_name)})
+                raise errors.APIValidationException(error='Multiple "{}" query params not allowed'.format(param_name))
             if param_count > 0:
                 param_value = self.request.GET.get(param_name)
                 parse = parsers.get(param_name, util.parse_pagination_int_param)
                 try:
                     pagination[param_name] = parse(param_value)
                 except util.PaginationParseError as e:
-                    raise errors.APIValidationException({'error': e.message})
+                    raise errors.APIValidationException(error=e.message)
 
         if 'page' in pagination:
             if 'skip' in pagination:
-                raise errors.APIValidationException({'error': '"page" and "skip" query params are mutually exclusive'})
+                raise errors.APIValidationException(error='"page" and "skip" query params are mutually exclusive')
             if 'limit' not in pagination:
-                raise errors.APIValidationException({'error': '"limit" query param is required with "page"'})
+                raise errors.APIValidationException(error='"limit" query param is required with "page"')
             pagination['skip'] = pagination['limit'] * (pagination.pop('page') - 1)
 
         return pagination

--- a/api/web/base.py
+++ b/api/web/base.py
@@ -349,35 +349,13 @@ class RequestHandler(webapp2.RequestHandler):
         request_id = self.request.id
         custom_errors = None
         message = str(exception)
+        core_status = None
         if isinstance(exception, webapp2.HTTPException):
             code = exception.code
-        elif isinstance(exception, errors.InputValidationException):
-            code = 400
-        elif isinstance(exception, errors.APIAuthProviderException):
-            code = 401
-        elif isinstance(exception, errors.APIRefreshTokenException):
-            code = 401
+        elif isinstance(exception, errors.APIException):
+            code = exception.status_code
+            core_status = exception.core_status_code
             custom_errors = exception.errors
-        elif isinstance(exception, errors.APIUnknownUserException):
-            code = 402
-        elif isinstance(exception, errors.APIConsistencyException):
-            code = 400
-        elif isinstance(exception, errors.APIPermissionException):
-            custom_errors = exception.errors
-            code = 403
-        elif isinstance(exception, errors.APINotFoundException):
-            code = 404
-        elif isinstance(exception, errors.APIConflictException):
-            code = 409
-        elif isinstance(exception, errors.APIValidationException):
-            code = 422
-            custom_errors = exception.errors
-        elif isinstance(exception, errors.FileStoreException):
-            code = 400
-        elif isinstance(exception, errors.FileFormException):
-            code = 400
-        elif isinstance(exception, errors.FileFormException):
-            code = 400
         elif isinstance(exception, ElasticsearchException):
             code = 503
             message = "Search is currently down. Try again later."
@@ -393,9 +371,9 @@ class RequestHandler(webapp2.RequestHandler):
             self.request.logger.error(tb)
 
         if return_json:
-            return util.create_json_http_exception_response(message, code, request_id, custom=custom_errors)
+            return util.create_json_http_exception_response(message, code, request_id, core_status_code=core_status, custom=custom_errors)
 
-        util.send_json_http_exception(self.response, message, code, request_id, custom=custom_errors)
+        util.send_json_http_exception(self.response, message, code, request_id, core_status_code=core_status, custom=custom_errors)
 
     def log_user_access(self, access_type, cont_name=None, cont_id=None, filename=None, multifile=False, origin_override=None):
         origin = origin_override if origin_override is not None else self.origin

--- a/api/web/errors.py
+++ b/api/web/errors.py
@@ -19,6 +19,12 @@ class APIException(Exception):
     default_msg = 'There was an error processing the request.'
 
     def __init__(self, msg=None, errors=None):
+        """Construct an APIException
+
+        Arguments:
+            msg (str): The optional message (otherwise default_msg will be used)
+            errors (dict): An optional dictionary of additional error properties to include in the response
+        """
         if not msg:
             msg = self.default_msg
         super(APIException, self).__init__(msg)
@@ -63,6 +69,19 @@ class InputValidationException(APIException):
     default_msg = 'Input does not match input schema.'
 
     def __init__(self, msg=None, reason=None, key=None, error=None, cause=None, **kwargs):
+        """Construct an InputValidationException
+
+        If a cause is specified, then an attempt will be made to extract additional fields
+        from that exception. (e.g. key, error and msg from ValidationError)
+
+        Arguments:
+            msg (str): The optional message (otherwise default_msg will be used)
+            reason (str): The optional reason portion of the error message
+            key (str): The key or keys that caused the validation error
+            error (str): The specific validation error that occurred
+            cause (Exception): The root cause of the error (for example jsonschema.ValidationError)
+            **kwargs: Additional key-value properties to add to the response
+        """
         if cause:
             # Extract validation error details from cause
             if isinstance(cause, ValidationError):

--- a/api/web/errors.py
+++ b/api/web/errors.py
@@ -129,7 +129,7 @@ class APIConsistencyException(APIException):
 
 class APIStorageException(APIException):
     """An error occurred while performing a CRUD action in the storage layer"""
-    pass
+    status_code = 400
 
 class DBValidationException(APIException):
     """Legacy exception: payload did not match mongo json schema due to developer error"""

--- a/api/web/errors.py
+++ b/api/web/errors.py
@@ -12,10 +12,11 @@ class APIException(Exception):
     # default response msg
     default_msg = 'There was an error processing the request.'
 
-    def __init__(self, msg):
+    def __init__(self, msg=None, errors=None):
         if not msg:
-            msg = default_msg
+            msg = self.default_msg
         super(APIException, self).__init__(msg)
+        self.errors = errors
 
 ###
 # Auth Exceptions
@@ -70,11 +71,6 @@ class APIValidationException(APIException):
     """Specially formatted reponse to allow clients to provide detailed information about input vaidation issue"""
     status_code = 422
     default_msg = 'Input does not match input schema.'
-
-    def __init__(self, errors):
-
-        super(APIValidationException, self).__init__('Validation Error.')
-        self.errors = errors
 
 class FileFormException(APIException):
     """File Form for upload requests made by client is incorrect"""

--- a/api/web/errors.py
+++ b/api/web/errors.py
@@ -1,64 +1,120 @@
+class APIException(Exception):
+    """Base core exception class"""
 
-class APIAuthProviderException(Exception):
-    pass
+    # HTTP status code returned
+    status_code = 500
 
-# Creating mulitple containers with same id
-class APIConflictException(Exception):
-    pass
+    # unique string status code
+    # used when client needs more detail than HTTP status code can provide
+    # optional
+    core_status_code = None
 
-# For checking database consistency
-class APIConsistencyException(Exception):
-    pass
+    # default response msg
+    default_msg = 'There was an error processing the request.'
 
-# API could not find what was requested
-class APINotFoundException(Exception):
-    pass
+    def __init__(self, msg):
+        if not msg:
+            msg = default_msg
+        super(APIException, self).__init__(msg)
 
-class APIPermissionException(Exception):
+###
+# Auth Exceptions
+###
+
+class APIAuthProviderException(APIException):
+    """Authentication through 3rd party, session token, or API key failed"""
+    status_code = 401
+    default_msg = 'Unsuccessful authentication.'
+
+class APIUnknownUserException(APIException):
+    """Authentication was successful but user was not found or disabled"""
+    status_code = 402
+    default_msg = 'User could not be found or is disabled.'
+
+class APIPermissionException(APIException):
+    """User does not have permission to perform requested action"""
+    status_code = 403
+    default_msg = 'User does not have permission to perform requested action.'
+
     def __init__(self, msg, errors=None):
 
         super(APIPermissionException, self).__init__(msg)
         self.errors = errors
 
-class APIRefreshTokenException(Exception):
-    # Specifically alert a client when the user's refresh token expires
-    # Requires client to ask for `offline=true` permission to receive a new one
-    def __init__(self, msg):
+class APIRefreshTokenException(APIException):
+    """
+    Specifically alert a client when the user's refresh token expires
+    Note: for some 3rd party auth providers, requires client to ask for `offline=true` permission to receive a new one
+    """
+    status_code = 401
+    core_status_code = 'invalid_refresh_token'
+    default_msg = 'User refresh token has expired.'
 
-        super(APIRefreshTokenException, self).__init__(msg)
-        self.errors = {'core_status_code': 'invalid_refresh_token'}
 
-class APIReportException(Exception):
-    pass
+###
+# Input Validation Exceptions
+###
 
-# Invalid or missing parameters for a report request
-class APIReportParamsException(Exception):
-    pass
+class InputValidationException(APIException):
+    """Payload for a POST or PUT does not match input json schema"""
+    status_code = 400
+    default_msg = 'Input does not match input schema.'
 
-class APIStorageException(Exception):
-    pass
+# Probably doesn't need to be it's own class, should use InputValidationException
+class APIReportParamsException(APIException):
+    """Invalid or missing parameters for a report request"""
+    status_code = 400
+    default_msg = 'Report parameters are invalid.'
 
-# User Id not found or disabled
-class APIUnknownUserException(Exception):
-    pass
+class APIValidationException(APIException):
+    """Specially formatted reponse to allow clients to provide detailed information about input vaidation issue"""
+    status_code = 422
+    default_msg = 'Input does not match input schema.'
 
-class APIValidationException(Exception):
     def __init__(self, errors):
 
         super(APIValidationException, self).__init__('Validation Error.')
         self.errors = errors
 
-# Payload for a POST or PUT does not match mongo json schema
-class DBValidationException(Exception):
+class FileFormException(APIException):
+    """File Form for upload requests made by client is incorrect"""
+    status_code = 400
+    default_msg = 'File form upload request is incorrect.'
+
+class FileStoreException(APIException):
+    """?"""
+    status_code = 400
+
+
+###
+# API Server Exceptions
+###
+
+class APINotFoundException(APIException):
+    """The requested object could not be found"""
+    status_code = 404
+    default_msg = 'The resource could not be found.'
+
+class APIConflictException(APIException):
+    """
+    There was an attempt to create a new object with the same unique key as another object
+    Usually _id, but not limited to that key
+    """
+    status_code = 409
+    default_msg = 'A resource with the same unique identification key already exists.'
+
+class APIConsistencyException(APIException):
+    """Legacy db consistency exception"""
+    status_code = 400
+
+class APIStorageException(APIException):
+    """An error occurred while performing a CRUD action in the storage layer"""
     pass
 
-class FileStoreException(Exception):
+class DBValidationException(APIException):
+    """Legacy exception: payload did not match mongo json schema due to developer error"""
     pass
 
-# File Form for upload requests made by client is incorrect
-class FileFormException(Exception):
-    pass
-
-# Payload for a POST or PUT does not match input json schema
-class InputValidationException(Exception):
+class APIReportException(APIException):
+    """A non-user error occurred while attempting to generate a report"""
     pass

--- a/api/web/errors.py
+++ b/api/web/errors.py
@@ -105,10 +105,6 @@ class FileFormException(APIException):
     status_code = 400
     default_msg = 'File form upload request is incorrect.'
 
-class FileStoreException(APIException):
-    """?"""
-    status_code = 400
-
 
 ###
 # API Server Exceptions

--- a/api/web/errors.py
+++ b/api/web/errors.py
@@ -66,6 +66,7 @@ class APIRefreshTokenException(APIException):
 class InputValidationException(APIException):
     """Payload for a POST or PUT does not match input json schema"""
     status_code = 400
+    core_status_code = 'input_validation_error'
     default_msg = 'Input does not match input schema.'
 
     def __init__(self, msg=None, reason=None, key=None, error=None, cause=None, **kwargs):
@@ -82,6 +83,8 @@ class InputValidationException(APIException):
             cause (Exception): The root cause of the error (for example jsonschema.ValidationError)
             **kwargs: Additional key-value properties to add to the response
         """
+        self.cause = cause
+
         if cause:
             # Extract validation error details from cause
             if isinstance(cause, ValidationError):
@@ -94,7 +97,7 @@ class InputValidationException(APIException):
 
                 error = cause.message.replace("u'", "'")
                 if not msg:
-                    msg = '{} on key {}: {}'.format(reason, key, error)
+                    msg = "{} on key '{}': {}.".format(reason, key, error)
             elif not msg:
                 msg = str(cause)
 


### PR DESCRIPTION
There is now a single base APIException which carries a `status_code`, `core_status_code`, and `default_message`. 

Validation errors include additional client-parseable attributes (closes #690)

Wherever possible, I eliminated the following anti-pattern:
```python
except APISomeException as e:
    self.abort(400, e.message)
```

I did **NOT** try to replace all instances of `self.abort` with `raise APIException` -- I think that should be a separate PR.

Refs #807 

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
