### PR TITLE
Pluggable gear transport

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -51,8 +51,7 @@ DEFAULT_CONFIG = {
     },
     'queue': {
         'max_retries': 3,
-        'retry_on_fail': False,
-        'prefetch': False
+        'retry_on_fail': False
     },
     'auth': {
         'google': {

--- a/api/jobs/gears.py
+++ b/api/jobs/gears.py
@@ -165,29 +165,8 @@ def insert_gear(doc):
 
     result = config.db.gears.insert(doc)
 
-    if config.get_item('queue', 'prefetch'):
-        log.info('Queuing prefetch job for gear %s', doc['gear']['name'])
-
-        job = Job(doc, {}, destination={}, tags=['prefetch'], request={
-            'inputs': [
-                {
-                    'type': 'http',
-                    'uri': doc['exchange']['rootfs-url'],
-                    'vu': 'vu0:x-' + doc['exchange']['rootfs-hash']
-                }
-            ],
-            'target': {
-                'command': ['uname', '-a'],
-                'env': {
-                    'PATH': '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-                },
-            },
-            'outputs': [ ],
-        })
-        job.insert()
     if last_gear:
         auto_update_rules(doc['_id'], last_gear.get('_id'))
-
 
     return result
 

--- a/api/jobs/gears.py
+++ b/api/jobs/gears.py
@@ -12,7 +12,6 @@ import gears as gear_tools
 
 from .. import config
 from ..dao import dbutil
-from .jobs import Job
 
 from ..web.errors import APIValidationException, APINotFoundException
 

--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -6,6 +6,7 @@ import bson
 import copy
 import datetime
 import string
+from urlparse import urlparse
 
 from ..types import Origin
 from ..dao.containerutil import create_filereference_from_dictionary, create_containerreference_from_dictionary, create_containerreference_from_filereference
@@ -278,11 +279,22 @@ class Job(object):
         if gear.get('gear', {}).get('custom', {}).get('flywheel', {}).get('invalid', False):
             raise Exception('Gear marked as invalid, will not run!')
 
+        uri = gear['exchange']['rootfs-url']
+        parsed = urlparse(uri)
+        scheme = parsed.scheme
+
+        if scheme == 'https':
+            # SSL does not change the input scheme type, both are just 'http'
+            scheme = 'http'
+        else:
+            # Other URI types keep the input scheme separate
+            uri = parsed.netloc + parsed.path
+
         r = {
             'inputs': [
                 {
-                    'type': 'http',
-                    'uri': gear['exchange']['rootfs-url'],
+                    'type': scheme,
+                    'uri': uri,
                     'vu': 'vu0:x-' + gear['exchange']['rootfs-hash'],
                     'location': '/',
                 }

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -351,7 +351,7 @@ class Queue(object):
                     # API-key gears cannot be peeked
                     return None
 
-        # Return if there is a job request already (probably prefetch)
+        # Return if there is a job request already
         if job.request is not None:
             log.info('Job %s already has a request, so not generating', job.id_)
             return job


### PR DESCRIPTION
1. Remove gear prefetch feature. It's a red-headed stepchild, and we've changed our tradeshow strategy to not use this anymore.
1. Allow the gear scheme to be non-http. Unlike http URIs, the scheme component is separated out into the input `type`.