### PR TITLE
Hide data views behind X-Accept-Feature: beta

### DIFF
--- a/api/data_views/handlers.py
+++ b/api/data_views/handlers.py
@@ -4,6 +4,7 @@ from .. import config, validators
 from ..auth import containerauth
 from ..dao import noop
 from ..web import base
+from ..web.request import beta_feature
 from ..web.errors import APIStorageException, InputValidationException
 
 from .data_view import DataView
@@ -17,11 +18,13 @@ class DataViewHandler(base.RequestHandler):
     storage = DataViewStorage()
     parent_projection = {'permissions':1, 'public':1}
 
+    @beta_feature
     @require_login
     def get_columns(self):
         """Return all known column aliases with description and type"""
         return ColumnAliases.get_columns()
 
+    @beta_feature
     def list_views(self, parent):
         """List all views belonging to the parent container"""
         # Permission check is different here
@@ -35,6 +38,7 @@ class DataViewHandler(base.RequestHandler):
 
         return self.storage.get_data_views(parent, public_only=public_only)
 
+    @beta_feature
     @validators.verify_payload_exists
     def post(self, parent):
         """Create a new view on the parent container"""
@@ -55,6 +59,7 @@ class DataViewHandler(base.RequestHandler):
         else:
             self.abort(404, 'View {} not inserted'.format(result.inserted_id))
 
+    @beta_feature
     def delete(self, _id):
         """Delete the view identified by _id"""
         parent_container = self.storage.get_parent(_id, projection=self.parent_projection)
@@ -70,6 +75,7 @@ class DataViewHandler(base.RequestHandler):
 
         self.abort(404, 'Data view {} not deleted'.format(_id))
 
+    @beta_feature
     def get(self, _id):
         """Get the view identified by _id"""
         cont = self.storage.get_el(_id)
@@ -78,6 +84,7 @@ class DataViewHandler(base.RequestHandler):
 
         return cont
 
+    @beta_feature
     @validators.verify_payload_exists
     def put(self, _id):
         """Update the view identified by _id"""
@@ -94,6 +101,7 @@ class DataViewHandler(base.RequestHandler):
             return {'modified': result.modified_count}
         self.abort(404, 'Data view {} not updated'.format(_id))
 
+    @beta_feature
     def execute_saved(self, _id):
         """Execute the data view specified by id"""
         cont = self.storage.get_el(_id)
@@ -102,6 +110,7 @@ class DataViewHandler(base.RequestHandler):
 
         return self.do_execute_view(cont)
 
+    @beta_feature
     @require_login
     @validators.verify_payload_exists
     def execute_adhoc(self):

--- a/tests/integration_tests/python/conftest.py
+++ b/tests/integration_tests/python/conftest.py
@@ -251,6 +251,10 @@ def legacy_cas_file(as_admin, api_db, data_builder, randstr, file_form):
 
 class BaseUrlSession(requests.Session):
     """Requests session subclass using core api's base url"""
+    def __init__(self, *args, **kwargs):
+        super(BaseUrlSession, self).__init__(*args, **kwargs)
+        self.headers.update({ 'X-Accept-Feature': 'beta' })
+
     def request(self, method, url, **kwargs):
         return super(BaseUrlSession, self).request(method, SCITRAN_SITE_API_URL + url, **kwargs)
 


### PR DESCRIPTION
Adds a `beta_feature` decorator, and applies it to each method in the data views handler. 

### Test Requirements

Disable the line to add `X-Accept-Feature` header in [conftest.py](https://github.com/flywheel-io/core/compare/data-views-beta?expand=1#diff-71fec714aaaa2e8bac88a7b2aaf90d52R256) and verify that tests fail with 422 errors. (done - manually tested)

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
