### PR TITLE
Save data view results to container

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -217,10 +217,11 @@ endpoints = [
         ]),
 
         prefix('/views', [
-            route('/data',             DataViewHandler, h='execute_adhoc',   m=['POST']),
-            route('/columns',          DataViewHandler, h='get_columns',     m=['GET']),
-            route('/<_id:{oid}>',      DataViewHandler,                      m=['GET', 'DELETE', 'PUT']),
-            route('/<_id:{oid}>/data', DataViewHandler, h='execute_saved',   m=['GET'])
+            route('/data',             DataViewHandler, h='execute_adhoc',     m=['POST']),
+            route('/save',             DataViewHandler, h='execute_and_save',  m=['POST']),
+            route('/columns',          DataViewHandler, h='get_columns',       m=['GET']),
+            route('/<_id:{oid}>',      DataViewHandler,                        m=['GET', 'DELETE', 'PUT']),
+            route('/<_id:{oid}>/data', DataViewHandler, h='execute_saved',     m=['GET'])
         ]),
 
 

--- a/api/create_file.py
+++ b/api/create_file.py
@@ -1,57 +1,93 @@
+"""Provides functionality for creating files on a container"""
 import datetime
 import uuid
 
 from . import config, files, util, upload
-from .placer import TargetedPlacer
+from .placer import TargetedMultiPlacer
+
+class PendingFile(object):
+    def __init__(self, filename, path, fileobj, metadata):
+        self.filename = filename
+        self.path = path
+        self.fileobj = fileobj
+        
+        if metadata is not None:
+            self.metadata = metadata.copy()
+        else:
+            self.metadata = {}
+        self.metadata['name'] = filename
 
 class FileCreator(object):
-    """Handle creation of a single file on target container"""
-    def __init__(self, handler):
+    """Helper class for creating file(s) on target container"""
+    def __init__(self, handler, container_type, container):
+        """Initialize the file creator, setting the destination container"""
         self.handler = handler
         self.file_processor = None
-        self.filepath = None
-        self.fileobj = None
-        self.filename = None
 
-    def create_file(self, filename):
-        self.filename = filename
+        self.container_type = container_type
+        self.container = container
+
+        self._files = []
+
+    def create_file(self, filename, metadata=None):
+        """Open a file for writing, and add it to the pending file list.
+
+        Arguments:
+            filename (str): The name of the file to create
+            metadata (dict): The optional metadata to set
+        """
         if not self.file_processor:
             self.file_processor = files.FileProcessor(config.fs)
 
-        self.filepath, self.fileobj = self.file_processor.make_temp_file()
-        return self.fileobj
+        path, fileobj = self.file_processor.make_temp_file()
+        self._files.append(PendingFile(filename, path, fileobj, metadata))
+        return fileobj
 
-    def finalize(self, target_container_type, target_container):
-        self.fileobj.close()
+    def finalize(self):
+        """Finalize the the file creation.
+        
+        This moves the temp files that were created into place, and updates the container.
 
+        Returns:
+            list: The list of files that were saved
+        """
         timestamp = datetime.datetime.utcnow()
-        metadata = { 'name': self.filename }
         context = { 'uid': self.handler.uid }
+        origin = self.handler.origin
+
+        # Construct the file metadata list
+        metadata = [ pending_file.metadata for pending_file in self._files ]
 
         # Create our targeted placer
-        placer = TargetedPlacer(target_container_type, target_container, target_container['_id'],
-            metadata, timestamp, self.handler.origin, context, self.file_processor, self.handler.log_user_access)
+        placer = TargetedMultiPlacer(self.container_type, self.container, self.container['_id'],
+            metadata, timestamp, origin, {'uid': self.handler.uid}, self.file_processor, self.handler.log_user_access)
 
-        # Not a great practice. See process_upload() for details.
-        cgi_field = util.obj_from_map({
-            'filename': self.filename,
-            'path': self.filepath,
-            'size': self.fileobj.size,
-            'hash': self.fileobj.hash,
-            'uuid': str(uuid.uuid4()),
-            'mimetype': util.guess_mimetype(self.filename),
-            'modified': timestamp
-        })
-        file_attrs = upload.make_file_attrs(cgi_field, self.handler.origin)
+        for pending_file in self._files:
+            # Not a great practice. See process_upload() for details.
+            cgi_field = util.obj_from_map({
+                'filename': pending_file.filename,
+                'path': pending_file.path,
+                'size': pending_file.fileobj.size,
+                'hash': pending_file.fileobj.hash,
+                'uuid': str(uuid.uuid4()),
+                'mimetype': util.guess_mimetype(pending_file.filename),
+                'modified': timestamp
+            })
+            file_attrs = upload.make_file_attrs(cgi_field, origin)
 
-        # Place the file
-        placer.process_file_field(cgi_field, file_attrs)
+            # Place the file
+            placer.process_file_field(cgi_field, file_attrs)
 
         # And return the result
         return placer.finalize()
        
     def close(self):
-        if self.fileobj:
-            self.fileobj.close()
+        """Close all opened tempfiles, and delete the temp filesystem"""
+        for pending_file in self._files:
+            pending_file.fileobj.close()
 
+    def __enter__(self):
+        return self
 
+    def __exit__(self, exc, value, tb):
+        self.close()

--- a/api/create_file.py
+++ b/api/create_file.py
@@ -1,0 +1,57 @@
+import datetime
+import uuid
+
+from . import config, files, util, upload
+from .placer import TargetedPlacer
+
+class FileCreator(object):
+    """Handle creation of a single file on target container"""
+    def __init__(self, handler):
+        self.handler = handler
+        self.file_processor = None
+        self.filepath = None
+        self.fileobj = None
+        self.filename = None
+
+    def create_file(self, filename):
+        self.filename = filename
+        if not self.file_processor:
+            self.file_processor = files.FileProcessor(config.fs)
+
+        self.filepath, self.fileobj = self.file_processor.make_temp_file()
+        return self.fileobj
+
+    def finalize(self, target_container_type, target_container):
+        self.fileobj.close()
+
+        timestamp = datetime.datetime.utcnow()
+        metadata = { 'name': self.filename }
+        context = { 'uid': self.handler.uid }
+
+        # Create our targeted placer
+        placer = TargetedPlacer(target_container_type, target_container, target_container['_id'],
+            metadata, timestamp, self.handler.origin, context, self.file_processor, self.handler.log_user_access)
+
+        # Not a great practice. See process_upload() for details.
+        cgi_field = util.obj_from_map({
+            'filename': self.filename,
+            'path': self.filepath,
+            'size': self.fileobj.size,
+            'hash': self.fileobj.hash,
+            'uuid': str(uuid.uuid4()),
+            'mimetype': util.guess_mimetype(self.filename),
+            'modified': timestamp
+        })
+        file_attrs = upload.make_file_attrs(cgi_field, self.handler.origin)
+
+        # Place the file
+        placer.process_file_field(cgi_field, file_attrs)
+
+        # And return the result
+        return placer.finalize()
+       
+    def close(self):
+        if self.fileobj:
+            self.fileobj.close()
+
+

--- a/api/create_file.py
+++ b/api/create_file.py
@@ -52,7 +52,6 @@ class FileCreator(object):
             list: The list of files that were saved
         """
         timestamp = datetime.datetime.utcnow()
-        context = { 'uid': self.handler.uid }
         origin = self.handler.origin
 
         # Construct the file metadata list

--- a/api/data_views/handlers.py
+++ b/api/data_views/handlers.py
@@ -182,41 +182,37 @@ class DataViewHandler(base.RequestHandler):
         view.prepare(container_id, data_format, self.uid, pagination=self.pagination, report_progress=bool(target_container))
 
         def response_handler(environ, start_response): # pylint: disable=unused-argument
-            file_creator = None
+            write_progress=None
 
-            if target_container:
-                # If we're saving to container, start SSE event,
-                # and write the data to a temp file
-                write_progress = start_response('200 OK', [
-                    ('Content-Type', 'text/event-stream; charset=utf-8'),
-                    ('Connection', 'keep-alive')
-                ])
+            with FileCreator(self, target_container_type, target_container) as file_creator:
+                if target_container:
+                    # If we're saving to container, start SSE event,
+                    # and write the data to a temp file
+                    write_progress = start_response('200 OK', [
+                        ('Content-Type', 'text/event-stream; charset=utf-8'),
+                        ('Connection', 'keep-alive')
+                    ])
 
-                file_creator = FileCreator(self)
-                fileobj = file_creator.create_file(target_filename)
-                write = lambda data: fileobj.write(data)
-            else:
-                write = start_response('200 OK', [
-                    ('Content-Type', view.get_content_type()),
-                    ('Content-Disposition', 'attachment; filename="{}"'.format(view.get_filename('view-data'))),
-                    ('Connection', 'keep-alive')
-                ])
+                    fileobj = file_creator.create_file(target_filename)
+                    write = lambda data: fileobj.write(data)
+                else:
+                    write = start_response('200 OK', [
+                        ('Content-Type', view.get_content_type()),
+                        ('Content-Disposition', 'attachment; filename="{}"'.format(view.get_filename('view-data'))),
+                        ('Connection', 'keep-alive')
+                    ])
 
-            try:
                 view.execute(self.request, self.origin, write, write_progress_fn=write_progress)
-            finally:
-                if file_creator:
-                    file_creator.close()
 
-            if target_container:
-                result = file_creator.finalize(target_container_type, target_container)
+                if target_container:
+                    result = file_creator.finalize()
 
-                # Write final progress
-                progress = encoder.json_sse_pack({
-                    'event': 'result',
-                    'data': result,
-                })
-                write_progress(progress)
+                    # Write final progress
+                    progress = encoder.json_sse_pack({
+                        'event': 'result',
+                        'data': result,
+                    })
+                    write_progress(progress)
 
             return ''
 

--- a/api/data_views/handlers.py
+++ b/api/data_views/handlers.py
@@ -147,7 +147,7 @@ class DataViewHandler(base.RequestHandler):
         target = storage.get_el(payload['containerId'])
 
         if not self.user_is_admin:
-            permchecker = containerauth.default_container(target_parent_container=target)
+            permchecker = containerauth.default_container(self, target_parent_container=target)
             permchecker(noop)('POST')
 
         # Execute the data view
@@ -194,7 +194,7 @@ class DataViewHandler(base.RequestHandler):
                     ])
 
                     fileobj = file_creator.create_file(target_filename)
-                    write = lambda data: fileobj.write(data)
+                    write = fileobj.write 
                 else:
                     write = start_response('200 OK', [
                         ('Content-Type', view.get_content_type()),

--- a/api/data_views/handlers.py
+++ b/api/data_views/handlers.py
@@ -1,9 +1,11 @@
 from ..auth import require_login
 
 from .. import config, validators
+from ..create_file import FileCreator
 from ..auth import containerauth
 from ..dao import noop
-from ..web import base
+from ..dao.containerstorage import ContainerStorage
+from ..web import base, encoder
 from ..web.request import beta_feature
 from ..web.errors import APIStorageException, InputValidationException
 
@@ -12,6 +14,9 @@ from .storage import DataViewStorage
 from .column_aliases import ColumnAliases
 
 log = config.log
+
+# TODO: Update when subjects are real
+FILE_CONTAINERS = { 'project', 'session', 'acquisition' }
 
 class DataViewHandler(base.RequestHandler):
     """Provide /views API routes."""
@@ -113,6 +118,43 @@ class DataViewHandler(base.RequestHandler):
     @beta_feature
     @require_login
     @validators.verify_payload_exists
+    def execute_and_save(self):
+        """Execute the data view specified, and save the results as a file"""
+
+        # Validate payload
+        payload = self.request.json
+        validators.validate_data(payload, 'save-data-view.json', 'input', 'POST')
+
+        # Ensure that exactly one is set
+        if (not payload.get('view') and not payload.get('viewId')) or (payload.get('view') and payload.get('viewId')):
+            raise InputValidationException('Must specify one of "view" object or "viewId"')
+
+        # Verify target container type
+        if payload['containerType'] not in FILE_CONTAINERS:
+            raise InputValidationException('Must one of "{}" for containerType'.format(', '.join(FILE_CONTAINERS)))
+
+        # Verify that the view exists
+        if payload.get('viewId'):
+            view_id = payload['viewId']
+            view = self.storage.get_el(view_id)
+            parent_container = self.storage.get_parent(view_id, cont=view, projection=self.parent_projection)
+            self.permcheck('GET', container=view, parent_container=parent_container)
+        else:
+            view = payload.get('view')
+
+        # Verify that the destination container exists and user can post
+        storage = ContainerStorage.factory(payload['containerType'])
+        target = storage.get_el(payload['containerId'])
+
+        if not self.user_is_admin:
+            permchecker = containerauth.default_container(target_parent_container=target)
+            permchecker(noop)('POST')
+
+        # Execute the data view
+        return self.do_execute_view(view, target, payload['containerType'], payload['filename'])
+
+    @require_login
+    @validators.verify_payload_exists
     def execute_adhoc(self):
         """Execute the data view specified in body"""
         # Validate payload
@@ -121,7 +163,7 @@ class DataViewHandler(base.RequestHandler):
 
         return self.do_execute_view(payload)
 
-    def do_execute_view(self, view_spec):
+    def do_execute_view(self, view_spec, target_container=None, target_container_type=None, target_filename=None):
         """ Complete view execution for the given view definition """
         # Find destination container and validate permissions 
         container_id = self.request.GET.get('containerId')
@@ -137,16 +179,44 @@ class DataViewHandler(base.RequestHandler):
         view.validate_config()
 
         # Prepare by searching for container_id and checking permissions
-        view.prepare(container_id, data_format, self.uid, self.pagination)
+        view.prepare(container_id, data_format, self.uid, pagination=self.pagination, report_progress=bool(target_container))
 
         def response_handler(environ, start_response): # pylint: disable=unused-argument
-            write = start_response('200 OK', [
-                ('Content-Type', view.get_content_type()),
-                ('Content-Disposition', 'attachment; filename="{}"'.format(view.get_filename('view-data'))),
-                ('Connection', 'keep-alive')
-            ])
+            file_creator = None
 
-            view.execute(self.request, self.origin, write)
+            if target_container:
+                # If we're saving to container, start SSE event,
+                # and write the data to a temp file
+                write_progress = start_response('200 OK', [
+                    ('Content-Type', 'text/event-stream; charset=utf-8'),
+                    ('Connection', 'keep-alive')
+                ])
+
+                file_creator = FileCreator(self)
+                fileobj = file_creator.create_file(target_filename)
+                write = lambda data: fileobj.write(data)
+            else:
+                write = start_response('200 OK', [
+                    ('Content-Type', view.get_content_type()),
+                    ('Content-Disposition', 'attachment; filename="{}"'.format(view.get_filename('view-data'))),
+                    ('Connection', 'keep-alive')
+                ])
+
+            try:
+                view.execute(self.request, self.origin, write, write_progress_fn=write_progress)
+            finally:
+                if file_creator:
+                    file_creator.close()
+
+            if target_container:
+                result = file_creator.finalize(target_container_type, target_container)
+
+                # Write final progress
+                progress = encoder.json_sse_pack({
+                    'event': 'result',
+                    'data': result,
+                })
+                write_progress(progress)
 
             return ''
 

--- a/api/data_views/pipeline/report_progress.py
+++ b/api/data_views/pipeline/report_progress.py
@@ -17,8 +17,8 @@ class ReportProgress(PipelineStage):
         self._last_write = datetime.utcnow()
         self._progressobj = progressobj
 
-    """Pipeline stage that writes SSE progress"""
     def process(self, payload):
+        """Pipeline stage that writes SSE progress"""
         if payload != EndOfPayload:
             # Keep unmatched values at the end
             elapsed = datetime.utcnow() - self._last_write

--- a/api/data_views/pipeline/report_progress.py
+++ b/api/data_views/pipeline/report_progress.py
@@ -1,0 +1,41 @@
+from datetime import datetime, timedelta
+from .pipeline import PipelineStage, EndOfPayload
+from ...web import encoder
+
+MIN_UPDATE_TIME = timedelta(seconds=1) 
+
+class ReportProgress(PipelineStage):
+    def __init__(self, progressobj):
+        """Initialize the write progress stage.
+
+        Arguments:
+            progressobj (object): An object with a write_progress function
+        """
+        super(ReportProgress, self).__init__()
+
+        self._rows_written = 0
+        self._last_write = datetime.utcnow()
+        self._progressobj = progressobj
+
+    """Pipeline stage that writes SSE progress"""
+    def process(self, payload):
+        if payload != EndOfPayload:
+            # Keep unmatched values at the end
+            elapsed = datetime.utcnow() - self._last_write
+            if elapsed > MIN_UPDATE_TIME:
+                progress = encoder.json_sse_pack({
+                    'event': 'progress',
+                    'data': { 'rows': self._rows_written }
+                })
+                self._progressobj.write_progress(progress)
+                self._last_write = datetime.utcnow()
+
+            self._rows_written += 1
+        else:
+            progress = encoder.json_sse_pack({
+                'event': 'progress',
+                'data': { 'rows': self._rows_written, 'status': 'finalizing' }
+            })
+            self._progressobj.write_progress(progress)
+
+        self.emit(payload)

--- a/api/files.py
+++ b/api/files.py
@@ -28,7 +28,18 @@ class FileProcessor(object):
         else:
             self._temp_fs = fs.tempfs.TempFS('tmp')
 
-    def make_temp_file(self):
+    def make_temp_file(self, mode='wb'):
+        """Create and open a temporary file for writing.
+
+        The file that is opened is wrapped in a FileHasherWriter, so once writing is
+        complete, you can get the size and hash of the written file.
+        
+        Arguments:
+            mode (str): The open mode (default is 'wb')
+
+        Returns:
+            str, file: The path and opened file
+        """
         filename = str(uuid.uuid4())
         fileobj = self._temp_fs.open(filename, 'wb')
         return filename, FileHasherWriter(fileobj)
@@ -139,6 +150,7 @@ class FileHasherWriter(object):
 
     @property
     def hash(self):
+        """Return the formatted hash of the file"""
         return util.format_hash(self.hash_alg, self.hasher.hexdigest())
 
     def write(self, data):

--- a/api/files.py
+++ b/api/files.py
@@ -41,7 +41,7 @@ class FileProcessor(object):
             str, file: The path and opened file
         """
         filename = str(uuid.uuid4())
-        fileobj = self._temp_fs.open(filename, 'wb')
+        fileobj = self._temp_fs.open(filename, mode)
         return filename, FileHasherWriter(fileobj)
 
     def store_temp_file(self, src_path, dst_path, dst_fs=None):

--- a/api/files.py
+++ b/api/files.py
@@ -28,6 +28,11 @@ class FileProcessor(object):
         else:
             self._temp_fs = fs.tempfs.TempFS('tmp')
 
+    def make_temp_file(self):
+        filename = str(uuid.uuid4())
+        fileobj = self._temp_fs.open(filename, 'wb')
+        return filename, FileHasherWriter(fileobj)
+
     def store_temp_file(self, src_path, dst_path, dst_fs=None):
         if not isinstance(src_path, unicode):
             src_path = six.u(src_path)
@@ -118,6 +123,31 @@ class FileProcessor(object):
             # Otherwise clean up manually
             self._presistent_fs.removetree(fs.path.join('tmp', self._tempdir_name))
 
+class FileHasherWriter(object):
+    """File wrapper that hashes while writing to a file"""
+    def __init__(self, fileobj, hash_alg=None):
+        """Create a new file hasher/writer
+        
+        Arguments:
+            fileobj (file): The wrapped file object
+            hash_alg (str): The hash algorithm, or None to use default
+        """
+        self.fileobj = fileobj
+        self.hash_alg = hash_alg or DEFAULT_HASH_ALG
+        self.hasher = hashlib.new(self.hash_alg)
+        self.size = 0
+
+    @property
+    def hash(self):
+        return util.format_hash(self.hash_alg, self.hasher.hexdigest())
+
+    def write(self, data):
+        self.fileobj.write(data)
+        self.hasher.update(data)
+        self.size += len(data)
+
+    def close(self):
+        self.fileobj.close()
 
 def get_single_file_field_storage(file_system, use_filepath=False):
     # pylint: disable=attribute-defined-outside-init

--- a/api/upload.py
+++ b/api/upload.py
@@ -142,23 +142,8 @@ def process_upload(request, strategy, access_logger, container_type=None, id_=No
 
         # create a file-attribute map commonly used elsewhere in the codebase.
         # Stands in for a dedicated object... for now.
-        file_attrs = {
-            '_id': field.uuid,
-            'name': field.filename,
-            'modified': field.modified,
-            'size': field.size,
-            'mimetype': field.mimetype,
-            'hash': field.hash,
-            'origin': origin,
+        file_attrs = make_file_attrs(field, origin)
 
-            'type': None,
-            'modality': None,
-            'classification': {},
-            'tags': [],
-            'info': {}
-        }
-
-        file_attrs['type'] = files.guess_type_from_filename(file_attrs['name'])
         placer.process_file_field(field, file_attrs)
 
     # Respond either with Server-Sent Events or a standard json map
@@ -384,3 +369,25 @@ def extract_file_fields(form):
             result.append(field)
 
     return result
+
+def make_file_attrs(field, origin):
+    # create a file-attribute map commonly used elsewhere in the codebase.
+    # Stands in for a dedicated object... for now.
+    file_attrs = {
+        '_id': field.uuid,
+        'name': field.filename,
+        'modified': field.modified,
+        'size': field.size,
+        'mimetype': field.mimetype,
+        'hash': field.hash,
+        'origin': origin,
+
+        'type': None,
+        'modality': None,
+        'classification': {},
+        'tags': [],
+        'info': {}
+    }
+
+    file_attrs['type'] = files.guess_type_from_filename(file_attrs['name'])
+    return file_attrs

--- a/swagger/paths/data-views.yaml
+++ b/swagger/paths/data-views.yaml
@@ -97,6 +97,50 @@
       '200':
         description: 'The view execution result'
 
+/views/save:
+  post:
+    summary: Execute a view, saving data to the target container / file
+    operationId: save_view_data
+    tags:
+    - views
+    parameters:
+      - name: containerId
+        in: query
+        type: string
+        required: true
+        description: The target container for view execution
+      - name: format
+        in: query
+        type: string
+        enum: 
+          - csv
+          - tsv
+          - json
+          - json-row-column
+        default: json
+      - name: filter
+        in: query
+        type: string
+        description: An optional filter expression
+      - name: skip
+        in: query
+        type: integer
+        description: The optional number of rows to skip
+      - name: limit
+        in: query
+        type: integer
+        description: The optional max number of rows to return
+      - name: body
+        in: body
+        required: true
+        schema: 
+          $ref: schemas/input/save-data-view.json
+    produces:
+      - text/event-stream
+    responses:
+      '200':
+        description: 'The view execution result'
+
 /views/{ViewId}:
   parameters:
     - name: ViewId

--- a/swagger/schemas/definitions/data-view.json
+++ b/swagger/schemas/definitions/data-view.json
@@ -173,6 +173,19 @@
       "description": "Represents a column alias for use in data views. Maps from src to name.",
       "additionalProperties": false,
       "required": ["name", "src", "description", "type"]
+    },
+    "save-data-view-input": {
+      "type": "object",
+      "properties": {
+        "view":          { "$ref": "#/definitions/data-view-input" },
+        "viewId":        { "$ref": "common.json#/definitions/objectid" },
+        "containerType": { "$ref": "container.json#/definitions/container-type" },
+        "containerId":   { "$ref": "container.json#/definitions/_id" },
+        "filename":      { "$ref": "file.json#/definitions/name" }
+      },
+      "description": "A request to save data-view data to a container",
+      "additionalProperties": false,
+      "required": [ "containerType", "containerId", "filename" ]
     }
   }
 }

--- a/swagger/schemas/input/save-data-view.json
+++ b/swagger/schemas/input/save-data-view.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "allOf":[{"$ref":"../definitions/data-view.json#/definitions/save-data-view-input"}],
+  "example": {
+        "viewId": "5b50e35c25b313ce62673cfa",
+        "containerType": "project",
+        "containerId": "5b50e37425b313ce62673cfb",
+        "filename": "aggregate-results.csv"
+    }
+}

--- a/tests/integration_tests/python/test_data_views.py
+++ b/tests/integration_tests/python/test_data_views.py
@@ -1265,3 +1265,44 @@ def test_data_view_skip_and_limit(data_builder, file_form, as_admin):
         assert row['value'] == j
         assert isinstance(row['value2'], float)
         assert row['value2'] == 2*j
+
+def test_save_data_view_to_project(data_builder, file_form, as_admin):
+    project = data_builder.create_project(label='test-project')
+    session = data_builder.create_session(project=project, subject=subject1, label='ses-01')
+    acquisition = data_builder.create_acquisition(session=session, label='scout')
+
+    r = as_admin.post('/views/save?containerId={}'.format(project), json={
+        'view': {
+            'includeIds': True,
+            'includeLabels': False,
+            'columns': [
+                { 'src': 'project.label', 'dst': 'project_label' },
+                { 'src': 'subject.code', 'dst': 'subject_label' },
+                { 'src': 'subject.age' },
+                { 'src': 'subject.sex' },
+                { 'src': 'session.label', 'dst': 'session_label' },
+                { 'src': 'acquisition.label', 'dst': 'acquisition_label' }
+            ]
+        },
+        'containerType': 'project',
+        'containerId': project,
+        'filename': 'data_view.json'
+    })
+
+    assert r.ok
+
+    r = as_admin.get('/projects/{}/files/data_view.json'.format(project))
+    assert r.ok
+
+    rows = r.json()['data']
+    assert len(rows) == 1
+
+    assert rows[0]['project'] == project
+    assert rows[0]['project_label'] == 'test-project'
+    assert rows[0]['subject_label'] == subject1['code']
+    assert rows[0]['subject.age'] == subject1['age']
+    assert rows[0]['subject.sex'] == subject1['sex']
+    assert rows[0]['session'] == session
+    assert rows[0]['session_label'] == 'ses-01'
+    assert rows[0]['acquisition'] == acquisition
+    assert rows[0]['acquisition_label'] == 'scout'


### PR DESCRIPTION
This PR introduces `/api/views/save` endpoint that allows executing a saved or ad-hoc data view, saving the result as a file (e.g. csv) on a container.  This uses SSE to report progress while the view data is being generated. Currently supports project, session and acquisition -- it may be interesting to add collections and analyses as destination containers.

The `FileCreator` class was added as an abstraction to write a file to a container using `TargetedMultiPlacer`. Please let me know if there was a better way that I missed.

### Test Requirements
Using SDK:
- Test saving data view results to various containers, in various formats
- Verify permissions, for the view being executed, the container being examined, and the container being updated.
- Verify access log contents for containers being accessed

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
