### PR TITLE
Add pagination to DataViews

### DIFF
--- a/api/data_views/handlers.py
+++ b/api/data_views/handlers.py
@@ -137,7 +137,7 @@ class DataViewHandler(base.RequestHandler):
         view.validate_config()
 
         # Prepare by searching for container_id and checking permissions
-        view.prepare(container_id, data_format, self.uid)
+        view.prepare(container_id, data_format, self.uid, self.pagination)
 
         def response_handler(environ, start_response): # pylint: disable=unused-argument
             write = start_response('200 OK', [

--- a/api/data_views/pipeline/filter.py
+++ b/api/data_views/pipeline/filter.py
@@ -80,7 +80,11 @@ def compare_fn_eq(rhs):
 
 def compare_fn_ne(rhs):
     """Compare lhs != rhs"""
-    return lambda lhs: lhs != rhs
+    def not_equal_or_in(lhs):
+        if isinstance(lhs, list):
+            return rhs not in lhs
+        return lhs != rhs
+    return not_equal_or_in
 
 def compare_fn_gte(rhs):
     """Compare lhs >= rhs"""

--- a/api/data_views/pipeline/filter.py
+++ b/api/data_views/pipeline/filter.py
@@ -1,0 +1,121 @@
+import bson
+import datetime
+
+from .pipeline import PipelineStage, EndOfPayload
+from ..util import extract_json_property
+from ...util import datetime_from_str
+
+class Filter(PipelineStage):
+    """Filter stage for pipeline, filters out rows that don't match the filter spec
+
+    Expects a single flat row.
+    Emits a single row
+    """
+    def __init__(self, filter_spec):
+        """Initialize the pipeline stage, with the filter spec from pagination.
+
+        Arguments:
+            filter_spec (dict): The filter spec
+                e.g. {'filter': {u'subject.code': {'$eq': 1001.0}}}
+        """
+        super(Filter, self).__init__()
+
+        self.filters = []
+        for key, spec in filter_spec.items():
+            op = spec.keys()[0]
+            value = spec[op]
+
+            self.filters.append(make_filter_fn(key, op, value))
+
+    def process(self, payload):
+        if payload == EndOfPayload:
+            self.emit(payload)
+            return
+
+        for filter_fn in self.filters:
+            if not filter_fn(payload):
+                return
+
+        self.emit(payload)
+
+def make_filter_fn(key, op, value):
+    """Create a filter function that checks the value of key in context against value.
+
+    Arguments:
+        key (str): The key to extract
+        op (str): The operation (e.g. $lt)
+        value: The value to compare against
+    """
+    compare_fn_name = 'compare_fn_{}'.format(op.lstrip('$'))
+    if compare_fn_name not in globals():
+        # If this is encountered, it's probably because a new filter operation was added to pagination
+        raise RuntimeError('Invalid filter operation: {}'.format(op))
+    compare_fn = globals()[compare_fn_name](value)
+
+    # Type coercion for value type
+    coerce_fn = get_coerce_fn(type(value))
+
+    key = '_filter.{}'.format(key)
+
+    def filter_fn(context):
+        rhs = coerce_fn(context.pop(key, None))
+        return compare_fn(rhs)
+
+    return filter_fn
+
+def compare_fn_lt(rhs):
+    """Compare lhs < rhs"""
+    return lambda lhs: lhs < rhs
+
+def compare_fn_lte(rhs):
+    """Compare lhs <= rhs"""
+    return lambda lhs: lhs <= rhs
+
+def compare_fn_eq(rhs):
+    """Compare lhs == rhs"""
+    return lambda lhs: lhs == rhs
+
+def compare_fn_ne(rhs):
+    """Compare lhs != rhs"""
+    return lambda lhs: lhs != rhs
+
+def compare_fn_gte(rhs):
+    """Compare lhs >= rhs"""
+    return lambda lhs: lhs >= rhs
+
+def compare_fn_gt(rhs):
+    """Compare lhs > rhs"""
+    return lambda lhs: lhs > rhs
+
+def get_coerce_fn(cls):
+    """Get a function that coerces values into the given type"""
+    if cls == bson.ObjectId:
+        return coerce_objectid
+    if cls == float:
+        return coerce_float
+    if cls == datetime.datetime:
+        return coerce_datetime
+    if cls == str:
+        return lambda x: str(x)
+    return lambda x: x
+        
+def coerce_float(value):
+    """Attempt to coerce value to a float"""
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+def coerce_datetime(value):
+    """Attempt to coerce value to a datetime"""
+    if isinstance(value, datetime.datetime):
+        return value
+    return datetime_from_str(str(value)) or value
+
+def coerce_objectid(value):
+    """Attempt to coerce value to an ObjectId"""
+    if bson.ObjectId.is_valid(value):
+        return bson.ObjectId(value)
+    return value
+
+

--- a/api/data_views/pipeline/skip_limit.py
+++ b/api/data_views/pipeline/skip_limit.py
@@ -1,0 +1,25 @@
+import sys
+from .pipeline import PipelineStage, EndOfPayload
+
+class SkipAndLimit(PipelineStage):
+    """Pipeline stage that limits the number of values returned
+
+    Expects a single row
+    Emits a single row
+    """
+    def __init__(self, pagination):
+        super(SkipAndLimit, self).__init__()
+        self.limit = pagination.get('limit', sys.maxint)
+        self.skip = pagination.get('skip', 0)
+
+    def process(self, payload):
+        if payload == EndOfPayload:
+            self.emit(payload)
+        elif self.skip > 0:
+            # Skip while the skip count is positive
+            self.skip -= 1
+        elif self.limit > 0:
+            # Emit while limit is positive
+            self.emit(payload)
+            self.limit -= 1
+

--- a/swagger/paths/data-views.yaml
+++ b/swagger/paths/data-views.yaml
@@ -71,6 +71,10 @@
           - json
           - json-row-column
         default: json
+      - name: filter
+        in: query
+        type: string
+        description: An optional filter expression
       - name: body
         in: body
         required: true
@@ -158,6 +162,10 @@
           - json
           - json-row-column
         default: json
+      - name: filter
+        in: query
+        type: string
+        description: An optional filter expression
     produces:
       - application/json
       - text/csv

--- a/swagger/paths/data-views.yaml
+++ b/swagger/paths/data-views.yaml
@@ -75,6 +75,14 @@
         in: query
         type: string
         description: An optional filter expression
+      - name: skip
+        in: query
+        type: integer
+        description: The optional number of rows to skip
+      - name: limit
+        in: query
+        type: integer
+        description: The optional max number of rows to return
       - name: body
         in: body
         required: true
@@ -166,6 +174,14 @@
         in: query
         type: string
         description: An optional filter expression
+      - name: skip
+        in: query
+        type: integer
+        description: The optional number of rows to skip
+      - name: limit
+        in: query
+        type: integer
+        description: The optional max number of rows to return        
     produces:
       - application/json
       - text/csv

--- a/tests/integration_tests/python/test_data_views.py
+++ b/tests/integration_tests/python/test_data_views.py
@@ -1200,6 +1200,24 @@ def test_data_view_filtering(data_builder, file_form, as_admin):
     assert rows[0]['session'] == session1
     assert rows[0]['session_label'] == 'ses-01'
 
+    r = as_admin.post('/views/data?containerId={}&filter=session.tags!=tag1'.format(project), json={
+        'includeIds': True,
+        'includeLabels': True,
+        'columns': [
+            { 'src': 'session.label' },
+        ]
+    })
+
+    assert r.ok
+    rows = r.json()['data']
+    assert len(rows) == 1
+
+    assert rows[0]['project'] == project
+    assert rows[0]['project_label'] == 'test-project'
+    assert rows[0]['subject_label'] == subject2['code']
+    assert rows[0]['session'] == session2
+    assert rows[0]['session_label'] == 'ses-01'
+
 def test_data_view_skip_and_limit(data_builder, file_form, as_admin):
     project = data_builder.create_project(label='test-project')
     session1 = data_builder.create_session(project=project, subject=subject1, label='ses-01')


### PR DESCRIPTION
Specifically, support filtering, skip and limit. No support for sorting at this time, since data views are streamed.

Filtering is done in python as one of the last stages in the pipeline so that filtering on file columns can be supported. A possible optimization but complexity would be to do as much filtering during the aggregation stage as is possible.

Type coercion is done in the Filter stage to allow for meaningful comparison.

### Test Requirements
- Verify that pagination features work as expected
  - Filtering on various columns, using various comparison operators (covered by integration tests)
  - Skip and Limit (covered by integration tests)

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
