### PR TITLE
No root 

### DIFF
--- a/api/auth/__init__.py
+++ b/api/auth/__init__.py
@@ -43,7 +43,7 @@ def has_access(uid, container, perm):
 def always_ok(exec_op):
     """
     This decorator leaves the original method unchanged.
-    It is used as permissions checker when the request is a superuser_request
+    It is used as permissions checker when the request is from a site admin
     """
     return exec_op
 
@@ -51,7 +51,6 @@ def require_login(handler_method):
     """
     A decorator to ensure the request is not a public request.
 
-    Accepts superuser and non-superuser requests.
     Accepts drone and user requests.
     """
     def check_login(self, *args, **kwargs):
@@ -62,7 +61,7 @@ def require_login(handler_method):
 
 def require_admin(handler_method):
     """
-    A decorator to ensure the request is made as superuser.
+    A decorator to ensure the request is made as a site admin.
 
     Accepts drone and user requests.
     """
@@ -72,28 +71,16 @@ def require_admin(handler_method):
         return handler_method(self, *args, **kwargs)
     return check_admin
 
-def require_superuser(handler_method):
-    """
-    A decorator to ensure the request is made as superuser.
-
-    Accepts drone and user requests.
-    """
-    def check_superuser(self, *args, **kwargs):
-        if not self.superuser_request:
-            raise APIPermissionException('Superuser required.')
-        return handler_method(self, *args, **kwargs)
-    return check_superuser
-
 def require_drone(handler_method):
     """
     A decorator to ensure the request is made as a drone.
 
-    Will also ensure superuser, which is implied with a drone request.
+    Will also ensure site admin, which is implied with a drone request.
     """
     def check_drone(self, *args, **kwargs):
         if self.origin.get('type', '') != Origin.device:
             raise APIPermissionException('Drone request required.')
-        if not self.superuser_request:
+        if not self.user_is_admin:
             raise APIPermissionException('Superuser required.')
         return handler_method(self, *args, **kwargs)
     return check_drone

--- a/api/auth/containerauth.py
+++ b/api/auth/containerauth.py
@@ -128,14 +128,11 @@ def has_any_referer_access(handler, method, container, parent_container):
     """
     has_access = False
 
-    # if parent container is "site", then the user must be a superuser to make changes
-    if handler.superuser_request:
+    # if parent container is "site", then the user must be a admin to make changes
+    if handler.user_is_admin:
         has_access = True
     elif parent_container == 'site':
-        if handler.user_is_admin:
-            has_access = True
-        else:
-            has_access = method == 'GET' and container.get('public', False)
+        has_access = method == 'GET' and container.get('public', False)
     elif method == 'GET' and (container.get('public', False) or parent_container.get('public', False)):
         has_access = True
     elif parent_container.get('cont_name') == 'user':

--- a/api/auth/groupauth.py
+++ b/api/auth/groupauth.py
@@ -7,9 +7,7 @@ log = config.log
 def default(handler, group=None):
     def g(exec_op):
         def f(method, _id=None, query=None, payload=None, projection=None):
-            if handler.superuser_request:
-                pass
-            elif handler.public_request:
+            if handler.public_request:
                 handler.abort(400, 'public request is not valid')
             elif handler.user_is_admin:
                 pass
@@ -29,14 +27,14 @@ def list_permission_checker(handler, uid=None):
     def g(exec_op):
         def f(method, query=None, projection=None, pagination=None):
             if uid is not None:
-                if uid != handler.uid and not handler.superuser_request and not handler.user_is_admin:
+                if uid != handler.uid and not handler.user_is_admin:
                     handler.abort(403, 'User ' + handler.uid + ' may not see the Groups of User ' + uid)
                 query = query or {}
                 query['permissions._id'] = uid
                 projection = projection or {}
                 projection['permissions.$'] = 1
             else:
-                if not handler.superuser_request:
+                if not handler.complete_list:
                     query = query or {}
                     projection = projection or {}
                     query['permissions._id'] = handler.uid

--- a/api/auth/userauth.py
+++ b/api/auth/userauth.py
@@ -3,9 +3,7 @@ def default(handler, user=None):
         def f(method, _id=None, query=None, payload=None, projection=None):
             if handler.public_request:
                 handler.abort(403, 'public request is not authorized')
-            elif handler.superuser_request and not (method == 'DELETE' and _id == handler.uid):
-                pass
-            elif handler.user_is_admin and (method == 'DELETE' and not _id == handler.uid):
+            elif handler.user_is_admin and not (method == 'DELETE' and _id == handler.uid):
                 pass
             elif method == 'PUT' and handler.uid == _id:
                 if 'root' in payload and payload['root'] != user['root']:
@@ -16,9 +14,9 @@ def default(handler, user=None):
                     pass
             elif method == 'PUT' and handler.user_is_admin:
                 pass
-            elif method == 'POST' and not handler.superuser_request and not handler.user_is_admin:
+            elif method == 'POST' and not handler.user_is_admin:
                 handler.abort(403, 'only admins are allowed to create users')
-            elif method == 'POST' and (handler.superuser_request or handler.user_is_admin):
+            elif method == 'POST' and handler.user_is_admin:
                 pass
             elif method == 'GET':
                 pass

--- a/api/container/handlers/tree_handler.py
+++ b/api/container/handlers/tree_handler.py
@@ -12,15 +12,6 @@ class TreeHandler(base.RequestHandler):
         """Return the flywheel hierarchy graph (informational)"""
         return GRAPH
 
-    # TODO: Remove this property once native support in no-root lands
-    @property
-    def complete_list(self):
-        if self.is_true('root') or self.is_true('exhaustive'):
-            if self.user_is_admin:
-                return True
-            raise errors.APIPermissionException('User {} is not authorized to request complete lists'.format(self.uid))
-        return False
-
     @validators.verify_payload_exists
     @auth.require_login
     def post(self):

--- a/api/handlers/collectionshandler.py
+++ b/api/handlers/collectionshandler.py
@@ -110,7 +110,7 @@ class CollectionsHandler(ContainerHandler):
 
     def get_all(self):
         projection = self.get_list_projection('collections')
-        if self.superuser_request:
+        if self.user_is_admin:
             permchecker = always_ok
         elif self.public_request:
             permchecker = containerauth.list_public_request
@@ -119,7 +119,7 @@ class CollectionsHandler(ContainerHandler):
         query = {}
         page = permchecker(self.storage.exec_op)('GET', query=query, public=self.public_request, projection=projection, pagination=self.pagination)
         results = page['results']
-        if not self.superuser_request and not self.is_true('join_avatars'):
+        if not self.user_is_admin and not self.is_true('join_avatars'):
             self._filter_all_permissions(results, self.uid)
         if self.is_true('join_avatars'):
             self.storage.join_avatars(results)
@@ -154,7 +154,7 @@ class CollectionsHandler(ContainerHandler):
                 ])
         query = {'_id': {'$in': [ar['_id'] for ar in agg_res]}}
 
-        if not self.superuser_request:
+        if not self.user_is_admin:
             query['permissions._id'] = self.uid
 
         projection = self.get_list_projection('sessions')
@@ -183,7 +183,7 @@ class CollectionsHandler(ContainerHandler):
         elif sid != '':
             self.abort(400, sid + ' is not a valid ObjectId')
 
-        if not self.superuser_request:
+        if not self.user_is_admin:
             query['permissions._id'] = self.uid
 
         projection = self.get_list_projection('acquisitions')

--- a/api/handlers/devicehandler.py
+++ b/api/handlers/devicehandler.py
@@ -3,7 +3,7 @@ import datetime as dt
 from ..web import base
 from .. import config
 from .. import util
-from ..auth import require_drone, require_login, require_superuser
+from ..auth import require_drone, require_login, require_admin
 from ..auth.apikeys import DeviceApiKey
 from ..dao import containerstorage
 from ..web.errors import APINotFoundException, APIValidationException, APIException
@@ -64,7 +64,7 @@ class DeviceHandler(base.RequestHandler):
         api_key = DeviceApiKey.get(device['_id'])
         device['key'] = api_key['_id'] if api_key else DeviceApiKey.generate(device['_id'])
 
-    @require_superuser
+    @require_admin
     def post(self):
         payload = self.request.json_body if self.request.body else {}
 
@@ -79,7 +79,7 @@ class DeviceHandler(base.RequestHandler):
         key = DeviceApiKey.generate(result.inserted_id)
         return {'_id': result.inserted_id, 'key': key}
 
-    @require_superuser
+    @require_admin
     def delete(self, device_id):
         result = self.storage.delete_el(device_id)
         if result.deleted_count != 1:

--- a/api/handlers/grouphandler.py
+++ b/api/handlers/grouphandler.py
@@ -20,7 +20,7 @@ class GroupHandler(base.RequestHandler):
         group = self._get_group(_id)
         permchecker = groupauth.default(self, group)
         result = permchecker(self.storage.exec_op)('GET', _id)
-        if not self.superuser_request and not self.is_true('join_avatars'):
+        if not self.user_is_admin and not self.is_true('join_avatars'):
             self._filter_permissions([result], self.uid)
         if self.is_true('join_avatars'):
             self.storage.join_avatars([result])
@@ -53,7 +53,7 @@ class GroupHandler(base.RequestHandler):
         permchecker = groupauth.list_permission_checker(self, uid)
         page = permchecker(self.storage.exec_op)('GET', projection=projection, pagination=self.pagination)
         results = page['results']
-        if not self.superuser_request and not self.is_true('join_avatars') and not self.user_is_admin:
+        if not self.is_true('join_avatars') and not self.user_is_admin:
             self._filter_permissions(results, self.uid)
         if self.is_true('join_avatars'):
             self.storage.join_avatars(results)

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -179,7 +179,7 @@ class ListHandler(base.RequestHandler):
             query_params = None
         container = storage.get_container(_id, query_params)
         if container is not None:
-            if self.superuser_request or self.user_is_admin:
+            if self.user_is_admin:
                 permchecker = always_ok
             elif self.public_request:
                 permchecker = listauth.public_request(self, container)
@@ -701,7 +701,7 @@ class FileListHandler(ListHandler):
             raise Exception('Project ' + _id + ' does not exist')
 
         # Authorize: confirm user has admin/write perms
-        if not self.superuser_request:
+        if not self.user_is_admin:
             perms = project.get('permissions', [])
 
             for p in perms:

--- a/api/handlers/refererhandler.py
+++ b/api/handlers/refererhandler.py
@@ -47,7 +47,7 @@ class RefererHandler(base.RequestHandler):
         return update_validator
 
     def get_permchecker(self, parent_container):
-        if self.superuser_request:
+        if self.user_is_admin:
             return always_ok
         elif self.public_request:
             return containerauth.public_request(self, container=parent_container)
@@ -80,7 +80,7 @@ class AnalysesHandler(RefererHandler):
             # Legacy analysis - accept direct file uploads (inputs and outputs)
             analysis = upload.process_upload(self.request, upload.Strategy.analysis, self.log_user_access, origin=self.origin)
 
-        uid = None if self.superuser_request else self.uid
+        uid = None if self.user_is_admin else self.uid
         result = self.storage.create_el(analysis, cont_name, cid, self.origin, uid)
         return {'_id': result.inserted_id}
 

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -514,7 +514,7 @@ class JobsHandler(base.RequestHandler):
             raise InputValidationException('Cannot use analysis as destination for a job')
 
         uid = None
-        if not self.superuser_request:
+        if not self.user_is_admin:
             uid = self.uid
 
         job = Queue.enqueue_job(payload, self.origin, perm_check_uid=uid)
@@ -765,8 +765,8 @@ class JobHandler(base.RequestHandler):
             if self.origin.get('type', '') != Origin.device:
                 raise APIPermissionException('Only a drone can start a job with this endpoint')
 
-        # If user is not superuser, can only cancel jobs they spawned
-        if not self.superuser_request and not self.user_is_admin:
+        # If user is not site admin, can only cancel jobs they spawned
+        if not self.user_is_admin:
             if j.origin.get('id') != self.uid:
                 raise APIPermissionException('User does not have permission to access job {}'.format(_id))
             if mutation != {'state': 'cancelled'}:
@@ -928,11 +928,11 @@ class BatchHandler(base.RequestHandler):
     def get_all(self):
         """
         Get a list of batch jobs user has created.
-        Make a superuser request to see all batch jobs.
+        Site admins see all batch jobs.
         """
 
-        if self.superuser_request:
-            # Don't enforce permissions for superuser requests or drone requests
+        if self.user_is_admin:
+            # Don't enforce permissions for site admin requests or drone requests
             query = {}
         else:
             query = {'origin.id': self.uid}
@@ -1021,7 +1021,7 @@ class BatchHandler(base.RequestHandler):
 
         # Make sure user has read-write access, add those to acquisition list
         for c in containers:
-            if self.superuser_request or has_access(self.uid, c, 'rw'):
+            if self.user_is_admin or has_access(self.uid, c, 'rw'):
                 c.pop('permissions')
                 perm_checked_conts.append(c)
             else:
@@ -1030,8 +1030,8 @@ class BatchHandler(base.RequestHandler):
         if not perm_checked_conts:
             self.abort(403, 'User does not have write access to targets.')
 
-        # For superuser requests, don't check permissions when building context
-        if self.superuser_request:
+        # For site admin requests, don't check permissions when building context
+        if self.user_is_admin:
             context_uid = None
         else:
             context_uid = self.uid
@@ -1110,7 +1110,7 @@ class BatchHandler(base.RequestHandler):
         jobs_ = payload.get('jobs', [])
 
         uid = None
-        if not self.superuser_request:
+        if not self.user_is_admin:
             uid = self.uid
 
         for job_number, job_ in enumerate(jobs_):
@@ -1158,6 +1158,6 @@ class BatchHandler(base.RequestHandler):
         return {'number_cancelled': batch.cancel(batch_job)}
 
     def _check_permission(self, batch_job):
-        if not self.superuser_request:
+        if not self.user_is_admin:
             if batch_job['origin'].get('id') != self.uid:
                 raise APIPermissionException('User does not have permission to access batch {}'.format(batch_job.get('_id')))

--- a/api/reports/access_log_report.py
+++ b/api/reports/access_log_report.py
@@ -112,10 +112,8 @@ class AccessLogReport(Report):
 
     def user_can_generate(self, uid):
         """
-        User generating report must be superuser
+        User generating report must be site admin
         """
-        if config.db.users.count({'_id': uid, 'root': True}) > 0:
-            return True
         return False
 
     def build(self):

--- a/api/reports/handler.py
+++ b/api/reports/handler.py
@@ -21,7 +21,7 @@ class ReportHandler(base.RequestHandler):
         else:
             raise NotImplementedError('Report type {} is not supported'.format(report_type))
 
-        if self.superuser_request or report.user_can_generate(self.uid):
+        if self.user_is_admin or report.user_can_generate(self.uid):
             if self.is_true('csv'):
                 download_format = 'csv'
             else:

--- a/api/reports/site_report.py
+++ b/api/reports/site_report.py
@@ -14,10 +14,8 @@ class SiteReport(Report):
 
     def user_can_generate(self, uid):
         """
-        User generating report must be superuser
+        User generating report must be site admin
         """
-        if config.db.users.count({'_id': uid, 'root': True}) > 0:
-            return True
         return False
 
     def build(self):

--- a/api/reports/usage_report.py
+++ b/api/reports/usage_report.py
@@ -61,10 +61,8 @@ class UsageReport(Report):
 
     def user_can_generate(self, uid):
         """
-        User generating report must be superuser
+        User generating report must be site admin
         """
-        if config.db.users.count({'_id': uid, 'root': True}) > 0:
-            return True
         return False
 
 

--- a/api/upload.py
+++ b/api/upload.py
@@ -216,7 +216,7 @@ class Upload(base.RequestHandler):
     def upload(self, strategy):
         """Receive a sortable reaper upload."""
 
-        if not self.superuser_request:
+        if not self.user_is_admin:
             user = self.uid
             if not user:
                 self.abort(403, 'Uploading requires login')
@@ -225,7 +225,7 @@ class Upload(base.RequestHandler):
             strategy = strategy.replace('-', '')
             strategy = getattr(Strategy, strategy)
 
-        context = {'uid': self.uid if not self.superuser_request else None}
+        context = {'uid': self.uid if not self.user_is_admin else None}
 
         # Request for upload ticket
         if self.get_param('ticket') == '':
@@ -251,7 +251,7 @@ class Upload(base.RequestHandler):
     def engine(self):
         """Handles file uploads from the engine"""
 
-        if not self.superuser_request:
+        if not self.user_is_admin:
             self.abort(402, 'uploads must be from an authorized drone')
         level = self.get_param('level')
         if level is None:
@@ -300,7 +300,7 @@ class Upload(base.RequestHandler):
         Ref placer.TokenPlacer and FileListHandler.packfile_start for context.
         """
 
-        if not self.superuser_request:
+        if not self.user_is_admin:
             self.abort(402, 'uploads must be from an authorized drone')
 
         # Race condition: we could delete tokens & directories that are currently processing.

--- a/sdk/codegen/src/main/resources/fw-python/flywheel.mustache
+++ b/sdk/codegen/src/main/resources/fw-python/flywheel.mustache
@@ -59,8 +59,9 @@ class Flywheel:
         config = config_from_api_key(api_key)
         self.api_client = ApiClient(config, context=self)
 
-        # Root mode
+        # Root mode (Deprecated)
         if root:
+            log.warning('Root mode is deprecated')
             self.api_client.set_default_query_param('root', 'true')
 
         self.api_client.user_agent = 'Flywheel SDK/{} (Python {}; {})'.format(SDK_VERSION,

--- a/sdk/codegen/src/main/resources/fw-python/flywheel_methods.mustache
+++ b/sdk/codegen/src/main/resources/fw-python/flywheel_methods.mustache
@@ -52,7 +52,7 @@
         """
         return self.get_container(id, **kwargs)
 
-    def resolve(self, path):
+    def resolve(self, path, **kwargs):
         """Perform a path based lookup of nodes in the Flywheel hierarchy.
 
         :param str path: (required) The path to resolve
@@ -61,7 +61,7 @@
         if not isinstance(path, list):
             path = path.split('/')
 
-        return self.resolve_path(flywheel.ResolverInput(path=path))
+        return self.resolve_path(flywheel.ResolverInput(path=path), **kwargs)
 
     def lookup(self, path):
         """Perform a path based lookup of a single node in the Flywheel hierarchy.

--- a/sdk/codegen/src/main/resources/matlab/flywheel.mustache
+++ b/sdk/codegen/src/main/resources/matlab/flywheel.mustache
@@ -56,6 +56,7 @@ classdef Flywheel < handle
 
             % Set root mode
             if exist('root', 'var') && root
+                fprintf('WARNING: Root mode is deprecated\n');
                 obj.apiClient.restClient.addDefaultParameter('root', 'true');
             end
 

--- a/sdk/src/python/tests/integration_tests/sdk_test_case.py
+++ b/sdk/src/python/tests/integration_tests/sdk_test_case.py
@@ -32,9 +32,6 @@ def make_clients():
     fw = flywheel.Flywheel(api_key)
     fw.enable_feature('beta')
 
-    fw_root = flywheel.Flywheel(api_key, root=True)
-    fw_root.enable_feature('beta')
-
     # Mock cli login
     home = os.environ['HOME']
     os.environ['HOME'] = tmp_path = tempfile.mkdtemp()
@@ -51,10 +48,10 @@ def make_clients():
     shutil.rmtree(tmp_path)
     os.environ['HOME'] = home
 
-    return fw, fw_root, client
+    return fw, client
 
 class SdkTestCase(unittest.TestCase):
-    fw, fw_root, client = make_clients()
+    fw, client = make_clients()
 
     @classmethod
     def rand_string_lower(self, length=10):

--- a/sdk/src/python/tests/integration_tests/test_data_views.py
+++ b/sdk/src/python/tests/integration_tests/test_data_views.py
@@ -22,11 +22,11 @@ class DataViewTestCases(SdkTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.fw_root.delete_project(cls.project_id)
-        cls.fw_root.delete_group(cls.group_id)
+        cls.fw.delete_project(cls.project_id)
+        cls.fw.delete_group(cls.group_id)
 
         if cls.view_id:
-            cls.fw_root.delete_view(cls.view_id)
+            cls.fw.delete_view(cls.view_id)
 
     def setUp(self):
         self.test_acquisition_id = None

--- a/sdk/src/python/tests/integration_tests/test_resolver.py
+++ b/sdk/src/python/tests/integration_tests/test_resolver.py
@@ -14,8 +14,8 @@ class ResolverTestCases(SdkTestCase):
         self.gear_id = None
 
     def tearDown(self):
-        self.fw_root.delete_project(self.project_id)
-        self.fw_root.delete_group(self.group_id)
+        self.fw.delete_project(self.project_id)
+        self.fw.delete_group(self.group_id)
 
         if self.gear_id is not None:
             self.fw.delete_gear(self.gear_id)
@@ -195,15 +195,13 @@ class ResolverTestCases(SdkTestCase):
         r_group = result.path[0]
         self.assertEmpty(result.children)
 
-        # Try to resolve project
-        try:
-            fw.resolve([group_id, r_project.label])
-            self.fail('Expected ApiException')
-        except flywheel.ApiException as e:
-            self.assertEqual(e.status, 403)
+        # Resolve project, but no children
+        result = fw.resolve([group_id, r_project.label])
+        self.assertEqual(len(result.path), 2)
+        self.assertEqual(len(result.children), 0)
 
-        # Try to resolve project as root
-        result = self.fw_root.resolve([group_id])
+        # Try to resolve project with exhaustive flag
+        result = fw.resolve([group_id], exhaustive=True)
 
         self.assertEqual(len(result.path), 1)
         self.assertEqual(len(result.children), 1)
@@ -211,7 +209,7 @@ class ResolverTestCases(SdkTestCase):
         self.assertEqual(r_project.id, self.project_id)
 
         # Resolve project children
-        result = self.fw_root.resolve('{0}/{1}'.format(group_id, r_project.label))
+        result = fw.resolve('{0}/{1}'.format(group_id, r_project.label), exhaustive=True)
         self.assertEqual(len(result.path), 2)
 
         self.assertEqual(result.path[0].to_dict(), r_group.to_dict())

--- a/swagger/paths/resolver.yaml
+++ b/swagger/paths/resolver.yaml
@@ -25,6 +25,10 @@
         required: true
         schema:
           $ref: schemas/input/resolver.json
+      - in: query
+        type: boolean
+        name: exhaustive
+        description: 'Set to return a complete list regardless of permissions'
     responses:
       '200':
         description: ''

--- a/swagger/templates/container.yaml
+++ b/swagger/templates/container.yaml
@@ -19,6 +19,11 @@ template: |
     x-fw-default-limit: 1000
     tags:
       - '{{tag}}'
+    parameters:
+      - in: query
+        type: boolean
+        name: exhaustive
+        description: 'Set to return a complete list regardless of permissions'
     responses:
       '200':
         description: ''

--- a/tests/integration_tests/python/test_analyses.py
+++ b/tests/integration_tests/python/test_analyses.py
@@ -246,6 +246,7 @@ def test_legacy_analysis(data_builder, as_admin, file_form, api_db):
 
 
 def test_analysis_download(data_builder, as_admin, as_root, file_form, api_db):
+    project = data_builder.create_project()
     session = data_builder.create_session()
 
     # Create legacy analysis
@@ -256,6 +257,8 @@ def test_analysis_download(data_builder, as_admin, as_root, file_form, api_db):
     }))
     assert r.ok
     analysis = r.json()['_id']
+
+    as_admin.post('/projects/' + project + '/permissions', json={'_id': 'user@user.com', 'access': 'admin'})
 
     # Get download ticket for analysis via /download
     r = as_admin.get('/download', params={'ticket': ''}, json={'optional': True, 'nodes': [{'level':'analysis','_id': analysis}]})

--- a/tests/integration_tests/python/test_batch.py
+++ b/tests/integration_tests/python/test_batch.py
@@ -25,6 +25,10 @@ def test_batch(data_builder, as_user, as_admin, as_root, as_drone):
     r = as_root.get('/batch')
     assert r.ok
 
+    # get all as admin with exhaustive flag
+    r = as_admin.get('/batch', params={'exhaustive':True})
+    assert r.ok
+
     # try to create batch without gear_id/targets
     r = as_admin.post('/batch', json={})
     assert r.status_code == 400
@@ -301,14 +305,14 @@ def test_batch(data_builder, as_user, as_admin, as_root, as_drone):
         # set jobs to failed
         r = as_drone.put('/jobs/' + job, json={'state': 'running'})
         assert r.ok
-        r = as_root.put('/jobs/' + job, json={'state': 'failed'})
+        r = as_admin.put('/jobs/' + job, json={'state': 'failed'})
         assert r.ok
 
     # test batch is complete
     r = as_admin.get('/batch/' + batch_id)
     assert r.json()['state'] == 'failed'
 
-def test_no_input_batch(data_builder, default_payload, randstr, as_admin, as_root, as_drone, api_db):
+def test_no_input_batch(data_builder, default_payload, randstr, as_admin, as_drone, api_db):
     project = data_builder.create_project()
     session = data_builder.create_session(project=project)
     session2 = data_builder.create_session(project=project)
@@ -325,7 +329,7 @@ def test_no_input_batch(data_builder, default_payload, randstr, as_admin, as_roo
     }
 
 
-    r = as_root.post('/gears/' + gear_name, json=gear_doc)
+    r = as_admin.post('/gears/' + gear_name, json=gear_doc)
     assert r.ok
 
     gear = r.json()['_id']
@@ -402,7 +406,7 @@ def test_no_input_batch(data_builder, default_payload, randstr, as_admin, as_roo
         }
     }
 
-    r = as_root.post('/gears/' + gear_name, json=gear_doc)
+    r = as_admin.post('/gears/' + gear_name, json=gear_doc)
     assert r.ok
 
     gear2 = r.json()['_id']
@@ -439,16 +443,16 @@ def test_no_input_batch(data_builder, default_payload, randstr, as_admin, as_roo
 
     # cleanup
 
-    r = as_root.delete('/gears/' + gear)
+    r = as_admin.delete('/gears/' + gear)
     assert r.ok
 
-    r = as_root.delete('/gears/' + gear2)
+    r = as_admin.delete('/gears/' + gear2)
     assert r.ok
 
     # must remove jobs manually because gears were added manually
     api_db.jobs.remove({'gear_id': {'$in': [gear, gear2]}})
 
-def test_no_input_context_batch(data_builder, default_payload, as_admin, as_root, file_form, randstr, api_db):
+def test_no_input_context_batch(data_builder, default_payload, as_admin, file_form, randstr, api_db):
     project = data_builder.create_project()
     session = data_builder.create_session(project=project)
     session2 = data_builder.create_session(project=project)
@@ -464,7 +468,7 @@ def test_no_input_context_batch(data_builder, default_payload, as_admin, as_root
         }
     }
 
-    r = as_root.post('/gears/' + gear_name, json=gear_doc)
+    r = as_admin.post('/gears/' + gear_name, json=gear_doc)
     assert r.ok
     gear = r.json()['_id']
 
@@ -544,13 +548,13 @@ def test_no_input_context_batch(data_builder, default_payload, as_admin, as_root
     assert job2_inputs['test_context_value']['value'] == 'project_context_value'
 
     # Cleanup
-    r = as_root.delete('/gears/' + gear)
+    r = as_admin.delete('/gears/' + gear)
     assert r.ok
 
     # must remove jobs manually because gears were added manually
     api_db.jobs.remove({'gear_id': {'$in': [gear]}})
 
-def test_file_input_context_batch(data_builder, default_payload, as_admin, as_root, file_form, randstr, api_db):
+def test_file_input_context_batch(data_builder, default_payload, as_admin, file_form, randstr, api_db):
     project = data_builder.create_project()
     session = data_builder.create_session(project=project)
     session2 = data_builder.create_session(project=project)
@@ -576,7 +580,7 @@ def test_file_input_context_batch(data_builder, default_payload, as_admin, as_ro
         }
     }
 
-    r = as_root.post('/gears/' + gear_name, json=gear_doc)
+    r = as_admin.post('/gears/' + gear_name, json=gear_doc)
     assert r.ok
     gear = r.json()['_id']
 
@@ -667,7 +671,7 @@ def test_file_input_context_batch(data_builder, default_payload, as_admin, as_ro
     assert r.json()['state'] == 'running'
 
     # Cleanup
-    r = as_root.delete('/gears/' + gear)
+    r = as_admin.delete('/gears/' + gear)
     assert r.ok
 
     # must remove jobs manually because gears were added manually

--- a/tests/integration_tests/python/test_devices.py
+++ b/tests/integration_tests/python/test_devices.py
@@ -3,7 +3,7 @@ import datetime
 import bson
 
 
-def test_devices(as_public, as_user, as_admin, as_root, as_drone, api_db):
+def test_devices(as_public, as_user, as_admin, as_drone, api_db):
     # try to get all devices w/o logging in
     r = as_public.get('/devices')
     assert r.status_code == 403
@@ -51,7 +51,7 @@ def test_devices(as_public, as_user, as_admin, as_root, as_drone, api_db):
     assert 'key' in r.json()
 
     # try to do device check-in as user
-    r = as_root.put('/devices/self')
+    r = as_admin.put('/devices/self')
     assert r.status_code == 403
 
     # do empty device check-in (implicit last_seen update)
@@ -76,12 +76,12 @@ def test_devices(as_public, as_user, as_admin, as_root, as_drone, api_db):
     assert r.ok
     assert drone_id in r.json()
 
-    # try to create device w/o root
-    r = as_admin.post('/devices')
+    # try to create device w/o site admin
+    r = as_user.post('/devices')
     assert r.status_code == 403
 
     # create device
-    r = as_root.post('/devices', json={'type': 'test'})
+    r = as_admin.post('/devices', json={'type': 'test'})
     assert r.ok
     device_id = r.json()['_id']
     assert api_db.apikeys.count({'origin.id': bson.ObjectId(device_id), 'type': 'device'}) == 1
@@ -112,7 +112,7 @@ def test_devices(as_public, as_user, as_admin, as_root, as_drone, api_db):
     assert as_user.get('/devices/status').json()[device_id]['status'] == 'error'
 
     # delete device
-    r = as_root.delete('/devices/' + device_id)
+    r = as_admin.delete('/devices/' + device_id)
     assert r.ok
 
     r = as_user.get('/devices/' + device_id)

--- a/tests/integration_tests/python/test_download.py
+++ b/tests/integration_tests/python/test_download.py
@@ -878,7 +878,7 @@ def test_summary(data_builder, as_user, as_admin, file_form):
     # add user to project
     user_id = as_user.get('/users/self').json()['_id']
     assert as_admin.post('/projects/' + project + '/permissions', json={
-        'access': 'ro',
+        'access': 'admin',
         '_id': user_id
     }).ok
 

--- a/tests/integration_tests/python/test_download.py
+++ b/tests/integration_tests/python/test_download.py
@@ -9,7 +9,7 @@ import pytest
 from api import config, util
 
 
-def test_download_k(data_builder, file_form, as_admin, as_root, api_db, legacy_cas_file):
+def test_download_k(data_builder, file_form, as_admin, as_user, api_db, legacy_cas_file):
     project = data_builder.create_project(label='project1')
     subject = data_builder.create_subject(code='subject1', project=project)
     session = data_builder.create_session(label='session1', project=project, subject={'_id': subject})
@@ -24,23 +24,24 @@ def test_download_k(data_builder, file_form, as_admin, as_root, api_db, legacy_c
     # upload the same file to each container created and use different tags to
     # facilitate download filter tests:
     # acquisition: [], session: ['plus'], project: ['plus', 'minus']
+    as_admin.post('/projects/' + project + '/permissions', json={'_id': 'user@user.com', 'access': 'admin'})
     file_name = 'test.csv'
-    as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form(
+    as_user.post('/acquisitions/' + acquisition + '/files', files=file_form(
         file_name, meta={'name': file_name, 'type': 'csv'}))
 
-    as_admin.post('/acquisitions/' + acquisition2 + '/files', files=file_form(
+    as_user.post('/acquisitions/' + acquisition2 + '/files', files=file_form(
         file_name, meta={'name': file_name, 'type': 'csv'}))
 
-    as_admin.post('/acquisitions/' + acquisition3 + '/files', files=file_form(
+    as_user.post('/acquisitions/' + acquisition3 + '/files', files=file_form(
         'test.txt', meta={'name': file_name, 'type': 'text'}))
 
-    as_admin.post('/acquisitions/' + acquisition4 + '/files', files=file_form(
+    as_user.post('/acquisitions/' + acquisition4 + '/files', files=file_form(
         'test.txt', meta={'name': file_name, 'type': 'text'}))
 
-    as_admin.post('/sessions/' + session + '/files', files=file_form(
+    as_user.post('/sessions/' + session + '/files', files=file_form(
         file_name, meta={'name': file_name, 'type': 'csv', 'tags': ['plus']}))
 
-    as_admin.post('/projects/' + project + '/files', files=file_form(
+    as_user.post('/projects/' + project + '/files', files=file_form(
         file_name, meta={'name': file_name, 'type': 'csv', 'tags': ['plus', 'minus']}))
 
     # also a deleted file to make sure it doesn't show up
@@ -52,27 +53,10 @@ def test_download_k(data_builder, file_form, as_admin, as_root, api_db, legacy_c
     missing_object_id = '000000000000000000000000'
 
     # Try to download w/ nonexistent ticket
-    r = as_admin.get('/download', params={'ticket': missing_object_id})
+    r = as_user.get('/download', params={'ticket': missing_object_id})
     assert r.status_code == 404
 
     # Retrieve a ticket for a batch download as superuser
-    r = as_root.post('/download', json={
-        'optional': False,
-        'filters': [{'tags': {
-            '-': ['minus']
-        }}],
-        'nodes': [
-            {'level': 'project', '_id': project},
-        ]
-    })
-    assert r.ok
-    ticket = r.json()['ticket']
-
-    # Perform the download
-    r = as_root.get('/download', params={'ticket': ticket})
-    assert r.ok
-
-    # Retrieve a ticket for a batch download
     r = as_admin.post('/download', json={
         'optional': False,
         'filters': [{'tags': {
@@ -87,6 +71,23 @@ def test_download_k(data_builder, file_form, as_admin, as_root, api_db, legacy_c
 
     # Perform the download
     r = as_admin.get('/download', params={'ticket': ticket})
+    assert r.ok
+
+    # Retrieve a ticket for a batch download
+    r = as_user.post('/download', json={
+        'optional': False,
+        'filters': [{'tags': {
+            '-': ['minus']
+        }}],
+        'nodes': [
+            {'level': 'project', '_id': project},
+        ]
+    })
+    assert r.ok
+    ticket = r.json()['ticket']
+
+    # Perform the download
+    r = as_user.get('/download', params={'ticket': ticket})
     assert r.ok
 
     tar_file = cStringIO.StringIO(r.content)
@@ -112,11 +113,11 @@ def test_download_k(data_builder, file_form, as_admin, as_root, api_db, legacy_c
     # Download one session with many acquisitions and make sure they are in the same subject folder
 
     acquisition3 = data_builder.create_acquisition(session=session)
-    r = as_admin.post('/acquisitions/' + acquisition3 + '/files', files=file_form(
+    r = as_user.post('/acquisitions/' + acquisition3 + '/files', files=file_form(
         file_name, meta={'name': file_name, 'type': 'csv'}))
     assert r.ok
 
-    r = as_admin.post('/download', json={
+    r = as_user.post('/download', json={
         'optional': False,
         'nodes': [
             {'level': 'acquisition', '_id': acquisition},
@@ -127,7 +128,7 @@ def test_download_k(data_builder, file_form, as_admin, as_root, api_db, legacy_c
     ticket = r.json()['ticket']
 
     # Perform the download
-    r = as_admin.get('/download', params={'ticket': ticket})
+    r = as_user.get('/download', params={'ticket': ticket})
     assert r.ok
 
     tar_file = cStringIO.StringIO(r.content)
@@ -149,11 +150,11 @@ def test_download_k(data_builder, file_form, as_admin, as_root, api_db, legacy_c
         {'$set': {'ip': '255.255.255.255'}})
     assert update_result.modified_count == 1
 
-    r = as_admin.get('/download', params={'ticket': ticket})
+    r = as_user.get('/download', params={'ticket': ticket})
     assert r.status_code == 400
 
     # Try to retrieve a ticket referencing nonexistent containers
-    r = as_admin.post('/download', json={
+    r = as_user.post('/download', json={
         'optional': False,
         'nodes': [
             {'level': 'project', '_id': missing_object_id},
@@ -165,31 +166,34 @@ def test_download_k(data_builder, file_form, as_admin, as_root, api_db, legacy_c
 
     # Try to retrieve ticket for bulk download w/ invalid container name
     # (not project|session|acquisition)
-    r = as_admin.post('/download', params={'bulk': 'true'}, json={
+    r = as_user.post('/download', params={'bulk': 'true'}, json={
         'files': [{'container_name': 'collection', 'container_id': missing_object_id, 'filename': 'nosuch.csv'}]
     })
     assert r.status_code == 400
 
     # Try to retrieve ticket for bulk download referencing nonexistent file
-    r = as_admin.post('/download', params={'bulk': 'true'}, json={
+    r = as_user.post('/download', params={'bulk': 'true'}, json={
         'files': [{'container_name': 'project', 'container_id': project, 'filename': 'nosuch.csv'}]
     })
     assert r.status_code == 404
 
     # Retrieve ticket for bulk download
-    r = as_admin.post('/download', params={'bulk': 'true'}, json={
+    r = as_user.post('/download', params={'bulk': 'true'}, json={
         'files': [{'container_name': 'project', 'container_id': project, 'filename': file_name}]
     })
     assert r.ok
     ticket = r.json()['ticket']
 
     # Perform the download using symlinks
-    r = as_admin.get('/download', params={'ticket': ticket, 'symlinks': 'true'})
+    r = as_user.get('/download', params={'ticket': ticket, 'symlinks': 'true'})
     assert r.ok
 
     # test legacy cas file handling
     (project_legacy, file_name_legacy, file_content) = legacy_cas_file
-    r = as_admin.post('/download', json={
+
+    # Add user to leagcy project permissions
+    as_admin.post('/projects/' + project_legacy + '/permissions', json={'_id': 'user@user.com', 'access': 'admin'})
+    r = as_user.post('/download', json={
         'optional': False,
         'nodes': [
             {'level': 'project', '_id': project_legacy},
@@ -199,7 +203,7 @@ def test_download_k(data_builder, file_form, as_admin, as_root, api_db, legacy_c
     ticket = r.json()['ticket']
 
     # Perform the download
-    r = as_admin.get('/download', params={'ticket': ticket})
+    r = as_user.get('/download', params={'ticket': ticket})
     assert r.ok
 
     tar_file = cStringIO.StringIO(r.content)
@@ -216,7 +220,7 @@ def test_download_k(data_builder, file_form, as_admin, as_root, api_db, legacy_c
     file_id = api_db.acquisitions.find_one({'_id': ObjectId(acquisition)})['files'][0]['_id']
     config.fs.remove(util.path_from_uuid(file_id))
 
-    r = as_admin.post('/download', json={
+    r = as_user.post('/download', json={
         'optional': False,
         'nodes': [
             {'level': 'acquisition', '_id': acquisition},
@@ -227,7 +231,7 @@ def test_download_k(data_builder, file_form, as_admin, as_root, api_db, legacy_c
     ticket = r.json()['ticket']
 
     # Perform the download
-    r = as_admin.get('/download', params={'ticket': ticket})
+    r = as_user.get('/download', params={'ticket': ticket})
     assert r.ok
 
     tar_file = cStringIO.StringIO(r.content)
@@ -242,168 +246,180 @@ def test_download_k(data_builder, file_form, as_admin, as_root, api_db, legacy_c
     tar.close()
 
 
-def test_filelist_download(data_builder, file_form, as_admin, legacy_cas_file):
-    session = data_builder.create_session()
+def test_filelist_download(data_builder, file_form, as_user, as_admin, legacy_cas_file):
+    project = data_builder.create_project()
+    session = data_builder.create_session(project=project)
+
+    # Add User to permissions
+    as_admin.post('/projects/' + project + '/permissions', json={'_id': 'user@user.com', 'access': 'admin'})
+
     zip_cont = cStringIO.StringIO()
     with zipfile.ZipFile(zip_cont, 'w') as zip_file:
         zip_file.writestr('two.csv', 'sample\ndata\n')
     zip_cont.seek(0)
     session_files = '/sessions/' + session + '/files'
-    as_admin.post(session_files, files=file_form('one.csv'))
-    as_admin.post(session_files, files=file_form(('two.zip', zip_cont)))
+    as_user.post(session_files, files=file_form('one.csv'))
+    as_user.post(session_files, files=file_form(('two.zip', zip_cont)))
 
-    # try to get non-existent file
-    r = as_admin.get(session_files + '/non-existent.csv')
+    # try to get non-existent file (Use admin because the user permissions is checked)
+    r = as_user.get(session_files + '/non-existent.csv')
     assert r.status_code == 404
 
     # try to get file w/ non-matching hash
-    r = as_admin.get(session_files + '/one.csv', params={'hash': 'match me if you can'})
+    r = as_user.get(session_files + '/one.csv', params={'hash': 'match me if you can'})
     assert r.status_code == 409
 
     # get download ticket for single file
-    r = as_admin.get(session_files + '/one.csv', params={'ticket': ''})
+    r = as_user.get(session_files + '/one.csv', params={'ticket': ''})
     assert r.ok
     ticket = r.json()['ticket']
 
     # download single file w/ ticket
-    r = as_admin.get(session_files + '/one.csv', params={'ticket': ticket})
+    r = as_user.get(session_files + '/one.csv', params={'ticket': ticket})
     assert r.ok
 
     # try to get zip info for non-zip file
-    r = as_admin.get(session_files + '/one.csv', params={'ticket': ticket, 'info': 'true'})
+    r = as_user.get(session_files + '/one.csv', params={'ticket': ticket, 'info': 'true'})
     assert r.status_code == 400
 
     # try to get zip member of non-zip file
-    r = as_admin.get(session_files + '/one.csv', params={'ticket': ticket, 'member': 'hardly'})
+    r = as_user.get(session_files + '/one.csv', params={'ticket': ticket, 'member': 'hardly'})
     assert r.status_code == 400
 
     # try to download a different file w/ ticket
-    r = as_admin.get(session_files + '/two.zip', params={'ticket': ticket})
+    r = as_user.get(session_files + '/two.zip', params={'ticket': ticket})
     assert r.status_code == 400
 
     # get download ticket for zip file
-    r = as_admin.get(session_files + '/two.zip', params={'ticket': ''})
+    r = as_user.get(session_files + '/two.zip', params={'ticket': ''})
     assert r.ok
     ticket = r.json()['ticket']
 
     # get zip info
-    r = as_admin.get(session_files + '/two.zip', params={'ticket': ticket, 'info': 'true'})
+    r = as_user.get(session_files + '/two.zip', params={'ticket': ticket, 'info': 'true'})
     assert r.ok
 
     # try to get non-existent zip member
-    r = as_admin.get(session_files + '/two.zip', params={'ticket': ticket, 'member': 'hardly'})
+    r = as_user.get(session_files + '/two.zip', params={'ticket': ticket, 'member': 'hardly'})
     assert r.status_code == 400
 
     # get zip member
-    r = as_admin.get(session_files + '/two.zip', params={'ticket': ticket, 'member': 'two.csv'})
+    r = as_user.get(session_files + '/two.zip', params={'ticket': ticket, 'member': 'two.csv'})
     assert r.ok
 
     # test legacy cas file handling
     (project, file_name, file_content) = legacy_cas_file
-    r = as_admin.get('/projects/' + project + '/files/' + file_name, params={'ticket': ''})
+    # Add User to permissions
+    as_admin.post('/projects/' + project + '/permissions', json={'_id': 'user@user.com', 'access': 'admin'})
+    r = as_user.get('/projects/' + project + '/files/' + file_name, params={'ticket': ''})
     assert r.ok
 
     ticket = r.json()['ticket']
 
-    r = as_admin.get('/projects/' + project + '/files/' + file_name, params={'ticket': ticket})
+    r = as_user.get('/projects/' + project + '/files/' + file_name, params={'ticket': ticket})
     assert r.ok
     assert r.content == file_content
 
 
-def test_filelist_range_download(data_builder, as_admin, file_form):
-    session = data_builder.create_session()
-    session_files = '/sessions/' + session + '/files'
-    as_admin.post(session_files, files=file_form(('one.csv', '123456789')))
+def test_filelist_range_download(data_builder, as_user, as_admin, file_form):
+    project = data_builder.create_project()
+    session = data_builder.create_session(project=project)
 
-    r = as_admin.get(session_files + '/one.csv', params={'ticket': ''})
+    # Add user to permissions
+    as_admin.post('/projects/' + project + '/permissions', json={'_id': 'user@user.com', 'access': 'admin'})
+
+    session_files = '/sessions/' + session + '/files'
+    as_user.post(session_files, files=file_form(('one.csv', '123456789')))
+
+    r = as_user.get(session_files + '/one.csv', params={'ticket': ''})
     assert r.ok
     ticket = r.json()['ticket']
 
     # verify contents
-    r = as_admin.get(session_files + '/one.csv',
+    r = as_user.get(session_files + '/one.csv',
                      params={'ticket': ticket})
     assert r.ok
     assert r.content == '123456789'
 
     # download single file from byte 0 to end of file
-    r = as_admin.get(session_files + '/one.csv',
+    r = as_user.get(session_files + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'Range': 'bytes=0-'})
     assert r.ok
     assert r.content == '123456789'
 
-    r = as_admin.get(session_files + '/one.csv', params={'ticket': ''})
+    r = as_user.get(session_files + '/one.csv', params={'ticket': ''})
     assert r.ok
     ticket = r.json()['ticket']
 
     # download single file's first byte by using lower case header
-    r = as_admin.get(session_files + '/one.csv',
+    r = as_user.get(session_files + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'range': 'bytes=0-0'})
     assert r.ok
     assert r.content == '1'
 
-    r = as_admin.get(session_files + '/one.csv', params={'ticket': ''})
+    r = as_user.get(session_files + '/one.csv', params={'ticket': ''})
     assert r.ok
     ticket = r.json()['ticket']
 
     # download single file's first two byte
-    r = as_admin.get(session_files + '/one.csv',
+    r = as_user.get(session_files + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'Range': 'bytes=0-1'})
     assert r.ok
     assert r.content == '12'
 
-    r = as_admin.get(session_files + '/one.csv', params={'ticket': ''})
+    r = as_user.get(session_files + '/one.csv', params={'ticket': ''})
     assert r.ok
     ticket = r.json()['ticket']
 
     # try to download single file with invalid unit
-    r = as_admin.get(session_files + '/one.csv',
+    r = as_user.get(session_files + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'Range': 'lol=-5'})
     assert r.status_code == 200
     assert r.content == '123456789'
 
-    r = as_admin.get(session_files + '/one.csv', params={'ticket': ''})
+    r = as_user.get(session_files + '/one.csv', params={'ticket': ''})
     assert r.ok
     ticket = r.json()['ticket']
 
     # try to download single file with invalid range where the last byte is greater then the size of the file
     # in this case the whole file is returned
-    r = as_admin.get(session_files + '/one.csv',
+    r = as_user.get(session_files + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'Range': 'bytes=0-500'})
     assert r.ok
     assert r.content == '123456789'
 
-    r = as_admin.get(session_files + '/one.csv', params={'ticket': ''})
+    r = as_user.get(session_files + '/one.csv', params={'ticket': ''})
     assert r.ok
     ticket = r.json()['ticket']
 
     # try to download single file with invalid range where the first byte is greater then the size of the file
-    r = as_admin.get(session_files + '/one.csv',
+    r = as_user.get(session_files + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'Range': 'bytes=500-'})
     assert r.status_code == 416
 
-    r = as_admin.get(session_files + '/one.csv', params={'ticket': ''})
+    r = as_user.get(session_files + '/one.csv', params={'ticket': ''})
     assert r.ok
     ticket = r.json()['ticket']
 
     # try to download single file with invalid range first byte is greater than the last one
-    r = as_admin.get(session_files + '/one.csv',
+    r = as_user.get(session_files + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'Range': 'bytes=10-5'})
     assert r.ok
     assert r.content == '123456789'
 
-    r = as_admin.get(session_files + '/one.csv', params={'ticket': ''})
+    r = as_user.get(session_files + '/one.csv', params={'ticket': ''})
     assert r.ok
     ticket = r.json()['ticket']
 
     # try to download single file with invalid range header syntax
-    r = as_admin.get(session_files + '/one.csv',
+    r = as_user.get(session_files + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'Range': 'bytes-1+5'})
     assert r.ok
@@ -412,81 +428,85 @@ def test_filelist_range_download(data_builder, as_admin, file_form):
 
 @pytest.mark.skipif(not os.getenv('SCITRAN_PERSISTENT_FS_URL', 'osfs').startswith('osfs'),
                     reason="Only OSFS supports all of these special range formats.")
-def test_filelist_advanced_range_download(data_builder, as_admin, file_form):
+def test_filelist_advanced_range_download(data_builder, as_user, as_admin, file_form):
     # We run this test only with OSFS because other backends don't support fully the RFS standard.
     # Left comments about the found defects with the specific storage backends at the assertions.
+    project = data_builder.create_project()
+    session = data_builder.create_session(project=project)
 
-    session = data_builder.create_session()
+    # Add User to permissions
+    as_admin.post('/projects/' + project + '/permissions', json={'_id': 'user@user.com', 'access': 'admin'})
+
     session_files = '/sessions/' + session + '/files'
-    as_admin.post(session_files, files=file_form(('one.csv', '123456789')))
+    as_user.post(session_files, files=file_form(('one.csv', '123456789')))
 
-    r = as_admin.get(session_files + '/one.csv', params={'ticket': ''})
+    r = as_user.get(session_files + '/one.csv', params={'ticket': ''})
     assert r.ok
     ticket = r.json()['ticket']
 
     # download single file's last 5 bytes
     # ASFS returns the whole file, since it doesn't support this range format
-    r = as_admin.get(session_files + '/one.csv',
+    r = as_user.get(session_files + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'Range': 'bytes=-5'})
     assert r.ok
     assert r.content == '56789'
 
-    r = as_admin.get(session_files + '/one.csv', params={'ticket': ''})
+    r = as_user.get(session_files + '/one.csv', params={'ticket': ''})
     assert r.ok
     ticket = r.json()['ticket']
 
     # try to download single file with invalid range, in this case the whole file is returned
     # ASFS returns with status code 416
-    r = as_admin.get(session_files + '/one.csv',
+    r = as_user.get(session_files + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'Range': 'bytes=-'})
     assert r.ok
     assert r.content == '123456789'
 
-    r = as_admin.get(session_files + '/one.csv', params={'ticket': ''})
+    r = as_user.get(session_files + '/one.csv', params={'ticket': ''})
     assert r.ok
     ticket = r.json()['ticket']
 
     # try to download single file with invalid range, can't parse first byte
     # ASFS returns with status code 400
-    r = as_admin.get(session_files + '/one.csv',
+    r = as_user.get(session_files + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'Range': 'bytes=r-0'})
     assert r.ok
     assert r.content == '123456789'
 
-    r = as_admin.get(session_files + '/one.csv', params={'ticket': ''})
+    r = as_user.get(session_files + '/one.csv', params={'ticket': ''})
     assert r.ok
     ticket = r.json()['ticket']
 
     # try to download single file with invalid range, can't parse last byte
     # ASFS returns with status code 400
-    r = as_admin.get(session_files + '/one.csv',
+    r = as_user.get(session_files + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'Range': 'bytes=0-bb'})
     assert r.ok
     assert r.content == '123456789'
 
-    r = as_admin.get(session_files + '/one.csv', params={'ticket': ''})
+    r = as_user.get(session_files + '/one.csv', params={'ticket': ''})
     assert r.ok
     ticket = r.json()['ticket']
 
     # try to download single file with invalid range syntax
     # ASFS returns with status code 400
-    r = as_admin.get(session_files + '/one.csv',
+    r = as_user.get(session_files + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'Range': 'bytes=1+5'})
     assert r.ok
     assert r.content == '123456789'
 
-    r = as_admin.get(session_files + '/one.csv', params={'ticket': ''})
+    r = as_user.get(session_files + '/one.csv', params={'ticket': ''})
     assert r.ok
     ticket = r.json()['ticket']
 
     # download multiple ranges
     # GCSFS doesn't support multiple ranges
-    r = as_admin.get(session_files + '/one.csv',
+    r = as_user.get(session_files + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'Range': 'bytes=1-2, 3-4'})
     assert r.ok
@@ -500,9 +520,9 @@ def test_filelist_advanced_range_download(data_builder, as_admin, file_form):
                         'Content-Range: bytes 3-4/9\n\n' \
                         '45\n'.format(boundary)
 
-def test_analysis_download(data_builder, file_form, as_admin, as_drone, as_user, default_payload):
+def test_analysis_download(data_builder, file_form, as_user, as_admin, as_drone, default_payload):
     project = data_builder.create_project()
-    session = data_builder.create_session()
+    session = data_builder.create_session(project=project)
     zip_cont = cStringIO.StringIO()
     with zipfile.ZipFile(zip_cont, 'w') as zip_file:
         zip_file.writestr('two.csv', 'sample\ndata\n')
@@ -515,7 +535,7 @@ def test_analysis_download(data_builder, file_form, as_admin, as_drone, as_user,
     }).ok
 
     # create (legacy) analysis for testing the download functionality
-    r = as_admin.post('/sessions/' + session + '/analyses', files=file_form('one.csv', ('two.zip', zip_cont), meta={
+    r = as_user.post('/sessions/' + session + '/analyses', files=file_form('one.csv', ('two.zip', zip_cont), meta={
         'label': 'test',
         'inputs': [{'name': 'one.csv'}],
         'outputs': [{'name': 'two.zip'}],
@@ -529,22 +549,22 @@ def test_analysis_download(data_builder, file_form, as_admin, as_drone, as_user,
     new_analysis_outputs = '/analyses/' + analysis + '/files'
 
     # Check that analysis inputs are placed under the inputs key
-    r = as_admin.get('/sessions/' + session + '/analyses/' + analysis)
+    r = as_user.get('/sessions/' + session + '/analyses/' + analysis)
     assert r.ok
     assert [f['name'] for f in r.json().get('inputs', [])] == ['one.csv']
 
     # try to download analysis inputs w/ non-existent ticket
-    r = as_admin.get(analysis_inputs, params={'ticket': '000000000000000000000000'})
+    r = as_user.get(analysis_inputs, params={'ticket': '000000000000000000000000'})
     assert r.status_code == 404
 
     # get analysis batch download ticket for all inputs
     # Endpoint should no longer exist
-    r = as_admin.get(analysis_inputs, params={'ticket': ''}, json={"optional":True,"nodes":[{"level":"analysis","_id":analysis}]})
+    r = as_user.get(analysis_inputs, params={'ticket': ''}, json={"optional":True,"nodes":[{"level":"analysis","_id":analysis}]})
     assert r.status_code == 404
 
     ### Using '/download' endpoint only - for analysis outputs only! ###
     # try to download analysis outputs w/ non-existent ticket
-    r = as_admin.get('/download', params={'ticket': '000000000000000000000000'})
+    r = as_user.get('/download', params={'ticket': '000000000000000000000000'})
     assert r.status_code == 404
 
     # get analysis batch download ticket for all outputs
@@ -567,7 +587,7 @@ def test_analysis_download(data_builder, file_form, as_admin, as_drone, as_user,
     }).ok
 
     # batch download analysis outputs w/ ticket
-    r = as_admin.get('/download', params={'ticket': ticket})
+    r = as_user.get('/download', params={'ticket': ticket})
     assert r.ok
 
     # Check to make sure inputs and outputs are in tar
@@ -575,104 +595,107 @@ def test_analysis_download(data_builder, file_form, as_admin, as_drone, as_user,
         assert set([m.name for m in tar.getmembers()]) == set(['test/input/one.csv', 'test/output/two.zip'])
 
     # try to get download ticket for non-existent analysis file
-    r = as_admin.get(analysis_inputs + '/non-existent.csv')
+    r = as_user.get(analysis_inputs + '/non-existent.csv')
     assert r.status_code == 404
 
     # get analysis download ticket for single file
-    r = as_admin.get(analysis_inputs + '/one.csv', params={'ticket': ''})
+    r = as_user.get(analysis_inputs + '/one.csv', params={'ticket': ''})
     assert r.ok
     ticket = r.json()['ticket']
 
     # download single analysis file w/ ticket
-    r = as_admin.get(analysis_inputs + '/one.csv', params={'ticket': ticket})
+    r = as_user.get(analysis_inputs + '/one.csv', params={'ticket': ticket})
     assert r.ok
 
     # try to get zip info for non-zip file
-    r = as_admin.get(analysis_inputs + '/one.csv', params={'ticket': ticket, 'info': 'true'})
+    r = as_user.get(analysis_inputs + '/one.csv', params={'ticket': ticket, 'info': 'true'})
     assert r.status_code == 400
 
     # try to get zip member of non-zip file
-    r = as_admin.get(analysis_inputs + '/one.csv', params={'ticket': ticket, 'member': 'nosuch'})
+    r = as_user.get(analysis_inputs + '/one.csv', params={'ticket': ticket, 'member': 'nosuch'})
     assert r.status_code == 400
 
     # try to download a different file w/ ticket
-    r = as_admin.get(analysis_outputs + '/two.zip', params={'ticket': ticket})
+    r = as_user.get(analysis_outputs + '/two.zip', params={'ticket': ticket})
     assert r.status_code == 400
 
     # get analysis download ticket for zip file
-    r = as_admin.get(analysis_outputs + '/two.zip', params={'ticket': ''})
+    r = as_user.get(analysis_outputs + '/two.zip', params={'ticket': ''})
     assert r.ok
     ticket = r.json()['ticket']
 
     # get zip info
-    r = as_admin.get(analysis_outputs + '/two.zip', params={'ticket': ticket, 'info': 'true'})
+    r = as_user.get(analysis_outputs + '/two.zip', params={'ticket': ticket, 'info': 'true'})
     assert r.ok
 
     # try to get non-existent zip member
-    r = as_admin.get(analysis_outputs + '/two.zip', params={'ticket': ticket, 'member': 'nosuch'})
+    r = as_user.get(analysis_outputs + '/two.zip', params={'ticket': ticket, 'member': 'nosuch'})
     assert r.status_code == 400
 
     # get zip member
-    r = as_admin.get(analysis_outputs + '/two.zip', params={'ticket': ticket, 'member': 'two.csv'})
+    r = as_user.get(analysis_outputs + '/two.zip', params={'ticket': ticket, 'member': 'two.csv'})
     assert r.ok
 
     ### single file analysis download using FileListHandler ###
     # try to get download ticket for non-existent analysis file
-    r = as_admin.get(new_analysis_inputs + '/non-existent.csv')
+    r = as_user.get(new_analysis_inputs + '/non-existent.csv')
     assert r.status_code == 404
 
     # get analysis download ticket for single file
-    r = as_admin.get(new_analysis_inputs + '/one.csv', params={'ticket': ''})
+    r = as_user.get(new_analysis_inputs + '/one.csv', params={'ticket': ''})
     assert r.ok
     ticket = r.json()['ticket']
 
     # download single analysis file w/ ticket
-    r = as_admin.get(new_analysis_inputs + '/one.csv', params={'ticket': ticket})
+    r = as_user.get(new_analysis_inputs + '/one.csv', params={'ticket': ticket})
     assert r.ok
 
     # try to get zip info for non-zip file
-    r = as_admin.get(new_analysis_inputs + '/one.csv', params={'ticket': ticket, 'info': 'true'})
+    r = as_user.get(new_analysis_inputs + '/one.csv', params={'ticket': ticket, 'info': 'true'})
     assert r.status_code == 400
 
     # try to get zip member of non-zip file
-    r = as_admin.get(new_analysis_inputs + '/one.csv', params={'ticket': ticket, 'member': 'nosuch'})
+    r = as_user.get(new_analysis_inputs + '/one.csv', params={'ticket': ticket, 'member': 'nosuch'})
     assert r.status_code == 400
 
     # try to download a different file w/ ticket
-    r = as_admin.get(new_analysis_outputs + '/two.zip', params={'ticket': ticket})
+    r = as_user.get(new_analysis_outputs + '/two.zip', params={'ticket': ticket})
     assert r.status_code == 400
 
     # get analysis download ticket for zip file
-    r = as_admin.get(new_analysis_outputs + '/two.zip', params={'ticket': ''})
+    r = as_user.get(new_analysis_outputs + '/two.zip', params={'ticket': ''})
     assert r.ok
     ticket = r.json()['ticket']
 
     # get zip info
-    r = as_admin.get(new_analysis_outputs + '/two.zip', params={'ticket': ticket, 'info': 'true'})
+    r = as_user.get(new_analysis_outputs + '/two.zip', params={'ticket': ticket, 'info': 'true'})
     assert r.ok
 
     # try to get non-existent zip member
-    r = as_admin.get(new_analysis_outputs + '/two.zip', params={'ticket': ticket, 'member': 'nosuch'})
+    r = as_user.get(new_analysis_outputs + '/two.zip', params={'ticket': ticket, 'member': 'nosuch'})
     assert r.status_code == 400
 
     # get zip member
-    r = as_admin.get(new_analysis_outputs + '/two.zip', params={'ticket': ticket, 'member': 'two.csv'})
+    r = as_user.get(new_analysis_outputs + '/two.zip', params={'ticket': ticket, 'member': 'two.csv'})
     assert r.ok
 
     # delete session analysis (job)
-    r = as_admin.delete('/sessions/' + session + '/analyses/' + analysis)
+    r = as_user.delete('/sessions/' + session + '/analyses/' + analysis)
     assert r.ok
 
 
-def test_analyses_range_download(data_builder, as_admin, file_form):
-    session = data_builder.create_session()
+def test_analyses_range_download(data_builder, as_user, as_admin, file_form):
+    project = data_builder.create_project()
+    session = data_builder.create_session(project=project)
+    # Add User to permissions
+    as_admin.post('/projects/' + project + '/permissions', json={'_id': 'user@user.com', 'access': 'admin'})
     zip_cont = cStringIO.StringIO()
     with zipfile.ZipFile(zip_cont, 'w') as zip_file:
         zip_file.writestr('two.csv', 'sample\ndata\n')
     zip_cont.seek(0)
 
     # create (legacy) analysis for testing the download functionality
-    r = as_admin.post('/sessions/' + session + '/analyses', files=file_form(('one.csv', '123456789'),
+    r = as_user.post('/sessions/' + session + '/analyses', files=file_form(('one.csv', '123456789'),
                                                                             ('two.zip', zip_cont),
                                                                             meta={
                                                                                 'label': 'test',
@@ -684,39 +707,39 @@ def test_analyses_range_download(data_builder, as_admin, file_form):
 
     analysis_inputs = '/analyses/' + analysis + '/inputs'
 
-    r = as_admin.get(analysis_inputs + '/one.csv', params={'ticket': ''})
+    r = as_user.get(analysis_inputs + '/one.csv', params={'ticket': ''})
     assert r.ok
     ticket = r.json()['ticket']
 
     # verify contents
-    r = as_admin.get(analysis_inputs + '/one.csv',
+    r = as_user.get(analysis_inputs + '/one.csv',
                      params={'ticket': ticket})
     assert r.ok
     assert r.content == '123456789'
 
     # download single file from byte 0 to end of file
-    r = as_admin.get(analysis_inputs + '/one.csv',
+    r = as_user.get(analysis_inputs + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'Range': 'bytes=0-'})
     assert r.ok
     assert r.content == '123456789'
 
     # download single file's first byte by using lower case header
-    r = as_admin.get(analysis_inputs + '/one.csv',
+    r = as_user.get(analysis_inputs + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'range': 'bytes=0-0'})
     assert r.ok
     assert r.content == '1'
 
     # download single file's first two byte
-    r = as_admin.get(analysis_inputs + '/one.csv',
+    r = as_user.get(analysis_inputs + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'Range': 'bytes=0-1'})
     assert r.ok
     assert r.content == '12'
 
     # try to download single file with invalid unit
-    r = as_admin.get(analysis_inputs + '/one.csv',
+    r = as_user.get(analysis_inputs + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'Range': 'lol=-5'})
     assert r.status_code == 200
@@ -724,51 +747,54 @@ def test_analyses_range_download(data_builder, as_admin, file_form):
 
     # try to download single file with invalid range where the last byte is greater then the size of the file
     # in this case the whole file is returned
-    r = as_admin.get(analysis_inputs + '/one.csv',
+    r = as_user.get(analysis_inputs + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'Range': 'bytes=0-500'})
     assert r.ok
     assert r.content == '123456789'
 
     # try to download single file with invalid range where the first byte is greater then the size of the file
-    r = as_admin.get(analysis_inputs + '/one.csv',
+    r = as_user.get(analysis_inputs + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'Range': 'bytes=500-'})
     assert r.status_code == 416
 
     # try to download single file with invalid range first byte is greater than the last one
-    r = as_admin.get(analysis_inputs + '/one.csv',
+    r = as_user.get(analysis_inputs + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'Range': 'bytes=10-5'})
     assert r.ok
     assert r.content == '123456789'
 
     # try to download single file with invalid range header syntax
-    r = as_admin.get(analysis_inputs + '/one.csv',
+    r = as_user.get(analysis_inputs + '/one.csv',
                      params={'ticket': ticket, 'view': 'true'},
                      headers={'Range': 'bytes-1+5'})
     assert r.ok
     assert r.content == '123456789'
 
 
-def test_filters(data_builder, file_form, as_admin):
+def test_filters(data_builder, file_form, as_user, as_admin):
 
     project = data_builder.create_project()
     session = data_builder.create_session()
     acquisition = data_builder.create_acquisition()
     acquisition2 = data_builder.create_acquisition()
 
-    as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form(
+    # Add User to permissions
+    as_admin.post('/projects/' + project + '/permissions', json={'_id': 'user@user.com', 'access': 'admin'})
+
+    as_user.post('/acquisitions/' + acquisition + '/files', files=file_form(
         "test.csv", meta={'name': "test.csv", 'type': 'csv', 'tags': ['red', 'blue']}))
-    as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form(
+    as_user.post('/acquisitions/' + acquisition + '/files', files=file_form(
         'test.dicom', meta={'name': 'test.dicom', 'type': 'dicom', 'tags': ['red']}))
-    as_admin.post('/acquisitions/' + acquisition2 + '/files', files=file_form(
+    as_user.post('/acquisitions/' + acquisition2 + '/files', files=file_form(
         'test.nifti', meta={'name': 'test.nifti', 'type': 'nifti'}))
-    r = as_admin.get('/acquisitions/' + acquisition)
+    r = as_user.get('/acquisitions/' + acquisition)
     assert r.ok
 
     # Malformed filters
-    r = as_admin.post('/download', json={
+    r = as_user.post('/download', json={
         'optional': False,
         'filters': [
             {'tags': 'red'}
@@ -780,7 +806,7 @@ def test_filters(data_builder, file_form, as_admin):
     assert r.status_code == 400
 
     # No filters
-    r = as_admin.post('/download', json={
+    r = as_user.post('/download', json={
         'optional': False,
         'nodes': [
             {'level': 'session', '_id': session},
@@ -790,7 +816,7 @@ def test_filters(data_builder, file_form, as_admin):
     assert r.json()['file_cnt'] == 3
 
     # Filter by tags
-    r = as_admin.post('/download', json={
+    r = as_user.post('/download', json={
         'optional': False,
         'filters': [
             {'tags': {'+':['red']}}
@@ -803,7 +829,7 @@ def test_filters(data_builder, file_form, as_admin):
     assert r.json()['file_cnt'] == 2
 
     # Use filter aliases
-    r = as_admin.post('/download', json={
+    r = as_user.post('/download', json={
         'optional': False,
         'filters': [
             {'tags': {'plus':['red']}}
@@ -817,9 +843,9 @@ def test_filters(data_builder, file_form, as_admin):
     assert r.json()['file_cnt'] == 2
 
     # Filter by type
-    as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form(
+    as_user.post('/acquisitions/' + acquisition + '/files', files=file_form(
         "test", meta={'name': "test", 'tags': ['red', 'blue']}))
-    r = as_admin.post('/download', json={
+    r = as_user.post('/download', json={
         'optional': False,
         'filters': [
             {'types': {'+':['nifti']}}
@@ -830,7 +856,7 @@ def test_filters(data_builder, file_form, as_admin):
     })
     assert r.ok
     assert r.json()['file_cnt'] == 1
-    r = as_admin.post('/download', json={
+    r = as_user.post('/download', json={
         'optional': False,
         'filters': [
             {'types': {'+':['null']}}
@@ -860,16 +886,16 @@ def test_summary(data_builder, as_user, as_admin, file_form):
     # facilitate download filter tests:
     # acquisition: [], session: ['plus'], project: ['plus', 'minus']
     file_name = 'test.csv'
-    as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form(
+    as_user.post('/acquisitions/' + acquisition + '/files', files=file_form(
         file_name, meta={'name': file_name, 'type': 'csv'}))
 
-    as_admin.post('/acquisitions/' + acquisition2 + '/files', files=file_form(
+    as_user.post('/acquisitions/' + acquisition2 + '/files', files=file_form(
         file_name, meta={'name': file_name, 'type': 'csv'}))
 
-    as_admin.post('/sessions/' + session + '/files', files=file_form(
+    as_user.post('/sessions/' + session + '/files', files=file_form(
         file_name, meta={'name': file_name, 'type': 'csv', 'tags': ['plus']}))
 
-    as_admin.post('/projects/' + project + '/files', files=file_form(
+    as_user.post('/projects/' + project + '/files', files=file_form(
         file_name, meta={'name': file_name, 'type': 'csv', 'tags': ['plus', 'minus']}))
 
 
@@ -881,26 +907,26 @@ def test_summary(data_builder, as_user, as_admin, file_form):
 
     missing_object_id = '000000000000000000000000'
 
-    r = as_admin.post('/download/summary', json=[{"level":"project", "_id":project}])
+    r = as_user.post('/download/summary', json=[{"level":"project", "_id":project}])
     assert r.ok
     assert len(r.json()) == 1
     assert r.json().get("csv", {}).get("count",0) == 4
 
-    r = as_admin.post('/download/summary', json=[{"level":"session", "_id":session}])
+    r = as_user.post('/download/summary', json=[{"level":"session", "_id":session}])
     assert r.ok
     assert len(r.json()) == 1
     assert r.json().get("csv", {}).get("count",0) == 2
 
-    r = as_admin.post('/download/summary', json=[{"level":"acquisition", "_id":acquisition},{"level":"acquisition", "_id":acquisition2}])
+    r = as_user.post('/download/summary', json=[{"level":"acquisition", "_id":acquisition},{"level":"acquisition", "_id":acquisition2}])
     assert r.ok
     assert len(r.json()) == 1
     assert r.json().get("csv", {}).get("_id") == "csv"
     assert r.json().get("csv", {}).get("count",0) == 2
 
-    r = as_admin.post('/download/summary', json=[{"level":"group", "_id":missing_object_id}])
+    r = as_user.post('/download/summary', json=[{"level":"group", "_id":missing_object_id}])
     assert r.status_code == 400
 
-    r = as_admin.post('/sessions/' + session + '/analyses',  files=file_form(
+    r = as_user.post('/sessions/' + session + '/analyses',  files=file_form(
         file_name, meta={'label': 'test', 'outputs':[{'name':file_name}]}))
     assert r.ok
     analysis = r.json()['_id']

--- a/tests/integration_tests/python/test_groups.py
+++ b/tests/integration_tests/python/test_groups.py
@@ -7,9 +7,11 @@ def test_groups(as_user, as_admin, data_builder):
 
     group = data_builder.create_group()
     user_id = data_builder.create_user(_id='test-user@user.com')
+    r = as_admin.post('/groups/' + group + '/permissions', json={'_id': 'user@user.com', 'access': 'admin'})
+    assert r.ok
 
     # Able to find new group
-    r = as_admin.get('/groups/' + group)
+    r = as_user.get('/groups/' + group)
     assert r.ok
     initial_modified = r.json()['modified']
     created = r.json()['created']
@@ -33,11 +35,11 @@ def test_groups(as_user, as_admin, data_builder):
 
     # Able to change group label
     group_label = 'New group label'
-    r = as_admin.put('/groups/' + group, json={'label': group_label})
+    r = as_user.put('/groups/' + group, json={'label': group_label})
     assert r.ok
 
     # Get the group again to compare timestamps
-    r = as_admin.get('/groups/' + group)
+    r = as_user.get('/groups/' + group)
     assert r.ok
     second_modified = r.json()['modified']
     d1 = parse(first_modified)
@@ -46,16 +48,16 @@ def test_groups(as_user, as_admin, data_builder):
 
     # Try adding a tag with a slash
     tag_name = 'Grey/2'
-    r = as_admin.post('/groups/' + group + '/tags', json={'value': tag_name})
+    r = as_user.post('/groups/' + group + '/tags', json={'value': tag_name})
     assert r.status_code == 400
 
     # Add a tag to the group
     tag_name = 'Grey2'
-    r = as_admin.post('/groups/' + group + '/tags', json={'value': tag_name})
+    r = as_user.post('/groups/' + group + '/tags', json={'value': tag_name})
     assert r.ok
 
     # Get the group again to compare timestamps for the Add tag test groups
-    r = as_admin.get('/groups/' + group)
+    r = as_user.get('/groups/' + group)
     assert r.ok
     third_modified = r.json()['modified']
     d3 = parse(third_modified)
@@ -63,27 +65,27 @@ def test_groups(as_user, as_admin, data_builder):
 
     # Try editting the tag so that it includes a slash
     new_tag_name = 'B/rown'
-    r = as_admin.put('/groups/' + group + '/tags/' + tag_name, json={'value': new_tag_name})
+    r = as_user.put('/groups/' + group + '/tags/' + tag_name, json={'value': new_tag_name})
     assert r.status_code == 400
 
     # Edit the tag
     new_tag_name = 'Brown'
-    r = as_admin.put('/groups/' + group + '/tags/' + tag_name, json={'value': new_tag_name})
+    r = as_user.put('/groups/' + group + '/tags/' + tag_name, json={'value': new_tag_name})
     assert r.ok
 
     # Get the group again to compare timestamps for the Edit tag test groups
-    r = as_admin.get('/groups/' + group)
+    r = as_user.get('/groups/' + group)
     assert r.ok
     fourth_modified = r.json()['modified']
     d4 = parse(fourth_modified)
     assert d4 > d3
 
     # Delete the tag
-    r = as_admin.delete('/groups/' + group + '/tags/' + new_tag_name)
+    r = as_user.delete('/groups/' + group + '/tags/' + new_tag_name)
     assert r.ok
 
     # Get the group again to compare timestamps for the Delete tag test groups
-    r = as_admin.get('/groups/' + group)
+    r = as_user.get('/groups/' + group)
     assert r.ok
     fith_modified = r.json()['modified']
     d5 = parse(fith_modified)
@@ -91,11 +93,11 @@ def test_groups(as_user, as_admin, data_builder):
 
     # Add a permission to the group
     user = {'access': 'rw', '_id': user_id}
-    r = as_admin.post('/groups/' + group + '/permissions', json=user)
+    r = as_user.post('/groups/' + group + '/permissions', json=user)
     assert r.ok
 
     # Get the group again to compare timestamps for the Add permission test groups
-    r = as_admin.get('/groups/' + group)
+    r = as_user.get('/groups/' + group)
     assert r.ok
     six_modified = r.json()['modified']
     d6 = parse(six_modified)
@@ -103,7 +105,7 @@ def test_groups(as_user, as_admin, data_builder):
 
     # Edit a permission in the group
     user = {'access': 'ro', '_id': user_id}
-    r = as_admin.put('/groups/' + group + '/permissions/' + user['_id'], json=user)
+    r = as_user.put('/groups/' + group + '/permissions/' + user['_id'], json=user)
     assert r.ok
 
     # Get all permissions for each group
@@ -112,18 +114,18 @@ def test_groups(as_user, as_admin, data_builder):
     assert r.json()[0].get("permissions")[0].get("_id") == "admin@user.com"
 
     # Get the group again to compare timestamps for the Edit permission test groups
-    r = as_admin.get('/groups/' + group)
+    r = as_user.get('/groups/' + group)
     assert r.ok
     seven_modified = r.json()['modified']
     d7 = parse(seven_modified)
     assert d7 > d6
 
     # Delete a permission in the group
-    r = as_admin.delete('/groups/' + group + '/permissions/' + user['_id'])
+    r = as_user.delete('/groups/' + group + '/permissions/' + user['_id'])
     assert r.ok
 
     # Get the group again to compare timestamps for the Edit permission test groups
-    r = as_admin.get('/groups/' + group)
+    r = as_user.get('/groups/' + group)
     assert r.ok
     eight_modified = r.json()['modified']
     d8 = parse(eight_modified)
@@ -132,9 +134,16 @@ def test_groups(as_user, as_admin, data_builder):
     group2 = data_builder.create_group()
     r = as_admin.post('/groups/' + group2 + '/permissions', json={'access':'admin','_id':'user@user.com'})
     assert r.ok
+
+    # Test User can get group2
+    r = as_user.get('/groups/' + group2)
+    assert r.ok
+
+    # Test that group2 shows up in group list for user
     r = as_user.get('/groups')
     assert r.ok
-    assert len(r.json()) == 1
+    assert len(r.json()) == 2
+
     assert r.json()[0].get('permissions', []) != []
     r = as_admin.get('/groups')
     assert r.ok
@@ -149,10 +158,12 @@ def test_groups(as_user, as_admin, data_builder):
     assert r.json()['label'] == group_label
 
     # Test join=projects
-    project = data_builder.create_project()
+    project = data_builder.create_project(group=group2)
     r = as_admin.get('/groups', params={'join': 'projects'})
     assert r.ok
-    assert r.json()[0].get('projects')[0].get('_id') == project
+    for group in r.json():
+        if group["_id"] == group2:
+            assert group.get("projects")[0].get("_id") == project
 
 def test_groups_blacklist(as_admin):
     r = as_admin.post('/groups', json={'_id': 'unknown', 'label': 'Unknown group'})

--- a/tests/integration_tests/python/test_jobs.py
+++ b/tests/integration_tests/python/test_jobs.py
@@ -18,7 +18,7 @@ def test_jobs_access(as_user):
     r = as_user.get('/jobs/test-job/config.json')
     assert r.status_code == 403
 
-def test_jobs(data_builder, default_payload, as_public, as_user, as_admin, as_root, api_db, file_form):
+def test_jobs(data_builder, default_payload, as_public, as_user, as_admin, api_db, file_form):
     """
     Can be removed in favor of test_jobs_ask when /jobs/next is retired.
     """
@@ -99,7 +99,7 @@ def test_jobs(data_builder, default_payload, as_public, as_user, as_admin, as_ro
     job1_id = r.json()['_id']
 
     # get job
-    r = as_root.get('/jobs/' + job1_id)
+    r = as_admin.get('/jobs/' + job1_id)
     assert r.ok
 
     job = r.json()
@@ -119,7 +119,7 @@ def test_jobs(data_builder, default_payload, as_public, as_user, as_admin, as_ro
     r = as_admin.get('/jobs/' + job1_id + '/logs')
     assert r.ok
 
-    assert as_root.post('/projects/' + project + '/permissions', json={
+    assert as_admin.post('/projects/' + project + '/permissions', json={
         'access': 'admin',
         '_id': admin_id
     }).ok
@@ -141,7 +141,7 @@ def test_jobs(data_builder, default_payload, as_public, as_user, as_admin, as_ro
     assert r.status_code == 403
 
     # try to add job log to non-existent job
-    r = as_root.post('/jobs/000000000000000000000000/logs', json=job_logs)
+    r = as_admin.post('/jobs/000000000000000000000000/logs', json=job_logs)
     assert r.status_code == 404
 
     # get job log as text w/o logs
@@ -155,7 +155,7 @@ def test_jobs(data_builder, default_payload, as_public, as_user, as_admin, as_ro
     assert r.text == '<span class="fd--1">No logs were found for this job.</span>'
 
     # start job (Adds logs)
-    r = as_root.get('/jobs/next')
+    r = as_admin.get('/jobs/next')
     assert r.ok
     started_job = r.json()
     assert started_job['transitions']['running'] == started_job['modified']
@@ -214,7 +214,7 @@ def test_jobs(data_builder, default_payload, as_public, as_user, as_admin, as_ro
     })
     assert r.ok
 
-    r = as_root.get('/jobs/' + job1_id)
+    r = as_admin.get('/jobs/' + job1_id)
     assert r.ok
     updated_job = r.json()
     assert updated_job['profile']['versions']['engine'] == '9a12c5921a1d9206c2d82c0d1a60ebed3d55a338'
@@ -229,12 +229,16 @@ def test_jobs(data_builder, default_payload, as_public, as_user, as_admin, as_ro
     assert updated_job['profile']['executor']['swap_bytes'] == 31457280
 
     # add job log
-    r = as_root.post('/jobs/' + job1_id + '/logs', json=job_logs)
+    r = as_admin.post('/jobs/' + job1_id + '/logs', json=job_logs)
     assert r.ok
 
     # try to get job log of non-existent job
     r = as_admin.get('/jobs/000000000000000000000000/logs')
     assert r.status_code == 404
+
+    # try to get job logs without access to inputs
+    r = as_user.get('/jobs/' + job1_id + '/logs')
+    assert r.status_code == 403
 
     # get job log (non-empty)
     r = as_admin.get('/jobs/' + job1_id + '/logs')
@@ -242,7 +246,7 @@ def test_jobs(data_builder, default_payload, as_public, as_user, as_admin, as_ro
     assert len(r.json()['logs']) == 3
 
     # add same logs again (for testing text/html logs)
-    r = as_root.post('/jobs/' + job1_id + '/logs', json=job_logs)
+    r = as_admin.post('/jobs/' + job1_id + '/logs', json=job_logs)
     assert r.ok
 
     expected_job_logs = [{'fd': -1, 'msg': 'Gear Name: {}, Gear Version: {}\n'.format(job['gear_info']['name'], job['gear_info']['version'])}] + \
@@ -259,7 +263,7 @@ def test_jobs(data_builder, default_payload, as_public, as_user, as_admin, as_ro
     assert r.text == ''.join('<span class="fd-{fd}">{msg}</span>\n'.format(fd=log.get('fd'), msg=log.get('msg').replace('\n', '<br/>\n')) for log in expected_job_logs)
 
     # get job config
-    r = as_root.get('/jobs/' + job1_id + '/config.json')
+    r = as_admin.get('/jobs/' + job1_id + '/config.json')
     assert r.ok
 
     # try to cancel job w/o permission (different user)
@@ -301,34 +305,34 @@ def test_jobs(data_builder, default_payload, as_public, as_user, as_admin, as_ro
     assert r.status_code == 400
 
     # get next job - with nonexistent tag
-    r = as_root.get('/jobs/next', params={'tags': 'fake-tag'})
+    r = as_admin.get('/jobs/next', params={'tags': 'fake-tag'})
     assert r.status_code == 400
 
     # get next job - with excluding tag
-    r = as_root.get('/jobs/next', params={'tags': '!test-tag'})
+    r = as_admin.get('/jobs/next', params={'tags': '!test-tag'})
     assert r.status_code == 400
 
     # get next job - with excluding tag overlap
-    r = as_root.get('/jobs/next', params={'tags': ['test-tag', '!test-tag']})
+    r = as_admin.get('/jobs/next', params={'tags': ['test-tag', '!test-tag']})
     assert r.status_code == 400
 
     # get next job with peek
-    r = as_root.get('/jobs/next', params={'tags': 'test-tag', 'peek': True})
+    r = as_admin.get('/jobs/next', params={'tags': 'test-tag', 'peek': True})
     assert r.ok
     next_job_id_peek = r.json()['id']
 
     # get next job
-    r = as_root.get('/jobs/next', params={'tags': ['test-tag', '!fake-tag']})
+    r = as_admin.get('/jobs/next', params={'tags': ['test-tag', '!fake-tag']})
     assert r.ok
     next_job_id = r.json()['id']
     assert next_job_id == next_job_id_peek
 
     # set next job to failed
-    r = as_root.put('/jobs/' + next_job_id, json={'state': 'failed', 'failure_reason': 'gear_failure'})
+    r = as_admin.put('/jobs/' + next_job_id, json={'state': 'failed', 'failure_reason': 'gear_failure'})
     assert r.ok
 
-    # Get job and verify the 'failure' timestamp
-    r = as_root.get('/jobs/' + next_job_id)
+    # retry failed job
+    r = as_admin.get('/jobs/' + next_job_id)
     assert r.ok
     failed_job = r.json()
     assert failed_job['transitions']['failed'] == failed_job['modified']
@@ -395,7 +399,7 @@ def test_jobs(data_builder, default_payload, as_public, as_user, as_admin, as_ro
     r = as_admin.post('/jobs/add', json=job6)
     assert r.status_code == 500
 
-    assert as_root.delete('/gears/' + gear3).ok
+    assert as_admin.delete('/gears/' + gear3).ok
 
     # Attempt to set a malformed file reference as input
     job7 = copy.deepcopy(job_data)
@@ -436,7 +440,7 @@ def test_jobs(data_builder, default_payload, as_public, as_user, as_admin, as_ro
         "batch" : None,
     }
     api_db.jobs.insert_one(job_instance)
-    r = as_root.post('/jobs/reap')
+    r = as_admin.post('/jobs/reap')
     assert r.ok
     assert r.json().get('orphaned') == 1
     r = as_admin.get('/jobs/'+str(job_instance['_id'])+'/logs')
@@ -1358,7 +1362,7 @@ def test_analysis_job_creation_errors(data_builder, default_payload, as_admin, f
     assert r.status_code == 400
     assert len(as_admin.get('/sessions/' + session).json().get('analyses', [])) == 0
 
-def test_job_context(data_builder, default_payload, as_admin, as_root, file_form):
+def test_job_context(data_builder, default_payload, as_admin, file_form):
     # Dupe of test_queue.py
     gear_doc = default_payload['gear']['gear']
     gear_doc['inputs'] = {
@@ -1399,7 +1403,7 @@ def test_job_context(data_builder, default_payload, as_admin, as_root, file_form
     assert job1_label == 'job-name'
 
     # get job
-    r = as_root.get('/jobs/' + job1_id)
+    r = as_admin.get('/jobs/' + job1_id)
     assert r.ok
     r_job = r.json()
     r_inputs = r_job['config']['inputs']
@@ -1424,7 +1428,7 @@ def test_job_context(data_builder, default_payload, as_admin, as_root, file_form
     job2_id = r.json()['_id']
 
     # get job
-    r = as_root.get('/jobs/' + job2_id)
+    r = as_admin.get('/jobs/' + job2_id)
     assert r.ok
     r_job = r.json()
     r_inputs = r_job['config']['inputs']
@@ -1451,7 +1455,7 @@ def test_job_context(data_builder, default_payload, as_admin, as_root, file_form
     job3_id = r.json()['_id']
 
     # get job
-    r = as_root.get('/jobs/' + job3_id)
+    r = as_admin.get('/jobs/' + job3_id)
     assert r.ok
     r_job = r.json()
     r_inputs = r_job['config']['inputs']
@@ -1460,7 +1464,8 @@ def test_job_context(data_builder, default_payload, as_admin, as_root, file_form
     assert r_inputs['test_context_value']['found'] == True
     assert r_inputs['test_context_value']['value'] == { 'session_value': 3 }
 
-def test_job_api_key(data_builder, default_payload, as_public, as_admin, as_user, as_root, api_db, file_form):
+
+def test_job_api_key(data_builder, default_payload, as_public, as_admin, as_user, api_db, file_form):
     project = data_builder.create_project()
     acquisition = data_builder.create_acquisition()
     assert as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form('test.zip')).ok
@@ -1503,11 +1508,11 @@ def test_job_api_key(data_builder, default_payload, as_public, as_admin, as_user
     job_id = r.json()['_id']
 
     # get next job as admin
-    r = as_root.get('/jobs/next')
+    r = as_admin.get('/jobs/next')
     assert r.ok
 
     # get config
-    r = as_root.get('/jobs/'+ job_id +'/config.json')
+    r = as_admin.get('/jobs/'+ job_id +'/config.json')
     assert r.ok
     config = r.json()
 
@@ -1517,7 +1522,7 @@ def test_job_api_key(data_builder, default_payload, as_public, as_admin, as_user
     api_key = config['inputs']['api_key']['key']
 
     # check if job default label is empty string
-    r = as_root.get('/jobs/'+ job_id)
+    r = as_admin.get('/jobs/'+ job_id)
     assert r.json().get('label') == ""
 
     # ensure api_key works
@@ -1527,7 +1532,7 @@ def test_job_api_key(data_builder, default_payload, as_public, as_admin, as_user
     assert r.ok
 
     # complete job and ensure API key no longer works
-    r = as_root.put('/jobs/' + job_id, json={'state': 'complete'})
+    r = as_admin.put('/jobs/' + job_id, json={'state': 'complete'})
     assert r.ok
 
     r = as_job_key.get('/users/self')
@@ -1545,11 +1550,11 @@ def test_job_api_key(data_builder, default_payload, as_public, as_admin, as_user
     job_id = r.json()['_id']
 
     # get next job as admin
-    r = as_root.get('/jobs/next')
+    r = as_admin.get('/jobs/next')
     assert r.ok
 
     # get config
-    r = as_root.get('/jobs/'+ job_id +'/config.json')
+    r = as_admin.get('/jobs/'+ job_id +'/config.json')
     assert r.ok
     config = r.json()
 
@@ -1571,13 +1576,13 @@ def test_job_api_key(data_builder, default_payload, as_public, as_admin, as_user
     api_db.jobs.update_one({'_id': bson.ObjectId(job_id)}, {'$set': {'modified': datetime.datetime(1980, 1, 1)}})
 
     # reap orphans
-    r = as_root.post('/jobs/reap')
+    r = as_admin.post('/jobs/reap')
 
     # Make sure there is only one job that is pending
     assert api_db.jobs.count({'state': 'pending'}) == 1
 
     # get next job as admin
-    r = as_root.get('/jobs/next')
+    r = as_admin.get('/jobs/next')
     assert r.ok
     retried_job = r.json()
     retried_job_id = retried_job['id']
@@ -1593,7 +1598,7 @@ def test_job_api_key(data_builder, default_payload, as_public, as_admin, as_user
     assert found_config_uri
 
     # get config
-    r = as_root.get('/jobs/' + retried_job_id + '/config.json')
+    r = as_admin.get('/jobs/' + retried_job_id + '/config.json')
     assert r.ok
     config = r.json()
 
@@ -1609,7 +1614,7 @@ def test_job_api_key(data_builder, default_payload, as_public, as_admin, as_user
     assert r.ok
 
     # complete job and ensure API key no longer works
-    r = as_root.put('/jobs/' + retried_job_id, json={'state': 'complete'})
+    r = as_admin.put('/jobs/' + retried_job_id, json={'state': 'complete'})
     assert r.ok
 
     r = as_job_key.get('/users/self')
@@ -1630,9 +1635,9 @@ def test_job_api_key(data_builder, default_payload, as_public, as_admin, as_user
     job_id = r.json()['_id']
 
     # fail job and ensure API key no longer works
-    r = as_root.get('/jobs/next')
+    r = as_admin.get('/jobs/next')
     assert r.ok
-    r = as_root.put('/jobs/' + job_id, json={'state': 'failed'})
+    r = as_admin.put('/jobs/' + job_id, json={'state': 'failed'})
     assert r.ok
 
     # Retry it as the user
@@ -1640,16 +1645,17 @@ def test_job_api_key(data_builder, default_payload, as_public, as_admin, as_user
     assert r.ok
     retried_job_id = r.json()['_id']
 
-    r = as_root.get('/jobs/next')
+    r = as_admin.get('/jobs/next')
     assert r.ok
-    r = as_root.put('/jobs/' + retried_job_id, json={'state': 'failed'})
+    r = as_admin.put('/jobs/' + retried_job_id, json={'state': 'failed'})
     assert r.ok
 
     # Make sure admins can retry any job
     r = as_admin.post('/jobs/' + retried_job_id + '/retry')
     assert r.ok
 
-def test_job_tagging(data_builder, default_payload, as_admin, as_root, api_db, file_form):
+def test_job_tagging(data_builder, default_payload, as_admin, as_user, api_db, file_form):
+
     # Dupe of test_queue.py
     gear_doc = default_payload['gear']['gear']
     gear_name = 'gear-name'
@@ -1659,6 +1665,9 @@ def test_job_tagging(data_builder, default_payload, as_admin, as_root, api_db, f
     project = data_builder.create_project()
     session = data_builder.create_session()
     acquisition = data_builder.create_acquisition()
+
+    user_id = as_user.get('/users/self').json()['_id']
+    as_admin.post('/projects/' + project + '/permissions', json={'_id': user_id, 'access': 'admin'})
 
     # Test the gear name tag with auto job rule
     rule = {
@@ -1672,13 +1681,13 @@ def test_job_tagging(data_builder, default_payload, as_admin, as_root, api_db, f
     }
 
     # add project rule
-    r = as_admin.post('/projects/' + project + '/rules', json=rule)
+    r = as_user.post('/projects/' + project + '/rules', json=rule)
     assert r.ok
     rule_id = r.json()['_id']
 
     # create job
     # print gear_doc
-    assert as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form('test.csv')).ok
+    assert as_user.post('/acquisitions/' + acquisition + '/files', files=file_form('test.csv')).ok
 
     # Verify that job was created
     rule_jobs = [job for job in api_db.jobs.find({'gear_id': gear})]
@@ -1705,12 +1714,12 @@ def test_job_tagging(data_builder, default_payload, as_admin, as_root, api_db, f
     }
 
     # add job with explicit destination
-    r = as_admin.post('/jobs/add', json=job_data)
+    r = as_user.post('/jobs/add', json=job_data)
     assert r.ok
     manual_job_id = r.json()['_id']
 
     # get job
-    r = as_root.get('/jobs/' + manual_job_id)
+    r = as_admin.get('/jobs/' + manual_job_id)
     assert r.ok
 
     # Make sure that the job has the tag of the gear name
@@ -1718,7 +1727,7 @@ def test_job_tagging(data_builder, default_payload, as_admin, as_root, api_db, f
     assert gear_name in manual_job['tags']
 
     # Test the gear name tag with job-based analysis
-    r = as_admin.post('/sessions/' + session + '/analyses', json={
+    r = as_user.post('/sessions/' + session + '/analyses', json={
         'label': 'online',
         'job': job_data
     })
@@ -1726,19 +1735,19 @@ def test_job_tagging(data_builder, default_payload, as_admin, as_root, api_db, f
     analysis_id = r.json()['_id']
 
     # Verify job was created with it
-    r = as_admin.get('/analyses/' + analysis_id)
+    r = as_user.get('/analyses/' + analysis_id)
     assert r.ok
     analysis_job_id = r.json().get('job')
 
     # get job
-    r = as_root.get('/jobs/' + analysis_job_id)
+    r = as_admin.get('/jobs/' + analysis_job_id)
     assert r.ok
 
     # Make sure that the job has the tag of the gear name
     analysis_job = r.json()
     assert gear_name in analysis_job['tags']
 
-def test_job_reap_ticketed_jobs(data_builder, default_payload, as_drone, as_admin, as_root, api_db, file_form):
+def test_job_reap_ticketed_jobs(data_builder, default_payload, as_drone, as_admin, api_db, file_form):
     acquisition = data_builder.create_acquisition()
     assert as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form('test.zip')).ok
 
@@ -1801,7 +1810,7 @@ def test_job_reap_ticketed_jobs(data_builder, default_payload, as_drone, as_admi
     api_db.jobs.update_one({'_id': bson.ObjectId(job_id2)}, {'$set': {'modified': datetime.datetime(1980, 1, 1)}})
 
     # reap orphans
-    r = as_root.post('/jobs/reap')
+    r = as_admin.post('/jobs/reap')
 
     # Make sure that exactly 1 job got restarted
     assert api_db.jobs.count({'state': 'pending'}) == 1
@@ -1880,7 +1889,7 @@ def test_job_requests(randstr, default_payload, data_builder, as_admin, as_drone
     for request_input in not_url_job_request_inputs:
         assert request_input.get('type')
 
-def test_scoped_job_api_key(randstr, data_builder, default_payload, as_public, as_admin, as_root, file_form):
+def test_scoped_job_api_key(randstr, data_builder, default_payload, as_public, as_admin, file_form):
     gear_doc = default_payload['gear']['gear']
 
     rw_gear_name = randstr()
@@ -1938,12 +1947,12 @@ def test_scoped_job_api_key(randstr, data_builder, default_payload, as_public, a
     assert as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form('test.csv')).ok
 
     # get next job as admin
-    r = as_root.get('/jobs/next')
+    r = as_admin.get('/jobs/next')
     assert r.ok
     job_id = r.json()['id']
 
     # get config
-    r = as_root.get('/jobs/' + job_id + '/config.json')
+    r = as_admin.get('/jobs/' + job_id + '/config.json')
     assert r.ok
     config = r.json()
 
@@ -2045,7 +2054,7 @@ def test_scoped_job_api_key(randstr, data_builder, default_payload, as_public, a
     assert r.status_code == 403
 
     # fail job and ensure API key no longer works
-    r = as_root.put('/jobs/' + job_id, json={'state': 'failed'})
+    r = as_admin.put('/jobs/' + job_id, json={'state': 'failed'})
     assert r.ok
 
     r = as_job_key.get('/projects/' + project)
@@ -2056,7 +2065,7 @@ def test_scoped_job_api_key(randstr, data_builder, default_payload, as_public, a
     assert r.ok
 
     # get next job as admin
-    r = as_root.get('/jobs/next')
+    r = as_admin.get('/jobs/next')
     assert r.ok
     retried_job_id = r.json()['id']
 
@@ -2065,7 +2074,7 @@ def test_scoped_job_api_key(randstr, data_builder, default_payload, as_public, a
     assert r.status_code == 401
 
     # get config
-    r = as_root.get('/jobs/' + retried_job_id + '/config.json')
+    r = as_admin.get('/jobs/' + retried_job_id + '/config.json')
     assert r.ok
     config = r.json()
 
@@ -2078,7 +2087,7 @@ def test_scoped_job_api_key(randstr, data_builder, default_payload, as_public, a
     r = as_job_key.get('/projects/' + project)
     assert r.ok
 
-def test_retry_jobs(data_builder, default_payload, as_admin, as_user, as_root, as_drone, file_form):
+def test_retry_jobs(data_builder, default_payload, as_admin, as_user, as_drone, file_form):
     # Not testing sdk jobs here, those are tested in the test_api_jobs
     gear_doc = default_payload['gear']['gear']
     gear_doc['inputs'] = {
@@ -2120,16 +2129,16 @@ def test_retry_jobs(data_builder, default_payload, as_admin, as_user, as_root, a
     job0_id = r.json()['_id']
 
     # get job0
-    r = as_root.get('/jobs/' + job0_id)
+    r = as_admin.get('/jobs/' + job0_id)
     assert r.ok
     job0 = r.json()
 
     # start job0 (Adds logs)
-    r = as_root.get('/jobs/next')
+    r = as_admin.get('/jobs/next')
     assert r.ok
 
     # set job0 to failed
-    r = as_root.put('/jobs/' + job0_id, json={'state': 'failed'})
+    r = as_admin.put('/jobs/' + job0_id, json={'state': 'failed'})
     assert r.ok
 
     # retry failed job0 w/o admin as job1
@@ -2138,17 +2147,17 @@ def test_retry_jobs(data_builder, default_payload, as_admin, as_user, as_root, a
     job1_id = r.json()['_id']
 
     # try retry failed job0 as job1 again
-    r = as_root.post('/jobs/' + job0_id + '/retry')
+    r = as_admin.post('/jobs/' + job0_id + '/retry')
     assert r.status_code == 500
 
     # get job0 retried time
-    r = as_root.get('/jobs/' + job0_id)
+    r = as_admin.get('/jobs/' + job0_id)
     assert r.ok
     job0_retried_time = r.json().get('retried')
     assert job0_retried_time
 
     # get job1
-    r = as_root.get('/jobs/' + job1_id)
+    r = as_admin.get('/jobs/' + job1_id)
     assert r.ok
     job1 = r.json()
 
@@ -2163,10 +2172,9 @@ def test_retry_jobs(data_builder, default_payload, as_admin, as_user, as_root, a
     assert r.ok
 
     # set job1 to failed
-    r = as_root.put('/jobs/' + job1_id, json={'state': 'failed'})
+    r = as_admin.put('/jobs/' + job1_id, json={'state': 'failed'})
     assert r.ok
 
-    # retry failed job1 w/o root as job2
     r = as_admin.post('/jobs/' + job1_id + '/retry')
     assert r.ok
 
@@ -2180,23 +2188,23 @@ def test_retry_jobs(data_builder, default_payload, as_admin, as_user, as_root, a
     assert r.ok
 
     # try retry runnning job2 as job3
-    r = as_root.post('/jobs/' + job2_id + '/retry')
+    r = as_admin.post('/jobs/' + job2_id + '/retry')
     assert r.status_code == 400
 
     # try retry runnning job2 as job3 ignoring state
-    r = as_root.post('/jobs/' + job2_id + '/retry', params={'ignoreState': True})
+    r = as_admin.post('/jobs/' + job2_id + '/retry', params={'ignoreState': True})
     assert r.status_code == 400
 
     # set job2 to complete
-    r = as_root.put('/jobs/' + job2_id, json={'state': 'complete'})
+    r = as_admin.put('/jobs/' + job2_id, json={'state': 'complete'})
     assert r.ok
 
     # try retry complete job2 as job3
-    r = as_root.post('/jobs/' + job2_id + '/retry')
+    r = as_admin.post('/jobs/' + job2_id + '/retry')
     assert r.status_code == 400
 
     # retry complete job2 as job3
-    r = as_root.post('/jobs/' + job2_id + '/retry', params={'ignoreState': True})
+    r = as_admin.post('/jobs/' + job2_id + '/retry', params={'ignoreState': True})
     assert r.ok
 
     # get job3 as admin
@@ -2205,7 +2213,7 @@ def test_retry_jobs(data_builder, default_payload, as_admin, as_user, as_root, a
     job3_id = r.json()['id']
 
     # set job3 to failed
-    r = as_root.put('/jobs/' + job3_id, json={'state': 'failed'})
+    r = as_admin.put('/jobs/' + job3_id, json={'state': 'failed'})
     assert r.ok
 
     # Delete input file
@@ -2213,7 +2221,7 @@ def test_retry_jobs(data_builder, default_payload, as_admin, as_user, as_root, a
     assert r.ok
 
     # try retry failed job3
-    r = as_root.post('/jobs/' + job3_id + '/retry')
+    r = as_admin.post('/jobs/' + job3_id + '/retry')
     assert r.status_code == 404
 
     # Use session input file, but delete destination acquisition
@@ -2231,11 +2239,11 @@ def test_retry_jobs(data_builder, default_payload, as_admin, as_user, as_root, a
     job4_id = r.json()['_id']
 
     # start job3 (Adds logs)
-    r = as_root.get('/jobs/next')
+    r = as_admin.get('/jobs/next')
     assert r.ok
 
     # set job4 to failed
-    r = as_root.put('/jobs/' + job4_id, json={'state': 'failed'})
+    r = as_admin.put('/jobs/' + job4_id, json={'state': 'failed'})
     assert r.ok
 
     # Delete input file
@@ -2243,7 +2251,7 @@ def test_retry_jobs(data_builder, default_payload, as_admin, as_user, as_root, a
     assert r.ok
 
     # try retry failed job4 as job5
-    r = as_root.post('/jobs/' + job4_id + '/retry')
+    r = as_admin.post('/jobs/' + job4_id + '/retry')
     assert r.status_code == 404
 
 def test_config_values(data_builder, default_payload, as_admin, file_form):
@@ -2340,7 +2348,7 @@ def test_config_values(data_builder, default_payload, as_admin, file_form):
     r = as_admin.post('/jobs/add', json=job_data)
     assert r.ok
 
-def test_job_detail(data_builder, default_payload, as_admin, as_root, as_user, as_drone, as_public, file_form):
+def test_job_detail(data_builder, default_payload, as_admin, as_user, as_drone, as_public, file_form):
     # Dupe of test_queue.py
     gear_doc = default_payload['gear']['gear']
     gear_doc['inputs'] = {
@@ -2398,7 +2406,7 @@ def test_job_detail(data_builder, default_payload, as_admin, as_root, as_user, a
     assert r.ok
     job = r.json()['_id']
 
-    r = as_root.get('/jobs/next')
+    r = as_admin.get('/jobs/next')
     assert r.ok
     started_job = r.json()
     assert started_job['id'] == job

--- a/tests/integration_tests/python/test_notes.py
+++ b/tests/integration_tests/python/test_notes.py
@@ -1,36 +1,40 @@
-def test_notes(data_builder, as_admin):
+def test_notes(data_builder, as_user, as_admin):
     project = data_builder.create_project()
+    uid = as_user.get('/users/self').json()['_id']
+
+    r = as_admin.post('/projects/' + project + '/permissions', json={'_id': uid, 'access': 'rw'})
+    assert r.ok
 
     # Add a note
     note_text = 'test note'
-    r = as_admin.post('/projects/' + project + '/notes', json={'text': note_text})
+    r = as_user.post('/projects/' + project + '/notes', json={'text': note_text})
     assert r.ok
 
     # Verify note is present in project
-    r = as_admin.get('/projects/' + project)
+    r = as_user.get('/projects/' + project)
     assert r.ok
     assert len(r.json()['notes']) == 1
     note = r.json()['notes'][0]['_id']
 
-    r = as_admin.get('/projects/' + project + '/notes/' + note)
+    r = as_user.get('/projects/' + project + '/notes/' + note)
     assert r.ok
     assert r.json()['text'] == note_text
 
     # Modify note
     note_text_2 = 'modified note'
-    r = as_admin.put('/projects/' + project + '/notes/' + note, json={'text': note_text_2})
+    r = as_user.put('/projects/' + project + '/notes/' + note, json={'text': note_text_2})
     assert r.ok
 
     # Verify modified note
-    r = as_admin.get('/projects/' + project + '/notes/' + note)
+    r = as_user.get('/projects/' + project + '/notes/' + note)
     assert r.ok
     assert r.json()['text'] == note_text_2
 
     # Delete note
-    r = as_admin.delete('/projects/' + project + '/notes/' + note)
+    r = as_user.delete('/projects/' + project + '/notes/' + note)
     assert r.ok
 
-    r = as_admin.get('/projects/' + project + '/notes/' + note)
+    r = as_user.get('/projects/' + project + '/notes/' + note)
     assert r.status_code == 404
 
 

--- a/tests/integration_tests/python/test_resolver.py
+++ b/tests/integration_tests/python/test_resolver.py
@@ -49,7 +49,12 @@ def test_resolver(data_builder, as_admin, as_user, as_public, file_form):
 
     # resolve root (1 group)
     group = data_builder.create_group()
-    r = as_admin.post('/resolve', json={'path': []})
+
+    uid = as_user.get('/users/self').json()['_id']
+    r = as_admin.post('/groups/' + group + '/permissions', json={'_id': uid, 'access': 'admin'})
+    assert r.ok
+
+    r = as_user.post('/resolve', json={'path': []})
     result = r.json()
     assert r.ok
     assert result['path'] == []
@@ -60,7 +65,9 @@ def test_resolver(data_builder, as_admin, as_user, as_public, file_form):
     assert r.status_code == 404
 
     # GROUP
-    # try to resolve root/group as different (and non-root) user
+    # try to resolve root/group without permission
+    r = as_admin.delete('/groups/' + group + '/permissions/' + uid)
+    assert r.ok
     r = as_user.post('/resolve', json={'path': [group]})
     assert r.status_code == 403
 

--- a/tests/integration_tests/python/test_rules.py
+++ b/tests/integration_tests/python/test_rules.py
@@ -244,6 +244,13 @@ def test_site_rules_copied_to_new_projects(randstr, data_builder, file_form, as_
             project_2 = p['_id']
             break
 
+    # Find newly created project id using exhaustive
+    projects = as_admin.get('/projects', params={'exhaustive': True}).json()
+    for p in projects:
+        if p['label'] == 'test_project':
+            project_2 = p['_id']
+            break
+
     assert project_2
     r = as_admin.get('/projects/'+project_2+'/rules')
     assert r.ok
@@ -480,7 +487,7 @@ def test_project_rules(randstr, data_builder, file_form, as_root, as_admin, with
         }
     }
 
-    r = as_root.post('/engine',
+    r = as_admin.post('/engine',
         params={'level': 'project', 'id': project},
         files=file_form(meta=metadata)
     )
@@ -528,7 +535,7 @@ def test_project_rules(randstr, data_builder, file_form, as_root, as_admin, with
     assert r.ok
 
 
-def test_context_input_rule(randstr, data_builder, default_payload, api_db, as_admin, as_root, file_form):
+def test_context_input_rule(randstr, data_builder, default_payload, api_db, as_admin, file_form):
     project = data_builder.create_project()
     session = data_builder.create_session(project=project)
     acquisition = data_builder.create_acquisition(session=session)
@@ -546,7 +553,7 @@ def test_context_input_rule(randstr, data_builder, default_payload, api_db, as_a
         }
     }
 
-    r = as_root.post('/gears/' + gear_name, json=gear_doc)
+    r = as_admin.post('/gears/' + gear_name, json=gear_doc)
     assert r.ok
     gear = r.json()['_id']
 
@@ -614,7 +621,7 @@ def test_context_input_rule(randstr, data_builder, default_payload, api_db, as_a
     assert project_job['config']['inputs']['A']['found'] == False
 
     # Cleanup
-    r = as_root.delete('/gears/' + gear)
+    r = as_admin.delete('/gears/' + gear)
     assert r.ok
 
     # must remove jobs manually because gears were added manually

--- a/tests/integration_tests/python/test_tags.py
+++ b/tests/integration_tests/python/test_tags.py
@@ -1,5 +1,7 @@
-def test_tags(data_builder, as_admin):
+def test_tags(data_builder, as_admin, as_user):
     project = data_builder.create_project()
+    r = as_admin.post('/projects/' + project + '/permissions', json={'_id': 'user@user.com', 'access': 'rw'})
+    assert r.ok
 
     tag = 'test_tag'
     new_tag = 'new_test_tag'
@@ -14,56 +16,56 @@ def test_tags(data_builder, as_admin):
     short_tag_path = tags_path + '/' + short_tag
 
     # Add tag and verify
-    r = as_admin.get(tag_path)
+    r = as_user.get(tag_path)
     assert r.status_code == 404
-    r = as_admin.post(tags_path, json={'value': tag})
+    r = as_user.post(tags_path, json={'value': tag})
     assert r.ok
-    r = as_admin.get(tag_path)
+    r = as_user.get(tag_path)
     assert r.ok
     assert r.json() == tag
 
     # Add new tag and verify
-    r = as_admin.post(tags_path, json={'value': new_tag})
+    r = as_user.post(tags_path, json={'value': new_tag})
     assert r.ok
     # Add a duplicate tag, returns 404
-    r = as_admin.post(tags_path, json={'value': new_tag})
+    r = as_user.post(tags_path, json={'value': new_tag})
     assert r.status_code == 409
-    r = as_admin.get(new_tag_path)
+    r = as_user.get(new_tag_path)
     assert r.ok
     assert r.json() == new_tag
 
     # Add short tag and verify
-    r = as_admin.post(tags_path, json={'value': short_tag})
+    r = as_user.post(tags_path, json={'value': short_tag})
     assert r.ok
     # Add too long tag and verify
-    r = as_admin.post(tags_path, json={'value': too_long_tag})
+    r = as_user.post(tags_path, json={'value': too_long_tag})
     assert r.status_code == 400
 
     # Attempt to update tag, returns 404
-    r = as_admin.put(tag_path, json={'value': new_tag})
+    r = as_user.put(tag_path, json={'value': new_tag})
     assert r.status_code == 404
 
     # Update existing tag to other_tag
-    r = as_admin.get(other_tag_path)
+    r = as_user.get(other_tag_path)
     assert r.status_code == 404
-    r = as_admin.put(tag_path, json={'value': other_tag})
+    r = as_user.put(tag_path, json={'value': other_tag})
     assert r.ok
-    r = as_admin.get(other_tag_path)
+    r = as_user.get(other_tag_path)
     assert r.ok
     assert r.json() == other_tag
-    r = as_admin.get(tag_path)
+    r = as_user.get(tag_path)
     assert r.status_code == 404
 
     # Cleanup
-    r = as_admin.delete(other_tag_path)  # url for 'DELETE' is the same as the one for 'GET'
+    r = as_user.delete(other_tag_path)  # url for 'DELETE' is the same as the one for 'GET'
     assert r.ok
-    r = as_admin.get(other_tag_path)
+    r = as_user.get(other_tag_path)
     assert r.status_code == 404
-    r = as_admin.delete(new_tag_path)  # url for 'DELETE' is the same as the one for 'GET'
+    r = as_user.delete(new_tag_path)  # url for 'DELETE' is the same as the one for 'GET'
     assert r.ok
-    r = as_admin.get(new_tag_path)
+    r = as_user.get(new_tag_path)
     assert r.status_code == 404
-    r = as_admin.delete(short_tag_path)  # url for 'DELETE' is the same as the one for 'GET'
+    r = as_user.delete(short_tag_path)  # url for 'DELETE' is the same as the one for 'GET'
     assert r.ok
-    r = as_admin.get(short_tag_path)
+    r = as_user.get(short_tag_path)
     assert r.status_code == 404

--- a/tests/integration_tests/python/test_users.py
+++ b/tests/integration_tests/python/test_users.py
@@ -1,4 +1,4 @@
-def test_users(data_builder, as_root, as_admin, as_user, as_public):
+def test_users(data_builder, as_admin, as_user, as_public):
     # List users
     r = as_user.get('/users')
     assert r.ok
@@ -13,7 +13,7 @@ def test_users(data_builder, as_root, as_admin, as_user, as_public):
     user_id = r.json()['_id']
 
     # Get self as admin
-    r = as_root.get('/users/self')
+    r = as_admin.get('/users/self')
     assert r.ok
     admin_id = r.json()['_id']
     assert admin_id != user_id
@@ -31,7 +31,7 @@ def test_users(data_builder, as_root, as_admin, as_user, as_public):
     assert r.status_code == 404
 
     # Try adding new user missing required attr
-    r = as_root.post('/users', json={
+    r = as_admin.post('/users', json={
         '_id': 'jane.doe@gmail.com',
         'lastname': 'Doe',
         'email': 'jane.doe@gmail.com',
@@ -41,13 +41,13 @@ def test_users(data_builder, as_root, as_admin, as_user, as_public):
 
     # Add new user
     new_user_id = 'new@user.com'
-    r = as_root.post('/users', json={
+    r = as_admin.post('/users', json={
         '_id': new_user_id,
         'firstname': 'New',
         'lastname': 'User',
     })
     assert r.ok
-    r = as_root.get('/users/' + new_user_id)
+    r = as_admin.get('/users/' + new_user_id)
     assert r.ok
 
     # Add new user as admin
@@ -58,7 +58,7 @@ def test_users(data_builder, as_root, as_admin, as_user, as_public):
         'lastname': 'User2',
     })
     assert r.ok
-    r = as_root.get('/users/' + new_user_id)
+    r = as_admin.get('/users/' + new_user_id)
     assert r.ok
 
     #Get another user as user
@@ -74,15 +74,15 @@ def test_users(data_builder, as_root, as_admin, as_user, as_public):
     assert r.ok
 
     # Try to update non-existent user
-    r = as_root.put('/users/nonexistent@user.com', json={'firstname': 'Realname'})
+    r = as_admin.put('/users/nonexistent@user.com', json={'firstname': 'Realname'})
     assert r.status_code == 404
 
     # Try empty update
-    r = as_root.put('/users/' + new_user_id, json={})
+    r = as_admin.put('/users/' + new_user_id, json={})
     assert r.status_code == 400
 
     # Update existing user
-    r = as_root.put('/users/' + new_user_id, json={'firstname': 'Realname'})
+    r = as_admin.put('/users/' + new_user_id, json={'firstname': 'Realname'})
     assert r.ok
     assert r.json()['modified'] == 1
 
@@ -108,11 +108,11 @@ def test_users(data_builder, as_root, as_admin, as_user, as_public):
         assert p['_id'] != new_user_id_admin
 
     # Try to delete non-existent user
-    r = as_root.delete('/users/nonexistent@user.com')
+    r = as_admin.delete('/users/nonexistent@user.com')
     assert r.status_code == 404
 
     # Delete user
-    r = as_root.delete('/users/' + new_user_id)
+    r = as_admin.delete('/users/' + new_user_id)
     assert r.ok
 
     # Delete user
@@ -121,25 +121,25 @@ def test_users(data_builder, as_root, as_admin, as_user, as_public):
 
     # Test HTTPS enforcement on avatar urls
     new_user_id = 'new@user.com'
-    r = as_root.post('/users', json={
+    r = as_admin.post('/users', json={
         '_id': new_user_id,
         'firstname': 'New',
         'lastname': 'User',
     })
     assert r.ok
-    r = as_root.get('/users/' + new_user_id)
+    r = as_admin.get('/users/' + new_user_id)
     assert r.ok
 
-    r = as_root.put('/users/' + new_user_id, json={'avatar': 'https://lh3.googleusercontent.com/-XdUIqdMkCWA/AAAAAAAAAAI/AAAAAAAAAAA/4252rscbv5M/photo.jpg'})
-    r = as_root.get('/users/' + new_user_id)
+    r = as_admin.put('/users/' + new_user_id, json={'avatar': 'https://lh3.googleusercontent.com/-XdUIqdMkCWA/AAAAAAAAAAI/AAAAAAAAAAA/4252rscbv5M/photo.jpg'})
+    r = as_admin.get('/users/' + new_user_id)
     assert r.json()['avatar'] == 'https://lh3.googleusercontent.com/-XdUIqdMkCWA/AAAAAAAAAAI/AAAAAAAAAAA/4252rscbv5M/photo.jpg'
 
-    r = as_root.put('/users/' + new_user_id, json={'avatar': 'http://media.nomadicmatt.com/maldivestop001.jpg', 'avatars': {'custom': 'http://media.nomadicmatt.com/maldivestop001.jpg', 'provider': 'https://lh3.googleusercontent.com/-XdUIqdMkCWA/AAAAAAAAAAI/AAAAAAAAAAA/4252rscbv5M/photo.jpg'}})
+    r = as_admin.put('/users/' + new_user_id, json={'avatar': 'http://media.nomadicmatt.com/maldivestop001.jpg', 'avatars': {'custom': 'http://media.nomadicmatt.com/maldivestop001.jpg', 'provider': 'https://lh3.googleusercontent.com/-XdUIqdMkCWA/AAAAAAAAAAI/AAAAAAAAAAA/4252rscbv5M/photo.jpg'}})
     assert r.status_code == 400
-    r = as_root.get('/users/' + new_user_id)
+    r = as_admin.get('/users/' + new_user_id)
     assert r.json()['avatar'] != 'http://media.nomadicmatt.com/maldivestop001.jpg'
 
-    r = as_root.delete('/users/' + new_user_id)
+    r = as_admin.delete('/users/' + new_user_id)
     assert r.ok
 
 def test_generate_api_key(data_builder, as_public):

--- a/tests/unit_tests/python/test_auth_handlers.py
+++ b/tests/unit_tests/python/test_auth_handlers.py
@@ -7,10 +7,9 @@ from api.web.errors import APIPermissionException
 from pprint import pprint
 
 class MockRequestHandler(object):
-    def __init__(self, method, uid, superuser_request=False, public_request=False, user_is_admin=False):
+    def __init__(self, method, uid, public_request=False, user_is_admin=False):
         self.method = method
         self.uid = uid
-        self.superuser_request = superuser_request
         self.public_request = public_request
         self.user_is_admin = user_is_admin
 
@@ -41,7 +40,7 @@ private_data_view = {}
 
 def test_any_referer_with_site():
     uid = 'user@user.com'
-    
+
     # Public access
     referer = curry_referer(any_referer, container=public_data_view, parent_container='site')
     verify_has_access('GET', uid, referer)
@@ -81,8 +80,8 @@ def test_any_referer_with_user():
     verify_has_access('PUT', uid, referer)
 
     # Private access, superuser
-    verify_has_access('GET', uid2, referer, superuser_request=True)
-    verify_has_access('PUT', uid2, referer, superuser_request=True)
+    verify_has_access('GET', uid2, referer, user_is_admin=True)
+    verify_has_access('PUT', uid2, referer, user_is_admin=True)
 
 def test_any_referer_with_group():
     uid = 'user@user.com'
@@ -117,8 +116,8 @@ def test_any_referer_with_group():
     verify_has_no_access('PUT', uid4, referer)
 
     # Public access, superuser
-    verify_has_access('GET', uid4, referer, superuser_request=True)
-    verify_has_access('PUT', uid4, referer, superuser_request=True)
+    verify_has_access('GET', uid4, referer, user_is_admin=True)
+    verify_has_access('PUT', uid4, referer, user_is_admin=True)
 
     # Private access, admin user
     referer = curry_referer(any_referer, container=private_data_view, parent_container=parent_container)
@@ -138,8 +137,8 @@ def test_any_referer_with_group():
     verify_has_no_access('PUT', uid4, referer)
 
     # Private access, superuser
-    verify_has_access('GET', uid4, referer, superuser_request=True)
-    verify_has_access('PUT', uid4, referer, superuser_request=True)
+    verify_has_access('GET', uid4, referer, user_is_admin=True)
+    verify_has_access('PUT', uid4, referer, user_is_admin=True)
 
 def test_any_referer_with_container():
     uid = 'user@user.com'
@@ -174,8 +173,8 @@ def test_any_referer_with_container():
     verify_has_no_access('PUT', uid4, referer)
 
     # Public access, superuser
-    verify_has_access('GET', uid4, referer, superuser_request=True)
-    verify_has_access('PUT', uid4, referer, superuser_request=True)
+    verify_has_access('GET', uid4, referer, user_is_admin=True)
+    verify_has_access('PUT', uid4, referer, user_is_admin=True)
 
     # Private access, admin user
     referer = curry_referer(any_referer, container=private_data_view, parent_container=parent_container)
@@ -195,6 +194,6 @@ def test_any_referer_with_container():
     verify_has_no_access('PUT', uid4, referer)
 
     # Private access, superuser
-    verify_has_access('GET', uid4, referer, superuser_request=True)
-    verify_has_access('PUT', uid4, referer, superuser_request=True)
+    verify_has_access('GET', uid4, referer, user_is_admin=True)
+    verify_has_access('PUT', uid4, referer, user_is_admin=True)
 


### PR DESCRIPTION
### Changes
Site admin can do everything root mode does
  - slight exception for GET list (root=true or exhaustive=true needed to return entire list regardless of permissions)


### Test Plan
Integration tests
  - Tested that as_admin and as_root do the same thing (When calling get_all used the exhaustive flag)
  - Lowered the testing level to user with admin access on the group/project in order to test the auth layer (admin now skips it like root)

Manual tests
  - Can see all projects with root=true (can also use exhaustive=true)
  - Api calls returns single project without root=true (Frontend blocks it out)
  - Can upload to projects without root-true or permissions as long as user is site admin

This is not a breaking change to the frontend
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
