### PR TITLE
Adds counters for timeout and connection reset

### DIFF
--- a/api/metrics/__init__.py
+++ b/api/metrics/__init__.py
@@ -1,0 +1,22 @@
+from .values import SYSTEM_TIMEOUT_ERROR_COUNT, SYSTEM_CONNECTION_RESET_COUNT
+
+# See: https://uwsgi-docs.readthedocs.io/en/latest/PythonModule.html#uwsgi.register_signal
+# And: https://uwsgi-docs.readthedocs.io/en/latest/AlarmSubsystem.html
+
+TIMEOUT_ERROR_SIGNAL = 64
+CONNECTION_RESET_SIGNAL = 65
+
+def register_signal_handlers():
+    """ Register signal handlers for timeout and connection reset errors """
+    try:
+        import uwsgi
+        uwsgi.register_signal(TIMEOUT_ERROR_SIGNAL, 'worker', handle_error_signal)
+        uwsgi.register_signal(CONNECTION_RESET_SIGNAL, 'worker', handle_error_signal)
+    except ImportError:
+        pass
+
+def handle_error_signal(num):
+    if num == TIMEOUT_ERROR_SIGNAL:
+        SYSTEM_TIMEOUT_ERROR_COUNT.inc()
+    elif num == CONNECTION_RESET_SIGNAL:
+        SYSTEM_CONNECTION_RESET_COUNT.inc()

--- a/api/metrics/values.py
+++ b/api/metrics/values.py
@@ -49,6 +49,9 @@ SYSTEM_DISK_WRITE_BYTES = Gauge('uwsgi_system_disk_write_bytes', 'Observed disk 
 # Disk Usage
 SYSTEM_DISK_BYTES_USED = Gauge('uwsgi_system_disk_bytes_used', 'Observed disk usage, in bytes', ['path'], multiprocess_mode='max')
 SYSTEM_DISK_BYTES_FREE = Gauge('uwsgi_system_disk_bytes_free', 'Observed disk availability, in bytes', ['path'], multiprocess_mode='max')
+# Timeout errors
+SYSTEM_TIMEOUT_ERROR_COUNT = Counter('uwsgi_timeout_errors', 'Observed TIMEOUT errors', [])
+SYSTEM_CONNECTION_RESET_COUNT = Counter('uwsgi_connection_resets', 'Observed Connection reset errors', [])
 
 # ===== DB Stats =====
 # DB Version

--- a/api/web/start.py
+++ b/api/web/start.py
@@ -67,6 +67,7 @@ from . import encoder
 from .. import util
 from .request import SciTranRequest
 from ..metrics.request_wrapper import RequestWrapper
+from ..metrics import register_signal_handlers
 
 try:
     import uwsgi
@@ -74,6 +75,7 @@ except ImportError:
     uwsgi = None
 
 log = config.log
+register_signal_handlers() # Register signal handlers to capture connection errors
 
 def dispatcher(router, request, response):
     with RequestWrapper(request, response) as metrics:

--- a/docker/uwsgi-config.ini
+++ b/docker/uwsgi-config.ini
@@ -21,3 +21,15 @@ exec-asap = (rm -rf /tmp/prometheus; mkdir -p /tmp/prometheus) || true
 # See: https://uwsgi-docs.readthedocs.io/en/latest/Mules.html
 mule = api.metrics.mule:run_mule
 farm = metrics:1
+
+# These alarms are added to metrics by capturing log messages,
+# then generating signals which are handled in api/metrics/__init__.py
+
+# Generate signals for timeout and connection reset
+# See: https://uwsgi-docs.readthedocs.io/en/latest/AlarmSubsystem.html
+alarm = timeouterror signal:64
+alarm = connectionreset signal:65
+
+# Trip alarm on log messages
+log-alarm = timeouterror uwsgi_response_write_body_do.*TIMEOUT
+log-alarm = connectionreset uwsgi_response_write_body_do.*Connection reset by peer


### PR DESCRIPTION
This adds [log alarms](https://uwsgi-docs.readthedocs.io/en/latest/AlarmSubsystem.html) that match regular expressions on:
```uwsgi_response_write_body_do() TIMEOUT```
and
```uwsgi_response_write_body_do(): Connection reset by peer```

Which then generate [signals](https://uwsgi-docs.readthedocs.io/en/latest/Signals.html) which then [increment the new counters](https://github.com/flywheel-io/core/compare/error-alerts?expand=1#diff-b8ba9a69a6dd6f6b37a540a7f4d08ef9R18).

If anyone knows a less Rube Goldbergy way of doing this, I'm all ears.

Manually tested by reproducing both messages locally.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
