### PR TITLE
Only check for major version differences by default

### DIFF
--- a/sdk/codegen/src/main/resources/fw-python/flywheel.mustache
+++ b/sdk/codegen/src/main/resources/fw-python/flywheel.mustache
@@ -66,7 +66,9 @@ class Flywheel:
         {{/apis}}
 
         # Perform version check
-        self.check_version = not skip_version_check or '0' == os.environ.get('FLYWHEEL_SDK_SKIP_VERSION_CHECK')
+        self.check_version = not skip_version_check
+        if not self.check_version:
+            self.check_version = os.environ.get('FLYWHEEL_SDK_SKIP_VERSION_CHECK', '').lower() in ['0', 'false']
         self.api_client.set_version_check_fn(self.perform_version_check)
 
     {{#apis}}

--- a/sdk/codegen/src/main/resources/fw-python/flywheel.mustache
+++ b/sdk/codegen/src/main/resources/fw-python/flywheel.mustache
@@ -45,7 +45,7 @@ def config_from_api_key(api_key):
     return config
 
 class Flywheel:
-    def __init__(self, api_key, root=False, skip_version_check=False):
+    def __init__(self, api_key, root=False, skip_version_check=True):
         # Init logging
         logging.basicConfig()
 
@@ -66,7 +66,7 @@ class Flywheel:
         {{/apis}}
 
         # Perform version check
-        self.check_version = not skip_version_check and not os.environ.get('FLYWHEEL_SDK_SKIP_VERSION_CHECK')
+        self.check_version = not skip_version_check or '0' == os.environ.get('FLYWHEEL_SDK_SKIP_VERSION_CHECK')
         self.api_client.set_version_check_fn(self.perform_version_check)
 
     {{#apis}}

--- a/sdk/codegen/src/main/resources/matlab/flywheel.mustache
+++ b/sdk/codegen/src/main/resources/matlab/flywheel.mustache
@@ -50,9 +50,10 @@ classdef Flywheel < handle
                 obj.apiClient.restClient.addDefaultParameter('root', 'true');
             end
 
-            obj.checkVersion = isempty(getenv('FLYWHEEL_SDK_SKIP_VERSION_CHECK'));
-            if obj.checkVersion && exist('skipVersionCheck', 'var') && skipVersionCheck
-                obj.checkVersion = false;
+            if exist('skipVersionCheck', 'var') && ~skipVersionCheck
+                obj.checkVersion = true;
+            else
+                obj.checkVersion = strcmp('0', getenv('FLYWHEEL_SDK_SKIP_VERSION_CHECK'));
             end
 
             userAgent = sprintf('Flywheel SDK/%s (Matlab %s; %s)', {{packageName}}.Flywheel.SDK_VERSION, version, computer);

--- a/sdk/codegen/src/main/resources/matlab/flywheel.mustache
+++ b/sdk/codegen/src/main/resources/matlab/flywheel.mustache
@@ -53,7 +53,8 @@ classdef Flywheel < handle
             if exist('skipVersionCheck', 'var') && ~skipVersionCheck
                 obj.checkVersion = true;
             else
-                obj.checkVersion = strcmp('0', getenv('FLYWHEEL_SDK_SKIP_VERSION_CHECK'));
+                skipEnv = getenv('FLYWHEEL_SDK_SKIP_VERSION_CHECK');
+                obj.checkVersion = strcmp('0', skipEnv) || strcmpi('false', skipEnv);
             end
 
             userAgent = sprintf('Flywheel SDK/%s (Matlab %s; %s)', {{packageName}}.Flywheel.SDK_VERSION, version, computer);


### PR DESCRIPTION
The SDK version check is too noisy, especially when working against dev projects. For now, toggle everything except for the major version comparison.

Can be re-enabled by passing `skip_version_check=False` or setting the environment variable:
`FLYWHEEL_SDK_SKIP_VERSION_CHECK=0`

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
