### PR TITLE
Simplify reaper project creation

### DIFF
--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -11,9 +11,10 @@ from ..dao.containerstorage import AnalysisStorage
 from ..jobs.jobs import Job
 from ..jobs.queue import Queue
 from ..web import base
-from ..web.errors import APIPermissionException, InputValidationException
+from ..web.errors import APIPermissionException
 from ..web.request import log_access, AccessType
 
+PROJECT_BLACKLIST = ['Unknown', 'Unsorted']
 
 class ContainerHandler(base.RequestHandler):
     """
@@ -281,8 +282,8 @@ class ContainerHandler(base.RequestHandler):
             payload['permissions'] = [{'_id': self.uid, 'access': 'admin'}] if self.uid else []
 
             # Unsorted projects are reserved for reaper uploads
-            if payload.get('label') == 'Unsorted':
-                raise InputValidationException("{} is a reserved project label".format(payload.get('label')))
+            if payload['label'] in PROJECT_BLACKLIST:
+                self.abort(400, 'The project "{}" can\'t be created as it is integral within the API'.format(payload['label']))
         else:
             payload['permissions'] = parent_container.get('permissions', [])
         # Created and modified timestamps are added here to the payload

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -11,7 +11,7 @@ from ..dao.containerstorage import AnalysisStorage
 from ..jobs.jobs import Job
 from ..jobs.queue import Queue
 from ..web import base
-from ..web.errors import APIPermissionException
+from ..web.errors import APIPermissionException, InputValidationException
 from ..web.request import log_access, AccessType
 
 
@@ -279,6 +279,10 @@ class ContainerHandler(base.RequestHandler):
             payload['permissions'] = parent_container.get('permissions')
         elif cont_name =='projects':
             payload['permissions'] = [{'_id': self.uid, 'access': 'admin'}] if self.uid else []
+
+            # Unsorted projects are reserved for reaper uploads
+            if payload.get('label') == 'Unsorted':
+                raise InputValidationException("{} is a reserved project label".format(payload.get('label')))
         else:
             payload['permissions'] = parent_container.get('permissions', [])
         # Created and modified timestamps are added here to the payload

--- a/api/placer.py
+++ b/api/placer.py
@@ -239,7 +239,7 @@ class UIDReaperPlacer(UIDPlacer):
     """
 
     metadata_schema = 'uidupload.json'
-    create_hierarchy = staticmethod(hierarchy.upsert_bottom_up_hierarchy)
+    create_hierarchy = staticmethod(hierarchy.upsert_bottom_up_hierarchy_wrapper(reaper=True))
     match_type = 'uid'
 
 

--- a/api/placer.py
+++ b/api/placer.py
@@ -239,7 +239,7 @@ class UIDReaperPlacer(UIDPlacer):
     """
 
     metadata_schema = 'uidupload.json'
-    create_hierarchy = staticmethod(hierarchy.upsert_bottom_up_hierarchy_wrapper(reaper=True))
+    create_hierarchy = staticmethod(hierarchy.upsert_bottom_up_hierarchy)
     match_type = 'uid'
 
 

--- a/tests/integration_tests/python/test_containers.py
+++ b/tests/integration_tests/python/test_containers.py
@@ -459,6 +459,13 @@ def test_post_container(data_builder, as_admin, as_user):
     })
     assert r.status_code == 403
 
+    # try to add project with name Unsorted
+    r = as_admin.post('/projects', json={
+        'group': group,
+        'label': 'Unsorted'
+    })
+    assert r.status_code == 400
+
     # set as_user perms to rw on project
     r = as_user.get('/users/self')
     assert r.ok

--- a/tests/integration_tests/python/test_uploads.py
+++ b/tests/integration_tests/python/test_uploads.py
@@ -41,11 +41,12 @@ def upload_file_form(file_form, merge_dict, randstr):
     return create_form
 
 
-def test_reaper_upload(data_builder, randstr, upload_file_form, as_admin):
+def test_reaper_upload(data_builder, randstr, upload_file_form, as_admin, as_root):
     group_1 = data_builder.create_group()
     prefix = randstr()
     project_label_1 = prefix + '-project-label-1'
     session_uid = prefix + '-session-uid'
+    project_1 = data_builder.create_project(label=project_label_1, group=group_1)
 
     # reaper-upload files to group_1/project_label_1 using session_uid
     r = as_admin.post('/upload/reaper', files=upload_file_form(
@@ -100,11 +101,98 @@ def test_reaper_upload(data_builder, randstr, upload_file_form, as_admin):
     assert len(as_admin.get('/sessions/' + session + '/acquisitions').json()) == 2
     assert len(as_admin.get('/sessions/' + session).json()['files']) == 2
 
+    # No group or project given
+    r = as_root.post('/upload/reaper', files=upload_file_form(
+        group={'_id': ''},
+        project={'label': ''},
+        session={'uid': session_uid+'1'},
+    ))
+    assert r.ok
+
+    # get session created by the upload
+    r = as_root.get('/groups/unknown/projects')
+    assert r.ok
+    project_list = r.json()
+    assert len(project_list) == 1
+    project = project_list[0]
+    assert 'Unsorted' == project_list[0]['label']
+    unknown_project = project['_id']
+    assert len(as_root.get('/projects/' + unknown_project + '/sessions').json()) == 1
+
+    # No group given
+    r = as_root.post('/upload/reaper', files=upload_file_form(
+        group={'_id': ''},
+        project={'label': project_label_1},
+        session={'uid': session_uid+'2'},
+    ))
+    assert r.ok
+
+    # get session created by the upload
+    r = as_root.get('/groups/unknown/projects')
+    assert r.ok
+    project_list = r.json()
+    assert len(project_list) == 1
+    assert len(as_root.get('/projects/' + unknown_project + '/sessions').json()) == 2
+
+    # Group given but no project
+    group_3 = data_builder.create_group()
+    r = as_root.post('/upload/reaper', files=upload_file_form(
+        group={'_id': group_3},
+        project={'label': ''},
+        session={'uid': session_uid+'3'},
+    ))
+    assert r.ok
+    # get session created by the upload
+    r = as_root.get('/groups/' + group_3 + '/projects')
+    assert r.ok
+    project_list = r.json()
+    assert len(project_list) == 1
+    project = project_list[0]
+    assert 'Unsorted' == project_list[0]['label']
+    unknown_project = project['_id']
+    assert len(as_root.get('/projects/' + unknown_project + '/sessions').json()) == 1
+
+    # Group given but project is missed typed
+    r = as_root.post('/upload/reaper', files=upload_file_form(
+        group={'_id': group_3},
+        project={'label': 'Miss-typed project'},
+        session={'uid': session_uid+'4'},
+    ))
+    assert r.ok
+    # get session created by the upload
+    r = as_root.get('/groups/' + group_3 + '/projects')
+    assert r.ok
+    project_list = r.json()
+    assert len(project_list) == 1
+    project = project_list[0]
+    assert 'Unsorted' == project_list[0]['label']
+    unknown_project = project['_id']
+    assert len(as_root.get('/projects/' + unknown_project + '/sessions').json()) == 2
+
+    # Group given but project is missed typed
+    r = as_root.post('/upload/reaper', files=upload_file_form(
+        group={'_id': group_3},
+        project={'label': 'Miss-typed project'},
+        session={'uid': session_uid+'4'},
+    ))
+    assert r.ok
+    # get session created by the upload
+    r = as_root.get('/groups/' + group_3 + '/projects')
+    assert r.ok
+    project_list = r.json()
+    assert len(project_list) == 1
+    project = project_list[0]
+    assert 'Unsorted' == project_list[0]['label']
+    unknown_project = project['_id']
+    assert len(as_root.get('/projects/' + unknown_project + '/sessions').json()) == 2
+
+
+
     # clean up
     data_builder.delete_group(group_1, recursive=True)
     data_builder.delete_group(group_2, recursive=True)
 
-def test_reaper_upload_unknown_group_project(data_builder, file_form, as_root, as_admin):
+def test_label_upload_unknown_group_project(data_builder, file_form, as_root, as_admin):
     """
     If the label endpoint receives an upload with a blank group and project, set to
     group: unknown and create or find "Unknown" project


### PR DESCRIPTION
Reapers can only create Unsorted projects if there is no match.
Cases: 

| group\project | none given | no match | match |
|---------------|-------------------------------------|-------------------------------------|---------------------------------------|
| no match | group='unknown' project='Unsorted' | group='unknown' project='Unsorted' | N/A |
| match | group='group_id' project='Unsorted' | group='group_id' project='Unsorted' | group='group_id' project='project_id' |

Also, users can't create a project with label Unsorted

Current way it works

| group\project | '' | no match | match |
|---------------|-------------------------------------|---------------------------------------------------------------------------------------|---------------------------------------|
| no match | group='unknown' project='no_match_' | group='unknown' project='no_match_no_match'  ({given_group_id}_{given_project_label}) | N/A |
| match | group='group_id' project='Unknown' | group='group_id' project is created | group='group_id' project='project_id' |

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
