### PR TITLE
Carry redundant node_type on resolver node

### DIFF
--- a/api/resolver.py
+++ b/api/resolver.py
@@ -43,11 +43,16 @@ from .dao.basecontainerstorage import ContainerStorage
 from .jobs import gears
 from .web.errors import APINotFoundException, InputValidationException
 
+def set_container_type(node, container_type):
+    """Set container_type on node"""
+    node['container_type'] = container_type
+    # Redundantly set node_type so that older clients remain compatible
+    node['node_type'] = container_type
+
 def apply_container_type(lst, container_type):
     """Apply container_type to each item in in the list"""
     for item in lst:
-        item['container_type'] = container_type
-
+        set_container_type(item, container_type)
 
 class Node(object):
     """Base class for all nodes in the resolver tree"""
@@ -197,7 +202,7 @@ class ContainerNode(Node):
         child = results[0]
 
         self.storage.filter_container_files(child)
-        child['container_type'] = self.container_type
+        set_container_type(child, self.container_type)
         path_out.append(child)
 
         # Get the next node
@@ -292,7 +297,7 @@ class GearsNode(Node):
         if not gear:
             raise APINotFoundException('No gear {0} found.'.format(criterion))
 
-        gear['container_type'] = 'gear'
+        set_container_type(gear, 'gear')
         path_out.append(gear)
 
         return None
@@ -305,7 +310,7 @@ class GearsNode(Node):
         results = gears.get_gears()
 
         for gear in results:
-            gear['container_type'] = 'gear'
+            set_container_type(gear, 'gear')
 
         return list(results)
 

--- a/api/resolver.py
+++ b/api/resolver.py
@@ -44,9 +44,12 @@ from .jobs import gears
 from .web.errors import APINotFoundException, InputValidationException
 
 def set_container_type(node, container_type):
-    """Set container_type on node"""
+    """Set container_type on node.
+
+    This function sets node_type in addition to container_type so that
+    older clients (CLI, SDK) remain compatible with a minor version mismatch.
+    """
     node['container_type'] = container_type
-    # Redundantly set node_type so that older clients remain compatible
     node['node_type'] = container_type
 
 def apply_container_type(lst, container_type):

--- a/sdk/codegen/src/main/java/io/flywheel/codegen/MatlabGenerator.java
+++ b/sdk/codegen/src/main/java/io/flywheel/codegen/MatlabGenerator.java
@@ -471,10 +471,16 @@ public class MatlabGenerator extends DefaultCodegen implements CodegenConfig {
             }
         }
 
-        // Convert discriminator name
+        // Convert discriminator names
         if( model.discriminator != null ) {
             String matlabDiscriminator = makeValidMatlabNameHex(model.discriminator);
             model.vendorExtensions.put("x-matlab-discriminator", matlabDiscriminator);
+        }
+
+        if( model.vendorExtensions != null && model.vendorExtensions.containsKey("x-alt-discriminator") ) {
+            String altDiscriminator = (String)model.vendorExtensions.get("x-alt-discriminator");
+            String matlabAltDiscriminator = makeValidMatlabNameHex(altDiscriminator);
+            model.vendorExtensions.put("x-matlab-alt-discriminator", matlabAltDiscriminator);
         }
 
         return objs;

--- a/sdk/codegen/src/main/resources/fw-python/model.mustache
+++ b/sdk/codegen/src/main/resources/fw-python/model.mustache
@@ -61,6 +61,7 @@ class {{classname}}(object):
         self._{{name}} = None
 {{/vars}}
         self.discriminator = {{#discriminator}}'{{discriminator}}'{{/discriminator}}{{^discriminator}}None{{/discriminator}}
+        self.alt_discriminator = {{#vendorExtensions.x-alt-discriminator}}'{{.}}'{{/vendorExtensions.x-alt-discriminator}}{{^vendorExtensions.x-alt-discriminator}}None{{/vendorExtensions.x-alt-discriminator}}
 {{#vars}}{{#-first}}
 {{/-first}}
 {{#required}}
@@ -126,8 +127,11 @@ class {{classname}}(object):
 {{#discriminator}}
     def get_real_child_model(self, data):
         """Returns the real base class specified by the discriminator"""
-        discriminator_value = data[self.discriminator].lower()
-        return self.discriminator_value_class_map.get(discriminator_value)
+
+        discriminator_value = data.get(self.discriminator)
+        if not discriminator_value and self.alt_discriminator:
+            discriminator_value = data.get(self.alt_discriminator)
+        return self.discriminator_value_class_map.get(discriminator_value.lower())
 
 {{/discriminator}}
     def to_dict(self):

--- a/sdk/codegen/src/main/resources/matlab/model.mustache
+++ b/sdk/codegen/src/main/resources/matlab/model.mustache
@@ -240,7 +240,16 @@ classdef {{classname}} < {{packageName}}.ModelBase
         {{/discriminator}}
         {{#discriminator}}
         function result = fromJson(json)
-            discriminatorValue = json.{{vendorExtensions.x-matlab-discriminator}};
+            discriminatorValue = [];
+
+            if isfield(json, '{{vendorExtensions.x-matlab-discriminator}}')
+                discriminatorValue = json.{{vendorExtensions.x-matlab-discriminator}};
+            {{#vendorExtensions.x-matlab-alt-discriminator}}
+            elseif isfield(json, '{{vendorExtensions.x-matlab-alt-discriminator}}')
+                discriminatorValue = json.{{vendorExtensions.x-matlab-alt-discriminator}};
+            {{/vendorExtensions.x-matlab-alt-discriminator}}
+            end
+
             if isKey({{modelPackage}}.{{classname}}.discriminatorValueClassMap, discriminatorValue)
                 result = feval({{modelPackage}}.{{classname}}.discriminatorValueClassMap(discriminatorValue), json);
             else

--- a/swagger/schemas/definitions/resolver.json
+++ b/swagger/schemas/definitions/resolver.json
@@ -30,7 +30,8 @@
     			}
     		},
     		"discriminator": "container_type",
-    		"required": ["container_type"]
+    		"required": ["container_type"],
+    		"x-alt-discriminator": "node_type"
     	},
     	"resolver-node-list": {
 			"type": "array",

--- a/tests/integration_tests/python/test_resolver.py
+++ b/tests/integration_tests/python/test_resolver.py
@@ -203,6 +203,9 @@ def test_resolver(data_builder, as_admin, as_user, as_public, file_form):
     assert child_in_result({'name': acquisition_file, 'container_type': 'file'}, result)
     assert len(result['children']) == 1
 
+    # Verify that each node has a node_type and container_type
+    assert all(['node_type' in node for node in result['path']])
+
     # resolve root/group/project/session/acquisition/file
     r = as_admin.post('/resolve', json={'path': [group, project_label, session_label, acquisition_label, 'files', acquisition_file]})
     result = r.json()


### PR DESCRIPTION
This PR does 2 things:
- Carry `node_type` as well as `container_type` on resolver nodes
- Allow discriminating resolver node on either `node_type` or `container_type` in the SDK

This will allow prior clients to use the new resolver, and will allow new clients to use the old resolver endpoint, making #1098 a **Minor Change** rather than a **Breaking Change**.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
