### PR TITLE
Use string for JobTicket lookup

### DIFF
--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -417,7 +417,7 @@ class JobTicket(object):
     @staticmethod
     def find(job_id):
         """Find any tickets with job ID"""
-        return list(config.db.job_tickets.find({'job': job_id}))
+        return list(config.db.job_tickets.find({'job': str(job_id)}))
 
 
 class Logs(object):


### PR DESCRIPTION
* [JobTicket.create](https://github.com/flywheel-io/core/blob/orphan-jobs-fix/api/jobs/jobs.py#L405-L415) uses Job.id_ (a string) 
* When checking for orphans, Queue uses the document `job['_id']` calling [JobTicket.find](https://github.com/flywheel-io/core/blob/orphan-jobs-fix/api/jobs/queue.py#L482-L501).

Solution is to always use a `str` when looking up job tickets.

This affects engine uploads > ~5m by engine-2. 

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
