### PR TITLE
Batch Optional Inputs

### DIFF
--- a/api/jobs/batch.py
+++ b/api/jobs/batch.py
@@ -87,8 +87,11 @@ def find_matching_conts(gear, containers, container_type, optional_input_policy,
                 opt_ignore = optional_input_policy == 'ignored' and is_optional_input
                 opt_required = optional_input_policy == 'required' or not is_optional_input
 
+                # Skip ambiguity check for this input if the policy is to ignore and the input is optional
                 if len(files) > 1 and not opt_ignore:
                     ambiguous = True
+                # Skip the not_matched check for this input if the policy is to ignore or to be flexible
+                # and the input is an optional input
                 elif opt_required and len(files) == 0:
                     not_matched = True
                     break

--- a/api/jobs/batch.py
+++ b/api/jobs/batch.py
@@ -83,9 +83,9 @@ def find_matching_conts(gear, containers, container_type, context_inputs=False,
             ambiguous = False  # Are any of the inputs ambiguous?
             not_matched = False
             for input_name, files in suggestions.iteritems():
-                if len(files) > 1:
+                if len(files) > 1 and not (ignore_optional and gear['gear']['inputs'][input_name].get('optional', False)):
                     ambiguous = True
-                elif not gear['gear']['inputs'][input_name].get('optional', False) and (ignore_optional or len(files) == 0):
+                elif not gear['gear']['inputs'][input_name].get('optional', False) and len(files) == 0:
                     not_matched = True
                     break
 

--- a/api/jobs/gears.py
+++ b/api/jobs/gears.py
@@ -110,7 +110,7 @@ def suggest_for_files(gear, files, context=None):
                     'base': 'context',
                     'found': False
                 }]
-        else:
+        elif input_.get('base') == 'file':
             schema = gear_tools.isolate_file_invocation(invocation_schema, x)
             schemas[x] = Draft4Validator(schema)
 

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -697,6 +697,8 @@ class BatchHandler(base.RequestHandler):
         analysis_data = payload.get('analysis', {})
         tags = payload.get('tags', [])
 
+        ignore_optional = self.is_true('ignore_optional_inputs')
+
         # Request might specify a collection context
         collection_id = payload.get('target_context', {}).get('id', None)
         if collection_id:
@@ -774,7 +776,9 @@ class BatchHandler(base.RequestHandler):
 
         else:
             # Look for file matches in each acquisition
-            results = batch.find_matching_conts(gear, perm_checked_conts, 'acquisition', context_inputs=context_inputs, uid=context_uid)
+            results = batch.find_matching_conts(gear, perm_checked_conts, 'acquisition',
+                                                context_inputs=context_inputs, uid=context_uid,
+                                                ignore_optional=ignore_optional)
 
         matched = results['matched']
         batch_proposal = {}

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -825,6 +825,8 @@ class BatchHandler(base.RequestHandler):
             batch_proposal.pop('proposal')
 
         # Either way, return information about the status of the containers
+        if has_optional_input:
+            batch_proposal['optional_input_policy'] = optional_input_policy
         batch_proposal['not_matched'] = results.get('not_matched', [])
         batch_proposal['ambiguous'] = results.get('ambiguous', [])
         batch_proposal['matched'] = matched

--- a/swagger/paths/batch.yaml
+++ b/swagger/paths/batch.yaml
@@ -22,6 +22,11 @@
         description: The batch proposal
         schema:
           $ref: schemas/input/propose-batch.json
+      - name: ignore_optional_inputs
+        in: query
+        required: false
+        description: Ignore optional inputs
+        type: boolean
     responses:
       '200':
         description: The batch proposal object that was created

--- a/swagger/paths/batch.yaml
+++ b/swagger/paths/batch.yaml
@@ -22,11 +22,6 @@
         description: The batch proposal
         schema:
           $ref: schemas/input/propose-batch.json
-      - name: ignore_optional_inputs
-        in: query
-        required: false
-        description: Ignore optional inputs
-        type: boolean
     responses:
       '200':
         description: The batch proposal object that was created

--- a/swagger/schemas/definitions/batch.json
+++ b/swagger/schemas/definitions/batch.json
@@ -13,6 +13,10 @@
       },
       "additionalProperties": false
     },
+    "optional_input_policy": {
+      "type": "string",
+      "enum": ["ignored", "flexible", "required"]
+    },
     "batch": {
       "type": "object",
       "properties": {
@@ -43,6 +47,7 @@
         "ambiguous": { "$ref": "#/definitions/matched-container-list" },
         "matched": { "$ref": "#/definitions/matched-container-list" },
         "not_matched": { "$ref": "#/definitions/matched-container-list" },
+        "optional_input_policy": {"$ref": "#/definitions/optional_input_policy"},
 
         "improper_permissions": {
           "type": "array",
@@ -60,6 +65,7 @@
         "gear_id": {"$ref":"job.json#/definitions/gear_id"},
         "config": {"$ref":"job.json#/definitions/config"},
         "tags": {"$ref":"tag.json#/definitions/tag-list"},
+        "optional_input_policy": {"$ref": "#/definitions/optional_input_policy"},
         "analysis": {"$ref": "analysis.json#/definitions/analysis-input-job"},
         "targets": {
           "type": "array",

--- a/swagger/schemas/definitions/batch.json
+++ b/swagger/schemas/definitions/batch.json
@@ -15,7 +15,8 @@
     },
     "optional_input_policy": {
       "type": "string",
-      "enum": ["ignored", "flexible", "required"]
+      "enum": ["ignored", "flexible", "required"],
+      "description": "ignored: Ignore all optional inputs, flexible: match a file if it's there, otherwise still match the container, required: treat all optional inputs as required inputs."
     },
     "batch": {
       "type": "object",

--- a/swagger/schemas/input/propose-batch.json
+++ b/swagger/schemas/input/propose-batch.json
@@ -5,6 +5,7 @@
     "example": {
 	    "gear_id": "59b1b5b0e105c40019f50015",
 	    "config": {},
+	    "optional_input_policy": "flexible",
 	    "tags": ["test-tag"],
 	    "targets": [{
 	    	"type": "session",

--- a/swagger/schemas/output/batch-proposal.json
+++ b/swagger/schemas/output/batch-proposal.json
@@ -5,6 +5,7 @@
     "example": {
 	    "_id": "5a33fa6352e95c001707489b",
 	    "gear_id": "59b1b5b0e105c40019f50015",
+	    "optional_input_policy": "required",
 	    "config": {},
 	    "state": "pending",
 	    "origin": {

--- a/tests/integration_tests/python/test_batch.py
+++ b/tests/integration_tests/python/test_batch.py
@@ -674,3 +674,109 @@ def test_file_input_context_batch(data_builder, default_payload, as_admin, as_ro
     api_db.jobs.remove({'gear_id': {'$in': [gear]}})
 
 
+def test_optional_input_batch(data_builder, default_payload, as_admin, as_root, file_form, randstr, api_db):
+    project = data_builder.create_project()
+    session = data_builder.create_session(project=project)
+    session2 = data_builder.create_session(project=project)
+    acquisition = data_builder.create_acquisition(session=session)
+    acquisition2 = data_builder.create_acquisition(session=session2)
+
+    as_admin.post('/acquisitions/' + acquisition + '/files', files={
+        'file': ('test.txt', 'test\ncontent\n')})
+
+    as_admin.post('/acquisitions/' + acquisition2 + '/files', files={
+        'file': ('test2.txt', 'test\ncontent2\n')})
+    as_admin.post('/acquisitions/' + acquisition2 + '/files', files={
+        'file': ('test2.csv', 'test\ncsv2\n')})
+
+    gear_name = randstr()
+    gear_doc = default_payload['gear']
+    gear_doc['gear']['name'] = gear_name
+    gear_doc['gear']['inputs'] = {
+        'text': {
+            'base': 'file',
+            'name': {'pattern': '^.*.txt$'},
+            'size': {'maximum': 100000}
+        },
+        'csv': {
+            'base': 'file',
+            'name': {'pattern': '^.*.csv$'},
+            'size': {'maximum': 100000},
+            'optional': True
+        }
+    }
+
+    r = as_root.post('/gears/' + gear_name, json=gear_doc)
+    assert r.ok
+    gear = r.json()['_id']
+
+    # create a batch w/o inputs targeting sessions
+    r = as_admin.post('/batch', json={
+        'gear_id': gear,
+        'targets': [{'type': 'session', 'id': session}, {'type': 'session', 'id': session2}]
+    })
+    assert r.ok
+    batch1 = r.json()
+
+    assert len(batch1['matched']) == 2
+    assert batch1['matched'][0]['_id'] == acquisition
+    assert 'inputs' not in batch1['matched'][0]
+    assert batch1['matched'][1]['_id'] == acquisition2
+    assert 'inputs' not in batch1['matched'][1]
+
+    batch_id = batch1['_id']
+
+    # run batch
+    r = as_admin.post('/batch/' + batch_id + '/run')
+    assert r.ok
+
+    # Check job configs for inputs
+    jobs = r.json()
+    job1_inputs = jobs[0]['config']['inputs']
+    assert len(job1_inputs) == 1
+    assert 'text' in job1_inputs
+
+    job2_inputs = jobs[1]['config']['inputs']
+    assert len(job2_inputs) == 2
+    assert 'text' in job2_inputs
+    assert 'csv' in job2_inputs
+
+    # Test ignore_optional_inputs param so that ambiguity is not a problem for optional inputs
+    as_admin.post('/acquisitions/' + acquisition2 + '/files', files={
+        'file': ('test2_2.csv', 'test\ncsv2_2\n')})
+
+    r = as_admin.post('/batch', json={
+        'gear_id': gear,
+        'targets': [{'type': 'session', 'id': session}, {'type': 'session', 'id': session2}]
+    }, params={'ignore_optional_inputs': 'true'})
+    assert r.ok
+    batch2 = r.json()
+
+    assert len(batch2['matched']) == 2
+    assert batch2['matched'][0]['_id'] == acquisition
+    assert 'inputs' not in batch2['matched'][0]
+    assert batch2['matched'][1]['_id'] == acquisition2
+    assert 'inputs' not in batch2['matched'][1]
+
+    batch_id = batch2['_id']
+
+    # run batch
+    r = as_admin.post('/batch/' + batch_id + '/run')
+    assert r.ok
+
+    # Check job configs for inputs
+    jobs = r.json()
+    job1_inputs = jobs[0]['config']['inputs']
+    assert len(job1_inputs) == 1
+    assert 'text' in job1_inputs
+
+    job2_inputs = jobs[1]['config']['inputs']
+    assert len(job2_inputs) == 1
+    assert 'text' in job2_inputs
+
+    # Cleanup
+    r = as_root.delete('/gears/' + gear)
+    assert r.ok
+
+    # must remove jobs manually because gears were added manually
+    api_db.jobs.remove({'gear_id': {'$in': [gear]}})


### PR DESCRIPTION
### Changes
New `optional_input_policy` is a required key for batch proposals if the gear has optional inputs
- `ignored`
  - Optional inputs are always ignored and will not contribute to whether a container is matched nor will it be used in the job as an input
  - Won't contribute to whether the container has ambiguous inputs
- `flexible`
  - If a file is in the container that is suggested for the optional input, it will be used, if not, the container will still be considered a match and that job will just run without the optional input
  - The container may be marked as ambiguous if multiple files are suggested for the optional input
- `required`
  - Optional inputs are treated the same as required inputs
  - This is current functionality

Fixes bug where gears that have file inputs and api-key inputs 500 on batch runs
### Required frontend changes
If a gear has optional inputs, the user must specify an `optional_input_policy`
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
