### PR TITLE
Fix upgrade step to add gear_info to analyses

### DIFF
--- a/bin/database.py
+++ b/bin/database.py
@@ -1746,7 +1746,7 @@ def upgrade_job_to_52(job, gears):
     }}
     config.db.jobs.update_one({'_id': job_id}, update_doc)
     update_doc['$set']['gear_info']['id'] = gear_id
-    config.db.analyses.update_one({'job': job_id}, update_doc)
+    config.db.analyses.update_one({'job': str(job_id)}, update_doc)
     return True
 
 def upgrade_to_52():

--- a/tests/integration_tests/python/test_upgrades.py
+++ b/tests/integration_tests/python/test_upgrades.py
@@ -399,7 +399,7 @@ def test_52(data_builder, api_db, as_admin, file_form, database, default_payload
 
     # Create analysis
     analysis_id = api_db.analyses.insert_one({
-        'job': job1_id,
+        'job': str(job1_id),
         'inputs': []
     }).inserted_id
     assert analysis_id


### PR DESCRIPTION
Should not be restricted by code-freeze since it fixes an issue in a merged PR.

This is a fix for DB upgrade to `52` where analyses were not getting `gear_info` updates because they carry the job id as a string rather than `ObjectId`.

To re-run the upgrade (needs to be done on dev.flywheel.io and next.dev.flywheel.io):
```
db.singletons.update({_id:'version'}, {$set: {database: NumberInt(51)}})
```

### Test Requirements

1. Reset db version to `51` as instructed above, then perform `reset-containers`
2. Verify that any analysis object that has an associated job has a `gear_info` subdocument.

Testing can be done via mongo client or SDK.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
