### PR TITLE
Rename async keyword to async_

### DIFF
--- a/sdk/codegen/src/main/resources/fw-python/api.mustache
+++ b/sdk/codegen/src/main/resources/fw-python/api.mustache
@@ -37,7 +37,7 @@ class {{classname}}(object):
 {{#vendorExtensions.x-sdk-download-file-param}}
         :param str {{.}}: Destination file path
 {{/vendorExtensions.x-sdk-download-file-param}}
-        :param bool async: Perform the request asynchronously
+        :param bool async_: Perform the request asynchronously
         :return: {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}None{{/returnType}}
         """
         kwargs['_return_http_data_only'] = True
@@ -55,7 +55,7 @@ class {{classname}}(object):
                     resp.close()
         {{/vendorExtensions.x-sdk-download-file-param}}
         {{^vendorExtensions.x-sdk-download-file-param}}
-        if kwargs.get('async'):
+        if kwargs.get('async_'):
             return self.{{operationId}}_with_http_info({{#sortParamsByRequiredFlag}}{{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}{{/sortParamsByRequiredFlag}}**kwargs)  # noqa: E501
         else:
             (data) = self.{{operationId}}_with_http_info({{#sortParamsByRequiredFlag}}{{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}{{/sortParamsByRequiredFlag}}**kwargs)  # noqa: E501
@@ -81,7 +81,7 @@ class {{classname}}(object):
         """
 
         all_params = [{{#allParams}}'{{paramName}}'{{#hasMore}}, {{/hasMore}}{{/allParams}}]  # noqa: E501
-        all_params.append('async')
+        all_params.append('async_')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
         all_params.append('_request_timeout')
@@ -218,7 +218,7 @@ class {{classname}}(object):
             files=local_var_files,
             response_type={{#returnType}}'{{returnType}}'{{/returnType}}{{^returnType}}None{{/returnType}},  # noqa: E501
             auth_settings=auth_settings,
-            async=params.get('async'),
+            async_=params.get('async_'),
             _return_http_data_only=params.get('_return_http_data_only'),
             _preload_content=params.get('_preload_content', True),
             _request_timeout=params.get('_request_timeout'),

--- a/sdk/codegen/src/main/resources/fw-python/api_client.mustache
+++ b/sdk/codegen/src/main/resources/fw-python/api_client.mustache
@@ -304,12 +304,12 @@ class ApiClient(object):
     def call_api(self, resource_path, method,
                  path_params=None, query_params=None, header_params=None,
                  body=None, post_params=None, files=None,
-                 response_type=None, auth_settings=None, async=None, # pylint: disable=W0111
+                 response_type=None, auth_settings=None, async_=None,
                  _return_http_data_only=None, collection_formats=None,
                  _preload_content=True, _request_timeout=None, _request_out=None):
         """Makes the HTTP request (synchronous) and returns deserialized data.
 
-        To make an async request, set the async parameter.
+        To make an async request, set the async_ parameter.
 
         :param resource_path: Path to method endpoint.
         :param method: Method to call.
@@ -324,7 +324,7 @@ class ApiClient(object):
         :param response: Response data type.
         :param files dict: key -> filename, value -> filepath,
             for `multipart/form-data`.
-        :param async bool: execute request asynchronously
+        :param async_ bool: execute request asynchronously
         :param _return_http_data_only: response data without head status code
                                        and headers
         :param collection_formats: dict of collection formats for path, query,
@@ -337,13 +337,13 @@ class ApiClient(object):
                                  timeout. It can also be a pair (tuple) of
                                  (connection, read) timeouts.
         :return:
-            If async parameter is True,
+            If async_ parameter is True,
             the request will be called asynchronously.
             The method will return the request thread.
-            If parameter async is False or missing,
+            If parameter async_ is False or missing,
             then the method will return the response directly.
         """
-        if not async:
+        if not async_:
             return self.__call_api(resource_path, method,
                                    path_params, query_params, header_params,
                                    body, post_params, files,

--- a/sdk/codegen/src/main/resources/fw-python/flywheel.mustache
+++ b/sdk/codegen/src/main/resources/fw-python/flywheel.mustache
@@ -87,7 +87,7 @@ class Flywheel:
         {{#vendorExtensions.x-sdk-download-file-param}}
         :param str {{.}}: Destination file path
         {{/vendorExtensions.x-sdk-download-file-param}}
-        :param bool async: Perform the request asynchronously
+        :param bool async_: Perform the request asynchronously
         :return: {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}None{{/returnType}}
         """
         return self.{{classVarName}}.{{operationId}}({{#sortParamsByRequiredFlag}}{{#allParams}}{{#required}}{{paramName}}, {{/required}}{{/allParams}}{{/sortParamsByRequiredFlag}}{{#vendorExtensions.x-sdk-download-file-param}}{{.}}, {{/vendorExtensions.x-sdk-download-file-param}}**kwargs)
@@ -108,7 +108,7 @@ class Flywheel:
         {{#vendorExtensions.x-sdk-download-file-param}}
         :param str {{.}}: Destination file path
         {{/vendorExtensions.x-sdk-download-file-param}}
-        :param bool async: Perform the request asynchronously
+        :param bool async_: Perform the request asynchronously
         :return: {{#returnType}}{{returnType}}{{/returnType}}{{^returnType}}None{{/returnType}}
         """
         req_info = {}

--- a/sdk/docker/python3-test-env.sh
+++ b/sdk/docker/python3-test-env.sh
@@ -10,5 +10,5 @@ docker run --rm -it \
     -e PYTHONPATH=/local/src/python/gen \
     -e SdkTestKey=${SdkTestKey} \
     -e FLYWHEEL_SDK_SKIP_VERSION_CHECK=1 \
-    python:3.6 /bin/bash -c "cd src/python/tests; pip install -r requirements.txt; /bin/bash"
+    python:3.7 /bin/bash -c "cd src/python/tests; pip install -r requirements.txt; /bin/bash"
 


### PR DESCRIPTION
`async` is a reserved keyword in python 3.7. This PR replaces async with `async_`.

Refs: swagger-api/swagger-codegen#8328

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
