### PR TITLE
Use 'invalid' keyword for disabled gears

### DIFF
--- a/api/jobs/gears.py
+++ b/api/jobs/gears.py
@@ -25,7 +25,10 @@ def get_gears(all_versions=False, pagination=None):
 
     if all_versions:
         kwargs = {
+            # Invalid disables a gear from running entirely.
+            # https://github.com/flywheel-io/gears/tree/master/spec#reserved-custom-keys
             'filter': { 'gear.custom.flywheel.invalid': {'$ne': True} },
+
             'sort': [('gear.name', 1), ('created', -1)]
         }
         page = dbutil.paginate_find(config.db.gears, kwargs, pagination)
@@ -36,6 +39,7 @@ def get_gears(all_versions=False, pagination=None):
 
     pipe = [
         {'$match': {
+            # Same as above.
             'gear.custom.flywheel.invalid': {'$ne': True}}
         },
         {'$sort': {

--- a/api/jobs/gears.py
+++ b/api/jobs/gears.py
@@ -25,7 +25,7 @@ def get_gears(all_versions=False, pagination=None):
 
     if all_versions:
         kwargs = {
-            'filter': { 'gear.custom.flywheel.disabled': {'$ne': True} },
+            'filter': { 'gear.custom.flywheel.invalid': {'$ne': True} },
             'sort': [('gear.name', 1), ('created', -1)]
         }
         page = dbutil.paginate_find(config.db.gears, kwargs, pagination)
@@ -36,7 +36,7 @@ def get_gears(all_versions=False, pagination=None):
 
     pipe = [
         {'$match': {
-            'gear.custom.flywheel.disabled': {'$ne': True}}
+            'gear.custom.flywheel.invalid': {'$ne': True}}
         },
         {'$sort': {
             'gear.name': 1,

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -173,6 +173,8 @@ class Queue(object):
 
         gear = get_gear(gear_id)
 
+        # Invalid disables a gear from running entirely.
+        # https://github.com/flywheel-io/gears/tree/master/spec#reserved-custom-keys
         if gear.get('gear', {}).get('custom', {}).get('flywheel', {}).get('invalid', False):
             raise InputValidationException('Gear marked as invalid, will not run!')
 

--- a/tests/integration_tests/python/test_gears.py
+++ b/tests/integration_tests/python/test_gears.py
@@ -43,7 +43,7 @@ def test_gear_add_versioning(default_payload, randstr, data_builder, as_root):
 
     # create new gear w/ gear_version_3
     gear_payload['gear']['version'] = gear_version_3
-    gear_payload['gear'].setdefault('custom', {}).setdefault('flywheel', {})['disabled'] = True
+    gear_payload['gear'].setdefault('custom', {}).setdefault('flywheel', {})['invalid'] = True
     r = as_root.post('/gears/' + gear_name, json=gear_payload)
     assert r.ok
     gear_id_3 = r.json()['_id']


### PR DESCRIPTION
See #1350 - Used incorrect keyword for gears that shouldn't be runnable.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
