### PR TITLE
Include response message in sdk exceptions

### DIFF
--- a/sdk/codegen/src/main/resources/fw-python/rest.mustache
+++ b/sdk/codegen/src/main/resources/fw-python/rest.mustache
@@ -236,16 +236,29 @@ class ApiException(Exception):
     def __init__(self, status=None, reason=None, http_resp=None):
         super(ApiException, self).__init__()
 
+        self.detail = None
+
         if http_resp is not None:
             self.status = http_resp.status_code
             self.reason = http_resp.reason
+
+            # Convert body to text
             try:
                 if six.PY3:
-                    self.body = http_resp.data.decode('utf8')
+                    self.body = http_resp.content.decode('utf8')
                 else:
-                    self.body = http_resp.data
+                    self.body = http_resp.content
             except: # pylint: disable=W0702
                 self.body = None
+
+            # Extract detailed message
+            if self.body:
+                try:
+                    response = json.loads(self.body)
+                    self.detail = response.get('message')
+                except: #pylint: disable=W0702
+                    pass
+
             self.headers = http_resp.headers
         else:
             self.status = status
@@ -255,13 +268,9 @@ class ApiException(Exception):
 
     def __str__(self):
         """Custom error messages for exception"""
-        error_message = "({0})\n"\
-                        "Reason: {1}\n".format(self.status, self.reason)
-        if self.headers:
-            error_message += "HTTP response headers: {0}\n".format(
-                self.headers)
+        error_message = "({0}) Reason: {1}".format(self.status, self.reason)
 
-        if self.body:
-            error_message += "HTTP response body: {0}\n".format(self.body)
+        if self.detail:
+            error_message += "\nDetail: {0}".format(self.detail)
 
         return error_message

--- a/sdk/codegen/src/main/resources/matlab/api_client.mustache
+++ b/sdk/codegen/src/main/resources/matlab/api_client.mustache
@@ -32,7 +32,12 @@ classdef ApiClient < handle
             statusCode = resp.getStatusCode();
             if statusCode < 200 || statusCode > 299
                 reason = resp.getReasonPhrase().toCharArray';
-                throw(MException('ApiClient:apiException', '(%d) Reason: %s', statusCode, reason));
+                detail = {{packageName}}.ApiClient.getResponseError(resp);
+                if isempty(detail)
+                    throw(MException('ApiClient:apiException', '(%d) Reason: %s', statusCode, reason));
+                else
+                    throw(MException('ApiClient:apiException', '(%d) Reason: %s\nDetail: %s', statusCode, reason, detail));
+                end
             end
         end
     end
@@ -43,6 +48,16 @@ classdef ApiClient < handle
         function json = getResponseJson(resp)
             body = resp.getBodyAsString().toCharArray';
             json = jsonio.jsonread(body, struct('ReplacementStyle', 'hex'));
+        end
+        function result = getResponseError(resp)
+            result = [];
+            try
+                data = {{packageName}}.ApiClient.getResponseJson(resp);
+                if isfield(data, 'message')
+                    result = data.message;
+                end
+            catch
+            end
         end
         function params = formatParamCollection(params, name, value, format)
             if iscell(value)

--- a/sdk/src/python/tests/integration_tests/test_errors.py
+++ b/sdk/src/python/tests/integration_tests/test_errors.py
@@ -1,0 +1,14 @@
+import unittest
+from sdk_test_case import SdkTestCase
+
+import flywheel
+
+class ErrorTestCases(SdkTestCase):
+    def test_error_message(self):
+        try:
+            self.fw.add_job({}) # Invalid request
+            self.fail('Expected an error creating invalid job')
+        except flywheel.ApiException as e:
+            self.assertNotEmpty(e.body)
+            self.assertEqual(e.detail, 'Job must specify gear')
+


### PR DESCRIPTION
This will generally improve supportability of the SDK, and as such I recommend making an exception to the code freeze to get this into the next release. I also consider it low risk.

### Test Requirements
- Verified (by hand) that exceptions include the detail string for Matlab
- Verified (by hand & integration test) that exceptions include the detail string for python

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
