### PR TITLE
Doesn't assume job has gear-info

### DIFF
--- a/api/dao/basecontainerstorage.py
+++ b/api/dao/basecontainerstorage.py
@@ -466,7 +466,7 @@ class ContainerStorage(object):
 
                     # Alias job.gear_info.name as job.gear_name until UI starts using gear_info.name directly
                     if join_doc is not None and j_type == 'job':
-                        join_doc['gear_name'] = join_doc['gear_info']['name']
+                        join_doc['gear_name'] = join_doc.get('gear_info', {}).get('name')
 
                     # Save to join table
                     container['join-origin'][j_type][j_id] = join_doc


### PR DESCRIPTION
DB upgrade doesn't always set gear info for a job (when the gear can't be found) so it 500s
  - ran into this on demo-delete
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
