### PR TITLE
Support expressions on data-view columns

### DIFF
--- a/api/data_views/column_aliases.json
+++ b/api/data_views/column_aliases.json
@@ -63,6 +63,34 @@
 		"type": "int"
 	},
 	{
+		"name": "subject_age_years",
+		"src": "subject.age",
+		"description": "The subject age, in years",
+		"type": "float",
+		"expr": "x / 31557600.0"
+	},
+	{
+		"name": "subject_age_months",
+		"src": "subject.age",
+		"description": "The subject age, in months",
+		"type": "float",
+		"expr": "x / 2592000.0"
+	},
+	{
+		"name": "subject_age_weeks",
+		"src": "subject.age",
+		"description": "The subject age, in weeks",
+		"type": "float",
+		"expr": "x / 604800.0"
+	},
+	{
+		"name": "subject_age_days",
+		"src": "subject.age",
+		"description": "The subject age, in days",
+		"type": "float",
+		"expr": "x / 86400.0"
+	},
+	{
 		"name": "subject_sex",
 		"src": "subject.sex",
 		"description": "The subject sex (one of female|male|other|unknown)"

--- a/api/data_views/column_aliases.py
+++ b/api/data_views/column_aliases.py
@@ -19,7 +19,7 @@ class ColumnAliases(object):
         for col in self.columns:
             if 'type' not in col:
                 col['type'] = 'string'
-            self.column_map[col['name']] = (col['src'], col.get('type'))
+            self.column_map[col['name']] = (col['src'], col.get('type'), col.get('expr'))
 
 
     @classmethod
@@ -52,5 +52,5 @@ class ColumnAliases(object):
         inst = cls.instance()
         if key in inst.column_map:
             return inst.column_map[key]
-        return (key, None)
+        return (key, None, None)
 

--- a/api/data_views/pipeline/extract_columns.py
+++ b/api/data_views/pipeline/extract_columns.py
@@ -25,6 +25,12 @@ class ExtractColumns(PipelineStage):
                 for col in column_map[cont_type]:
                     # Extract the json property
                     value = extract_json_property(col.src, cont, default=nil_value)
+
+                    # Apply expression, if specified
+                    if value != nil_value and col.expr is not None:
+                        # Expression has been validated, shouldn't encounter errors
+                        value = col.expr.eval({'x': value})
+
                     # Convert the property, if a datatype was specified
                     if col.datatype is not None:
                         value = convert_to_datatype(value, col.datatype)

--- a/api/data_views/safe_eval.py
+++ b/api/data_views/safe_eval.py
@@ -1,0 +1,100 @@
+"""Provide safe evaluation of simple math formulas"""
+import ast
+import operator
+
+# Decided against something like asteval to 1. Reduce dependencies, 2. Not introduce risk
+# Loosely based on solution here:
+# https://stackoverflow.com/questions/26505420/evaluate-math-equations-from-unsafe-user-input-in-python
+# Restricted even further to only allow arithmetic operations
+
+SAFE_OPS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.div
+}
+
+class CompiledExpression(object):
+    """Represents a prepared safe expression, ready for evaluation"""
+    def __init__(self, node):
+        """Create a compiled expression instance.
+
+        Arguments:
+            node (ast.AST): The root node of the expression
+        """
+        self.node = node
+
+    def eval(self, variables):
+        """Evaluate the expression, substituting variables for name nodes
+
+        Arguments:
+            variables (dict): The map of variable id to value
+        """
+        try:
+            return _safe_eval_expr(self.node, variables)
+        except KeyError:
+            raise ValueError('Unknown variable')
+
+def compile_expr(expr, variables=None):
+    """Compile string expr into a CompiledExpression
+    
+    Also validates that every name node is present in variables, if provided.
+        
+    Arguments:
+        variables (set): The set of variables available to the expression
+    """
+    # Parse
+    try:
+        node = ast.parse(expr, '<string>', 'eval').body
+    except SyntaxError as ex:
+        raise ValueError('Invalid syntax: {}'.format(ex))
+
+    # Quick validation of operations
+    _validate_expr(node, variables)
+
+    return CompiledExpression(node)
+
+def _validate_expr(node, variables=None):
+    """Validate that the AST uses only supported operations and variables.
+
+    Arguments:
+        node (ast.AST): The root expression
+        variables (set): The set of variables available to the expression
+    """
+    if isinstance(node, ast.Num):
+        return
+
+    if isinstance(node, ast.Name):
+        if variables and node.id not in variables:
+            raise ValueError('Unexpected variable: {}'.format(node.id))
+        return
+
+    if isinstance(node, ast.BinOp):
+        if node.op.__class__ not in SAFE_OPS:
+            raise ValueError('Unsafe operator')
+        _validate_expr(node.left, variables)
+        _validate_expr(node.right, variables)
+        return
+
+    raise ValueError('Unsafe operation')
+
+def _safe_eval_expr(node, variables):
+    """Evaluate an expression, returning a result.
+
+    Arguments:
+        node (ast.AST): The root expression
+        variables (dict): The map of variables available to the expression
+
+    Returns:
+        number: The result of the expression
+    """
+    if isinstance(node, ast.Num):
+        return node.n
+    elif isinstance(node, ast.Name):
+        return variables[node.id]
+    elif isinstance(node, ast.BinOp):
+        op = SAFE_OPS[node.op.__class__]
+        lhs = _safe_eval_expr(node.left, variables)
+        rhs = _safe_eval_expr(node.right, variables)
+        return op(lhs, rhs)
+    return None

--- a/swagger/schemas/definitions/data-view.json
+++ b/swagger/schemas/definitions/data-view.json
@@ -76,7 +76,11 @@
           "type": "string",
           "description": "The optional destination property name"
         },
-        "type": { "$ref": "#/definitions/column-type" }
+        "type": { "$ref": "#/definitions/column-type" },
+        "expr": {
+            "type": "string",
+            "description": "An optional expression, allowing simple calculations (add, subtract, multiply, divide). Use 'x' to substitute the column"
+        }
       },
       "required": ["src"],
       "additionalProperties": false,

--- a/tests/integration_tests/python/test_data_views.py
+++ b/tests/integration_tests/python/test_data_views.py
@@ -9,7 +9,7 @@ import pytest
 from StringIO import StringIO
 
 def years_to_secs(age):
-    return age * 86400 * 365
+    return int(age * 86400 * 365.25)
 
 subject1 = {
     'code': '1001',
@@ -18,7 +18,7 @@ subject1 = {
 }
 
 subject2 = {
-    'code': '1002',
+    'code': '1002', 
     'sex': 'female',
     'age': years_to_secs(33)
 }
@@ -213,7 +213,7 @@ def test_adhoc_data_view_session_target(data_builder, file_form, as_admin):
         'columns': [
             { 'src': 'project.label', 'dst': 'project' },
             { 'src': 'subject.code', 'dst': 'subject' },
-            { 'src': 'subject.age' },
+            { 'src': 'subject_age_years' },
             { 'src': 'subject.sex' },
             { 'src': 'session.label', 'dst': 'session' },
             { 'src': 'acquisition.label', 'dst': 'acquisition' }
@@ -226,7 +226,7 @@ def test_adhoc_data_view_session_target(data_builder, file_form, as_admin):
 
     assert rows[0]['project'] == 'test-project'
     assert rows[0]['subject'] == subject2['code']
-    assert rows[0]['subject.age'] == subject2['age']
+    assert rows[0]['subject_age_years'] == 33.0
     assert rows[0]['subject.sex'] == subject2['sex']
     assert rows[0]['session'] == 'ses-01'
     assert rows[0]['acquisition'] == 'scout'

--- a/tests/unit_tests/python/test_safe_eval.py
+++ b/tests/unit_tests/python/test_safe_eval.py
@@ -1,0 +1,36 @@
+import pytest
+from api.data_views import safe_eval
+
+def assert_invalid_expr(expr, variables=None):
+    try:
+        safe_eval.compile_expr(expr, variables)
+        pytest.fail('Expected ValueError')
+    except ValueError:
+        pass
+
+def test_safe_eval():
+    assert safe_eval.compile_expr('z+1/y', {'x', 'y', 'z'})
+
+    expr = safe_eval.compile_expr('x+1')
+    assert expr.eval({'x': 10}) == 11
+
+    expr = safe_eval.compile_expr('(x+1)*(y+3)')
+    assert expr.eval({'x':1, 'y':2}) == 10
+
+    try:
+        expr.eval({})
+        pytest.fail('Expected ValueError')
+    except ValueError:
+        pass
+
+    expr = safe_eval.compile_expr('0x10')
+    assert expr.eval({}) == 16
+
+    assert_invalid_expr('9**9**9')
+    assert_invalid_expr('print "Hello World"')
+    assert_invalid_expr('print("Hello World")')
+    assert_invalid_expr('"test"')
+    assert_invalid_expr('3 if x else 4')
+    assert_invalid_expr('import platform;print(platform.version())')
+    assert_invalid_expr('None', {'x'})
+    assert_invalid_expr('z+1', {'x', 'y'})


### PR DESCRIPTION
Also adds aliases for Subject Age in Years, Months, Weeks and Days.

Supported operations are `+`, `-`, `*`, `/` and literal numeric expressions.

### Test Requirements
- Verify that pre-defined columns with expressions work
- Verify that simple expressions can be defined when specifying columns
- Verify that complex and/or dangerous expressions are not executed

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
