### PR TITLE
Add exclusive tags

### DIFF
--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -395,6 +395,8 @@ class JobsHandler(base.RequestHandler):
     @require_admin
     def pending(self):
         tags = self.request.GET.getall('tags')
+
+        # Allow for tags to be specified multiple times, or just comma-deliminated
         if len(tags) == 1:
             tags = tags[0].split(',')
 
@@ -404,8 +406,10 @@ class JobsHandler(base.RequestHandler):
     def next(self):
         peek = self.is_true('peek')
         tags = self.request.GET.getall('tags')
-        if len(tags) <= 0:
-            tags = None
+
+        # Allow for tags to be specified multiple times, or just comma-deliminated
+        if len(tags) == 1:
+            tags = tags[0].split(',')
 
         job = Queue.start_job(tags=tags, peek=peek)
 

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -309,9 +309,18 @@ class Queue(object):
         Potential jobs must match at least one tag, if provided.
         """
 
+        if tags is None:
+            tags = []
+
+        inclusive_tags = filter(lambda x: not x.startswith('!'), tags)
+        exclusive_tags =  map(lambda x: x[1:], filter(lambda x: x.startswith('!'), tags)) # strip the '!' prefix
+
         query = { 'state': 'pending' }
-        if tags is not None:
-            query['tags'] = {'$in': tags }
+
+        if len(inclusive_tags) > 0:
+            query['tags'] = {'$in': inclusive_tags }
+        if len(exclusive_tags) > 0:
+            query['tags'] = {'$nin': exclusive_tags }
 
         modification = { '$set': {
             'state': 'running',

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -317,10 +317,13 @@ class Queue(object):
 
         query = { 'state': 'pending' }
 
+        if len(inclusive_tags) > 0 or len(exclusive_tags) > 0:
+            query['tags'] = {}
+
         if len(inclusive_tags) > 0:
-            query['tags'] = {'$in': inclusive_tags }
+            query['tags']['$in']  = inclusive_tags
         if len(exclusive_tags) > 0:
-            query['tags'] = {'$nin': exclusive_tags }
+            query['tags']['$nin'] = exclusive_tags
 
         modification = { '$set': {
             'state': 'running',

--- a/api/placer.py
+++ b/api/placer.py
@@ -228,6 +228,7 @@ class UIDPlacer(Placer):
             self.recalc_session_compliance()
         return self.saved
 
+
 class UIDReaperPlacer(UIDPlacer):
     """
     A placer that creates or matches based on UID.
@@ -241,6 +242,7 @@ class UIDReaperPlacer(UIDPlacer):
     create_hierarchy = staticmethod(hierarchy.upsert_bottom_up_hierarchy)
     match_type = 'uid'
 
+
 class LabelPlacer(UIDPlacer):
     """
     A placer that create a hierarchy based on labels.
@@ -253,6 +255,7 @@ class LabelPlacer(UIDPlacer):
     create_hierarchy = staticmethod(hierarchy.upsert_top_down_hierarchy)
     match_type = 'label'
 
+
 class UIDMatchPlacer(UIDPlacer):
     """
     A placer that uploads to an existing hierarchy it finds based on uid.
@@ -261,6 +264,7 @@ class UIDMatchPlacer(UIDPlacer):
     metadata_schema = 'uidmatchupload.json'
     create_hierarchy = staticmethod(hierarchy.find_existing_hierarchy)
     match_type = 'uid'
+
 
 class EnginePlacer(Placer):
     """
@@ -354,6 +358,7 @@ class EnginePlacer(Placer):
         self.recalc_session_compliance()
         return self.saved
 
+
 class TokenPlacer(Placer):
     """
     A placer that can accept N files and save them to a persistent directory across multiple requests.
@@ -392,6 +397,7 @@ class TokenPlacer(Placer):
             self.file_processor.store_temp_file(path, dest, dst_fs=config.local_fs)
         self.recalc_session_compliance()
         return self.saved
+
 
 class PackfilePlacer(Placer):
     """

--- a/tests/integration_tests/python/test_jobs.py
+++ b/tests/integration_tests/python/test_jobs.py
@@ -161,6 +161,10 @@ def test_jobs(data_builder, default_payload, as_public, as_user, as_admin, as_ro
     r = as_root.get('/jobs/next', params={'tags': 'fake-tag'})
     assert r.status_code == 400
 
+    # get next job - with excluding tag
+    r = as_root.get('/jobs/next', params={'tags': '!test-tag'})
+    assert r.status_code == 400
+
     # get next job with peek
     r = as_root.get('/jobs/next', params={'tags': 'test-tag', 'peek': True})
     assert r.ok

--- a/tests/integration_tests/python/test_jobs.py
+++ b/tests/integration_tests/python/test_jobs.py
@@ -165,13 +165,17 @@ def test_jobs(data_builder, default_payload, as_public, as_user, as_admin, as_ro
     r = as_root.get('/jobs/next', params={'tags': '!test-tag'})
     assert r.status_code == 400
 
+    # get next job - with excluding tag overlap
+    r = as_root.get('/jobs/next', params={'tags': ['test-tag', '!test-tag']})
+    assert r.status_code == 400
+
     # get next job with peek
     r = as_root.get('/jobs/next', params={'tags': 'test-tag', 'peek': True})
     assert r.ok
     next_job_id_peek = r.json()['id']
 
     # get next job
-    r = as_root.get('/jobs/next', params={'tags': 'test-tag'})
+    r = as_root.get('/jobs/next', params={'tags': ['test-tag', '!fake-tag']})
     assert r.ok
     next_job_id = r.json()['id']
     assert next_job_id == next_job_id_peek


### PR DESCRIPTION
This adds exclusive tags with a `!` prefix. To wit:

```
engine run -e -t '!dicom-mr-classifier,!dcm2niix,!qa-report-fmri'
```

### Test plan

Assume default job loadout.

Consume jobs with tags:

```
!dicom-mr-classifier,!dcm2niix,!qa-report-fmri
```

Observe no jobs consumed:

```json
"states": {
    "cancelled": 0,
    "complete": 0,
    "failed": 0,
    "pending": 37,
    "running": 0
},

```

Consume jobs with first tag of set removed:

```
!dcm2niix,!qa-report-fmri
```

Observe only classifier jobs consumed:

```json
"states": {
    "cancelled": 0,
    "complete": 37,
    "failed": 0,
    "pending": 37,
    "running": 0
},
```

Consume jobs with last tag inverted:

```
qa-report-fmri
```

Observe no change.
