### PR TITLE
Fix Dockerfile - COPY py bins from /usr/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN set -eux \
         libffi-dev \
         linux-headers \
         openssl-dev \
-        py2-pip \
-        python2-dev \
+        py-pip \
+        python-dev \
         su-exec \
         uwsgi-http \
         uwsgi-python \
@@ -62,7 +62,7 @@ RUN set -eux \
     && apk add --no-cache \
         mongodb \
     && mkdir -p /data/db
-COPY --from=dist /usr/lib/python2.7 /usr/lib/python2.7
+COPY --from=dist /usr /usr
 COPY tests/requirements.txt /var/scitran/code/api/tests/requirements.txt
 RUN set -eux \
     && pip install --requirement /var/scitran/code/api/tests/requirements.txt

--- a/docker/uwsgi-config.ini
+++ b/docker/uwsgi-config.ini
@@ -16,6 +16,5 @@ exec-asap = (rm -rf /tmp/prometheus; mkdir -p /tmp/prometheus) || true
 
 # Start the metrics mule process, and assign it to a farm
 # See: https://uwsgi-docs.readthedocs.io/en/latest/Mules.html
-mule = /var/scitran/code/api/api/metrics/mule.py
+mule = api.metrics.mule
 farm = metrics:1
-


### PR DESCRIPTION
While investigating the broken coreplus:latest, I found that copying `/usr/lib/python2.7` in the `Dockerfile` (since alpine) is not feature-complete, as python binaries (eg. `ipython`, which is installed for ops reasons in prod, too) are put under `/usr/bin`. Now copying whole `/usr`.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
