### PR TITLE
Fix intermittent total coverage report error

### DIFF
--- a/api/web/start.py
+++ b/api/web/start.py
@@ -14,8 +14,12 @@ warnings.filterwarnings('ignore', message=r'Implicitly cleaning up <TemporaryDir
 # Enable code coverage for testing when API is started
 # Start coverage before local module loading so their def and imports are counted
 #   http://coverage.readthedocs.io/en/coverage-4.2/faq.html
+# Assuming running via uwsgi and within 1 process, 1 thread
 if os.environ.get("SCITRAN_RUNTIME_COVERAGE") == "true": # pragma: no cover - oh, the irony
     def save_coverage(cov):
+        if os.getpid() != uwsgi.workers()[0]['pid']:
+            # Mule shutdown - do not write empty coverage
+            return
         print("Saving coverage")
         cov.stop()
         cov.save()


### PR DESCRIPTION
Fixes #1273 

My repro rate using `while :; do tests/bin/docker-tests.sh; done` was around 10%.
Tailing core logs for a lower-than-expected report's run revealed this:
```
/var/scitran/code/api # cat /tmp/core.log | grep -i coverage
Enabling code coverage
Saving coverage
Saving coverage
```
Inspecting pids, the culprit was the mule shutdown sometimes "winning" and creating an empty integration cov report.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
