### PR TITLE
Sdk gear rules

### DIFF
--- a/api/auth/__init__.py
+++ b/api/auth/__init__.py
@@ -34,7 +34,7 @@ def _check_scope(scope, container, parent_container=None):
     if container and container.get('parents'):
         return scope['id'] in container['parents'].itervalues() or scope['id'] == container['_id']
     elif parent_container and parent_container.get('parents'):
-        return scope['id'] in parent_container['parents'].itervalues()
+        return scope['id'] in parent_container['parents'].itervalues() or scope['id'] == parent_container['_id']
 
 def has_access(uid, container, perm):
     return _get_access(uid, container) >= INTEGER_PERMISSIONS[perm]

--- a/api/auth/__init__.py
+++ b/api/auth/__init__.py
@@ -19,8 +19,11 @@ PERMISSIONS = [
 INTEGER_PERMISSIONS = {r['rid']: i for i, r in enumerate(PERMISSIONS)}
 
 def _get_access(uid, container, scope=None):
-    if scope and _check_scope(scope, container):
-        return INTEGER_PERMISSIONS[scope['access']]
+    if scope:
+        if _check_scope(scope, container):
+            return INTEGER_PERMISSIONS[scope['access']]
+        else:
+            return -1
     permissions_list = container.get('permissions', [])
     for perm in permissions_list:
         if perm['_id'] == uid:
@@ -28,15 +31,10 @@ def _get_access(uid, container, scope=None):
     return -1
 
 def _check_scope(scope, container, parent_container=None):
-    if scope:
-        # print "Scoped request"
-        if container and container.get('parents'):
-            # print type(scope['id'])
-            # print type(container['_id'])
-            return scope['id'] in container['parents'].itervalues() or scope['id'] == container['_id']
-        elif parent_container and parent_container.get('parents'):
-            return scope['id'] in parent_container['parents'].itervalues()
-    return True
+    if container and container.get('parents'):
+        return scope['id'] in container['parents'].itervalues() or scope['id'] == container['_id']
+    elif parent_container and parent_container.get('parents'):
+        return scope['id'] in parent_container['parents'].itervalues()
 
 def has_access(uid, container, perm):
     return _get_access(uid, container) >= INTEGER_PERMISSIONS[perm]

--- a/api/auth/__init__.py
+++ b/api/auth/__init__.py
@@ -18,12 +18,25 @@ PERMISSIONS = [
 
 INTEGER_PERMISSIONS = {r['rid']: i for i, r in enumerate(PERMISSIONS)}
 
-def _get_access(uid, container):
+def _get_access(uid, container, scope=None):
+    if scope and _check_scope(scope, container):
+        return INTEGER_PERMISSIONS[scope['access']]
     permissions_list = container.get('permissions', [])
     for perm in permissions_list:
         if perm['_id'] == uid:
             return INTEGER_PERMISSIONS[perm['access']]
     return -1
+
+def _check_scope(scope, container, parent_container=None):
+    if scope:
+        # print "Scoped request"
+        if container and container.get('parents'):
+            # print type(scope['id'])
+            # print type(container['_id'])
+            return scope['id'] in container['parents'].itervalues() or scope['id'] == container['_id']
+        elif parent_container and parent_container.get('parents'):
+            return scope['id'] in parent_container['parents'].itervalues()
+    return True
 
 def has_access(uid, container, perm):
     return _get_access(uid, container) >= INTEGER_PERMISSIONS[perm]

--- a/api/auth/apikeys.py
+++ b/api/auth/apikeys.py
@@ -131,8 +131,39 @@ class JobApiKey(APIKey):
             raise APIAuthProviderException('Use of API key requires job to be in progress')
 
 
+class RuleApiKey(JobApiKey):
+    key_type = 'rule-job'
+
+    # pylint: disable=arguments-differ
+    @classmethod
+    def generate(cls, job_id, scope):
+        """
+        Returns an API key for the system for use by a specific job.
+        Re-uses such a key if it already exists.
+        """
+
+        job_id = str(job_id)
+
+        existing_key = config.db.apikeys.find_one({
+            'uid': 'system',
+            'job': job_id,
+        })
+
+        if existing_key is not None:
+            return existing_key['_id']
+
+        else:
+            api_key = cls.generate_api_key('system')
+            api_key['job'] = job_id
+            api_key['scope'] = scope
+
+            config.db.apikeys.insert_one(api_key)
+            return api_key['_id']
+
+
 APIKeyTypes = {
     'device': DeviceApiKey,
     'user': UserApiKey,
     'job': JobApiKey,
+    'rule-job': RuleApiKey,
 }

--- a/api/auth/apikeys.py
+++ b/api/auth/apikeys.py
@@ -55,7 +55,6 @@ class APIKey(object):
         return {
             '_id': util.create_nonce(),
             'created': datetime.datetime.utcnow(),
-            'uid': uid,
             'type': cls.key_type,
             'last_used': None,
             'origin': {'type': cls.key_type, 'id': uid}
@@ -67,13 +66,13 @@ class APIKey(object):
         Generates API key, replaces existing API key if it exists
         """
         api_key = cls.generate_api_key(uid)
-        config.db.apikeys.delete_many({'uid': uid, 'type': cls.key_type})
+        config.db.apikeys.delete_many({'origin.id': uid, 'type': cls.key_type})
         config.db.apikeys.insert_one(api_key)
         return api_key['_id']
 
     @classmethod
     def get(cls, uid):
-        return config.db.apikeys.find_one({'uid': uid, 'type': cls.key_type})
+        return config.db.apikeys.find_one({'origin.id': uid, 'type': cls.key_type})
 
     @classmethod
     def check(cls, api_key):
@@ -107,7 +106,7 @@ class JobApiKey(APIKey):
         job_id = str(job_id)
 
         existing_key = config.db.apikeys.find_one({
-            'uid': uid,
+            'origin.id': uid,
             'job': job_id,
         })
 

--- a/api/auth/authproviders.py
+++ b/api/auth/authproviders.py
@@ -416,7 +416,7 @@ class APIKeyAuthProvider(AuthProvider):
             raise APIAuthProviderException('Only user API keys can be used to grant a session.')
         return {
             'access_token': code,
-            'uid': api_key['uid'],
+            'uid': api_key['origin']['id'],
             'auth_type': self.auth_type,
             'expires': datetime.datetime.utcnow() + datetime.timedelta(hours=1)
         }

--- a/api/auth/containerauth.py
+++ b/api/auth/containerauth.py
@@ -2,7 +2,7 @@
 Purpose of this module is to define all the permissions checker decorators for the ContainerHandler classes.
 """
 
-from . import _get_access, _check_scope, INTEGER_PERMISSIONS
+from . import _get_access, INTEGER_PERMISSIONS
 from ..web.errors import APIPermissionException
 
 
@@ -18,8 +18,6 @@ def default_container(handler, container=None, target_parent_container=None):
             errors = None
             if method == 'GET' and container.get('public', False):
                 has_access = True
-            elif not _check_scope(handler.scope, container, parent_container=target_parent_container):
-                has_access = False
             elif method == 'GET':
                 has_access = _get_access(handler.uid, container, scope=handler.scope) >= INTEGER_PERMISSIONS['ro']
             elif method == 'POST':
@@ -98,8 +96,6 @@ def default_referer(handler, parent_container=None):
             access = _get_access(handler.uid, parent_container, scope=handler.scope)
             if method == 'GET' and parent_container.get('public', False):
                 has_access = True
-            elif not _check_scope(handler.scope, None, parent_container=parent_container):
-                has_access = False
             elif method == 'GET':
                 has_access = access >= INTEGER_PERMISSIONS['ro']
             elif method in ['POST', 'PUT', 'DELETE']:

--- a/api/dao/basecontainerstorage.py
+++ b/api/dao/basecontainerstorage.py
@@ -293,6 +293,7 @@ class ContainerStorage(object):
 
     def update_el(self, _id, payload, unset_payload=None, recursive=False, r_payload=None, replace_metadata=False):
         replace = None
+        include_refs = False
         if replace_metadata:
             replace = {}
             if payload.get('info') is not None:

--- a/api/dao/basecontainerstorage.py
+++ b/api/dao/basecontainerstorage.py
@@ -249,6 +249,13 @@ class ContainerStorage(object):
         else:
             raise APIStorageException('The container level {} has no parent.'.format(self.cont_name))
 
+    def get_parent_id(self, _id, parent_type):
+        cont = self.get_container(_id)
+        if self.cont_name == containerutil.pluralize(parent_type):
+            return cont['_id']
+        if cont.get('parents') and cont['parents'].get(parent_type):
+            return cont['parents'][parent_type]
+
 
     def _from_mongo(self, cont):
         pass

--- a/api/dao/containerutil.py
+++ b/api/dao/containerutil.py
@@ -65,7 +65,7 @@ def propagate_changes(cont_name, cont_ids, query, update, include_refs=False):
     if include_refs:
         analysis_query = copy.deepcopy(query)
         analysis_update = copy.deepcopy(update)
-        analysis_update.pop('permissions', None)
+        analysis_update.get('$set', {}).pop('permissions', None)
         analysis_query.update({'parent.type': singularize(cont_name), 'parent.id': {'$in': cont_ids}})
         config.db.analyses.update_many(analysis_query, analysis_update)
 

--- a/api/dao/containerutil.py
+++ b/api/dao/containerutil.py
@@ -64,8 +64,10 @@ def propagate_changes(cont_name, cont_ids, query, update, include_refs=False):
 
     if include_refs:
         analysis_query = copy.deepcopy(query)
+        analysis_update = copy.deepcopy(update)
+        analysis_update.pop('permissions', None)
         analysis_query.update({'parent.type': singularize(cont_name), 'parent.id': {'$in': cont_ids}})
-        config.db.analyses.update_many(analysis_query, update)
+        config.db.analyses.update_many(analysis_query, analysis_update)
 
     if cont_name in ('groups', 'projects', 'sessions'):
         child_cont = containers[containers.index(cont_name) + 1]

--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -43,7 +43,7 @@ def get_parent(cont_name, _id, parent_type):
     cont = get_container(cont_name, _id)
     if cont.get('parents') and cont['parents'].get(parent_type):
         return cont['parents'][parent_type]
-    return cont.get('parents', {}).get('group')
+
 
 def get_parent_tree(cont_name, _id):
     """

--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -423,6 +423,8 @@ def _upsert_container(cont, cont_type, parent, parent_type, upload_type, timesta
         if cont_type == 'session':
             insert_vals['group'] = parent['group']
         cont.update(insert_vals)
+        if cont_name in ['acquisitions', 'sessions', 'projects', 'analyses']:
+            cont['parents'] = ContainerStorage.factory(cont_name).r_get_parent_tree(cont)
         insert_id = config.db[cont_name].insert(cont)
         cont['_id'] = insert_id
         return cont

--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -39,14 +39,6 @@ def get_container(cont_name, _id):
         '_id': _id,
     })
 
-def get_parent(cont_name, _id, parent_type):
-    cont = get_container(cont_name, _id)
-    if cont_name == containerutil.pluralize(parent_type):
-        return cont['_id']
-    if cont.get('parents') and cont['parents'].get(parent_type):
-        return cont['parents'][parent_type]
-
-
 def get_parent_tree(cont_name, _id):
     """
     Given a contanier and an id, returns that container and its parent tree.

--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -56,8 +56,8 @@ def get_parent_tree(cont_name, _id):
         'group':    <group>
     }
     """
-    cont_name = containerutil.singularize(cont_name)
 
+    cont_name = containerutil.singularize(cont_name)
 
     if cont_name not in ['acquisition', 'session', 'project', 'group', 'analysis']:
         raise ValueError('Can only construct tree from group, project, session, analysis or acquisition level')
@@ -430,7 +430,7 @@ def _upsert_container(cont, cont_type, parent, parent_type, upload_type, timesta
             insert_vals['group'] = parent['group']
         cont.update(insert_vals)
         if cont_name in ['acquisitions', 'sessions', 'projects', 'analyses']:
-            cont['parents'] = ContainerStorage.factory(cont_name).r_get_parent_tree(cont)
+            cont['parents'] = ContainerStorage.factory(cont_name).get_parents(cont)
         insert_id = config.db[cont_name].insert(cont)
         cont['_id'] = insert_id
         return cont

--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -41,6 +41,8 @@ def get_container(cont_name, _id):
 
 def get_parent(cont_name, _id, parent_type):
     cont = get_container(cont_name, _id)
+    if cont_name == containerutil.pluralize(parent_type):
+        return cont['_id']
     if cont.get('parents') and cont['parents'].get(parent_type):
         return cont['parents'][parent_type]
 

--- a/api/dao/hierarchy.py
+++ b/api/dao/hierarchy.py
@@ -39,6 +39,12 @@ def get_container(cont_name, _id):
         '_id': _id,
     })
 
+def get_parent(cont_name, _id, parent_type):
+    cont = get_container(cont_name, _id)
+    if cont.get('parents') and cont['parents'].get(parent_type):
+        return cont['parents'][parent_type]
+    return cont.get('parents', {}).get('group')
+
 def get_parent_tree(cont_name, _id):
     """
     Given a contanier and an id, returns that container and its parent tree.

--- a/api/jobs/gears.py
+++ b/api/jobs/gears.py
@@ -66,6 +66,13 @@ def get_latest_gear(name):
     if gears.count() > 0:
         return gears[0]
 
+def requires_read_write_key(gear):
+    for x in gear['gear'].get('inputs', {}).keys():
+        input_ = gear['gear']['inputs'][x]
+        if input_.get('base') == 'api-key' and not input_.get('read-only'):
+            return True
+    return False
+
 def get_invocation_schema(gear):
     return gear_tools.derive_invocation_schema(gear['gear'])
 

--- a/api/jobs/gears.py
+++ b/api/jobs/gears.py
@@ -160,6 +160,12 @@ def fill_gear_default_values(gear, config_):
 def count_file_inputs(geardoc):
     return len([inp for inp in geardoc['gear']['inputs'].values() if inp['base'] == 'file'])
 
+def filter_optional_inputs(geardoc):
+    filtered_gear_doc = copy.deepcopy(geardoc)
+    inputs = filtered_gear_doc['gear']['inputs'].iteritems()
+    filtered_gear_doc['gear']['inputs'] = {inp: inp_val for inp, inp_val in inputs if not inp_val.get('optional')}
+    return filtered_gear_doc
+
 def insert_gear(doc):
     gear_tools.validate_manifest(doc['gear'])
     last_gear = get_latest_gear(doc['gear']['name'])

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -496,7 +496,7 @@ class JobHandler(base.RequestHandler):
                             uid = j.origin['id']
                             api_key = JobApiKey.generate(uid, j.id_)
                         elif 'auto' in j.tags:
-                            project_id = hierarchy.get_parent(pluralize(j.destination.type), j.destination.id, 'project')
+                            project_id = cs_factory(pluralize(j.destination.type)).get_parent_id(j.destination.id, 'project')
                             api_key = JobApiKey.generate(None, j.id_, scope={'level': 'project', 'id': project_id, 'access': 'ro'})
                         else:
                             raise Exception('Cannot provide an API key to a job not launched by a user')

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -28,7 +28,7 @@ from ..web.request import AccessType
 from .gears import (
     validate_gear_config, get_gears, get_gear, get_latest_gear,
     get_invocation_schema, remove_gear,
-    upsert_gear, check_for_gear_insertion,
+    upsert_gear, check_for_gear_insertion, filter_optional_inputs,
     add_suggest_info_to_files, count_file_inputs, requires_read_write_key
 )
 
@@ -55,7 +55,7 @@ class GearsHandler(base.RequestHandler):
         gears = get_gears(all_versions=self.is_true('all_versions'))
         if 'single_input' in filters:
             filtered = True
-            gears = [gear for gear in gears if count_file_inputs(gear) <= 1]
+            gears = [gear for gear in gears if count_file_inputs(filter_optional_inputs(gear)) <= 1]
         if 'read_only_key' in filters:
             filtered = True
             gears = [gear for gear in gears if not requires_read_write_key(gear)]

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -13,7 +13,7 @@ from .. import config
 from .. import upload
 from .. import files
 from ..auth import require_drone, require_login, require_admin, has_access
-from ..auth.apikeys import JobApiKey, RuleApiKey
+from ..auth.apikeys import JobApiKey
 from ..dao import dbutil, hierarchy
 from ..dao.containerstorage import ProjectStorage, SessionStorage, SubjectStorage, AcquisitionStorage, AnalysisStorage, cs_factory
 from ..types import Origin
@@ -483,7 +483,7 @@ class JobHandler(base.RequestHandler):
                             api_key = JobApiKey.generate(uid, j.id_)
                         elif 'auto' in j.tags:
                             project_id = hierarchy.get_parent(pluralize(j.destination.type), j.destination.id, 'project')
-                            api_key = RuleApiKey.generate(j.id_, {'level': 'project', 'id': project_id, 'access': 'ro'})
+                            api_key = JobApiKey.generate(None, j.id_, scope={'level': 'project', 'id': project_id, 'access': 'ro'})
                         else:
                             raise Exception('Cannot provide an API key to a job not launched by a user')
 

--- a/api/jobs/rules.py
+++ b/api/jobs/rules.py
@@ -156,6 +156,7 @@ def queue_job_legacy(gear_id, input_):
     """
 
     gear = gears.get_gear(gear_id)
+    gear = gears.filter_optional_inputs(gear)
 
     if gears.count_file_inputs(gear) != 1:
         raise Exception("Legacy gear enqueue attempt of " + gear_id + " failed: must have exactly 1 input in manifest")
@@ -200,6 +201,7 @@ def create_potential_jobs(db, container, container_type, file_):
 
             gear_id = rule['gear_id']
             gear = gears.get_gear(gear_id)
+            gear = gears.filter_optional_inputs(gear)
             gear_name = gear['gear']['name']
 
             if rule.get('match') is None:

--- a/api/web/base.py
+++ b/api/web/base.py
@@ -73,6 +73,7 @@ class RequestHandler(webapp2.RequestHandler):
                     self.origin = {'type': Origin.user, 'id': self.uid}
                     if 'job' in api_key:
                         self.origin['via'] = {'type': Origin.job, 'id': api_key['job']}
+                        self.scope = api_key.get('scope')
             else:
                 # User (oAuth) authentication
                 self.uid = self.authenticate_user_token(session_token)
@@ -123,6 +124,9 @@ class RequestHandler(webapp2.RequestHandler):
         elif drone_request:
             self.superuser_request = True
             self.user_is_admin = True
+        elif self.scope is not None:
+            self.superuser_request = False
+            self.user_is_admin = False
         else:
             user = config.db.users.find_one({'_id': self.uid}, ['root', 'disabled'])
             if not user:

--- a/api/web/base.py
+++ b/api/web/base.py
@@ -28,6 +28,7 @@ class RequestHandler(webapp2.RequestHandler):
 
         self.uid = None
         self.origin = None
+        self.scope = None
 
         # If user is attempting to log in through `/login`, ignore Auth here:
         # In future updates, move login and logout handlers to class that overrides this init

--- a/api/web/base.py
+++ b/api/web/base.py
@@ -69,7 +69,7 @@ class RequestHandler(webapp2.RequestHandler):
                 if api_key.get('type') == 'device':
                     drone_request = True  # Grant same access for backwards compatibility
                 else:
-                    self.uid = api_key['uid']
+                    self.uid = api_key['origin']['id']
                     if 'job' in api_key:
                         self.scope = api_key.get('scope')
             else:

--- a/api/web/base.py
+++ b/api/web/base.py
@@ -65,14 +65,12 @@ class RequestHandler(webapp2.RequestHandler):
                 # API key authentication
                 key = session_token.split()[1]
                 api_key = APIKey.validate(key)
+                self.origin = api_key['origin']
                 if api_key.get('type') == 'device':
-                    self.origin = {'type': Origin.device, 'id': api_key['uid']}
                     drone_request = True  # Grant same access for backwards compatibility
                 else:
                     self.uid = api_key['uid']
-                    self.origin = {'type': Origin.user, 'id': self.uid}
                     if 'job' in api_key:
-                        self.origin['via'] = {'type': Origin.job, 'id': api_key['job']}
                         self.scope = api_key.get('scope')
             else:
                 # User (oAuth) authentication
@@ -116,7 +114,7 @@ class RequestHandler(webapp2.RequestHandler):
             if is_job_upload and job_id is not None:
                 self.origin = {'type': Origin.job, 'id': job_id}
 
-        self.public_request = not drone_request and not self.uid
+        self.public_request = not drone_request and not self.uid and not self.scope
 
         if self.public_request:
             self.superuser_request = False

--- a/bin/database.py
+++ b/bin/database.py
@@ -1806,7 +1806,8 @@ def upgrade_children_to_54(cont, cont_name):
 def upgrade_api_keys_to_54(cont):
     config.db.apikeys.update_one({'_id': cont['_id']},
                                  {'$set': {'origin': {'type': cont['type'],
-                                                      'id': cont['uid']}}})
+                                                      'id': cont['uid']}},
+                                  '$unset': {'uid': ''}})
     return True
 
 def upgrade_to_54():

--- a/bin/database.py
+++ b/bin/database.py
@@ -1803,13 +1803,23 @@ def upgrade_children_to_54(cont, cont_name):
 
     return True
 
+def upgrade_api_keys_to_54(cont):
+    config.db.apikeys.update_one({'_id': cont['_id']},
+                                 {'$set': {'origin': {'type': cont['type'],
+                                                      'id': cont['uid']}}})
+    return True
+
 def upgrade_to_54():
     """
     Set parents for all projects, sessions, acquisitions, and analyses
+    Apikeys have origins
     """
 
     cursor = config.db.projects.find({})
     process_cursor(cursor, upgrade_children_to_54, 'projects')
+
+    cursor = config.db.apikeys.find({})
+    process_cursor(cursor, upgrade_api_keys_to_54)
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ strict-rfc3339==0.7
 unicodecsv==0.9.0
 webapp2==2.5.2
 WebOb==1.8.2
-git+https://github.com/flywheel-io/gears.git@invocation-api-key-upgrade#egg=gears
+git+https://github.com/flywheel-io/gears.git@v0.1.8#egg=gears

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ strict-rfc3339==0.7
 unicodecsv==0.9.0
 webapp2==2.5.2
 WebOb==1.8.2
-git+https://github.com/flywheel-io/gears.git@v0.1.6#egg=gears
+git+https://github.com/flywheel-io/gears.git@invocation-api-key-upgrade#egg=gears

--- a/sdk/src/python/tests/integration_tests/init_db.py
+++ b/sdk/src/python/tests/integration_tests/init_db.py
@@ -27,7 +27,8 @@ def create_user(db, _id, api_key, **kwargs):
         'created': datetime.datetime.utcnow(),
         'last_seen': None,
         'type': 'user',
-        'uid': _id
+        'uid': _id,
+        'origin': {'type': 'user', 'id': _id}
     }, upsert=True)
 
 def init_db():

--- a/sdk/src/python/tests/integration_tests/init_db.py
+++ b/sdk/src/python/tests/integration_tests/init_db.py
@@ -27,7 +27,6 @@ def create_user(db, _id, api_key, **kwargs):
         'created': datetime.datetime.utcnow(),
         'last_seen': None,
         'type': 'user',
-        'uid': _id,
         'origin': {'type': 'user', 'id': _id}
     }, upsert=True)
 

--- a/swagger/schemas/definitions/acquisition.json
+++ b/swagger/schemas/definitions/acquisition.json
@@ -34,12 +34,13 @@
                 }
             },
             "additionalProperties": false
-        }, 
+        },
         "acquisition-output":{
             "type":"object",
             "properties": {
               "_id":          {"$ref":"common.json#/definitions/objectid"},
               "public":       {"$ref":"container.json#/definitions/public"},
+              "parents":      {"$ref":"container.json#/definitions/parents"},
               "label":        {"$ref":"common.json#/definitions/label"},
               "info":         {"$ref":"container.json#/definitions/info"},
               "session":      {"$ref":"common.json#/definitions/objectid"},

--- a/swagger/schemas/definitions/analysis.json
+++ b/swagger/schemas/definitions/analysis.json
@@ -87,6 +87,7 @@
 				"description": {"$ref":"common.json#/definitions/description"},
 				"label":       {"$ref":"common.json#/definitions/label"},
 				"parent":      {"$ref":"#/definitions/parent"},
+                "parents":      {"$ref":"container.json#/definitions/parents"},
 				"created":     {"$ref":"created-modified.json#/definitions/created"},
 				"modified":    {"$ref":"created-modified.json#/definitions/modified"}
 			},
@@ -110,6 +111,7 @@
 				"description": {"$ref":"common.json#/definitions/description"},
 				"label":       {"$ref":"common.json#/definitions/label"},
 				"parent":      {"$ref":"#/definitions/parent"},
+                "parents":      {"$ref":"container.json#/definitions/parents"},
 				"created":     {"$ref":"created-modified.json#/definitions/created"},
 				"modified":    {"$ref":"created-modified.json#/definitions/modified"}
 			},

--- a/swagger/schemas/definitions/container.json
+++ b/swagger/schemas/definitions/container.json
@@ -34,6 +34,16 @@
           "required": ["_id"],
           "x-sdk-return": "_id"
         },
+        "parents": {
+          "type": "object",
+          "properties": {
+            "analysis": {"$ref": "#/definitions/_id"},
+            "acquisition": {"$ref": "#/definitions/_id"},
+            "session": {"$ref": "#/definitions/_id"},
+            "project": {"$ref": "#/definitions/_id"},
+            "group": {"$ref": "#/definitions/_id"}
+          }
+        },
         "container-reference": {
           "type": "object",
           "properties": {

--- a/swagger/schemas/definitions/project.json
+++ b/swagger/schemas/definitions/project.json
@@ -31,6 +31,7 @@
             "properties": {
                 "_id":         {"$ref":"common.json#/definitions/objectid"},
                 "public":      {"$ref":"container.json#/definitions/public"},
+                "parents":      {"$ref":"container.json#/definitions/parents"},
                 "label":       {"$ref":"common.json#/definitions/label"},
                 "info":        {"$ref":"container.json#/definitions/info"},
                 "info_exists": {"$ref":"container.json#/definitions/info_exists"},

--- a/swagger/schemas/definitions/session.json
+++ b/swagger/schemas/definitions/session.json
@@ -51,6 +51,7 @@
                 "info_exists":  {"$ref":"container.json#/definitions/info_exists"},
                 "operator":     {"$ref":"#/definitions/operator"},
                 "project":      {"$ref":"common.json#/definitions/objectid"},
+                "parents":      {"$ref":"container.json#/definitions/parents"},
                 "uid":          {"$ref":"container.json#/definitions/uid"},
                 "timestamp":    {"$ref":"container.json#/definitions/timestamp"},
                 "timezone":     {"$ref":"container.json#/definitions/timezone"},

--- a/tests/fixtures/common.py
+++ b/tests/fixtures/common.py
@@ -277,7 +277,8 @@ class DataBuilder(object):
                 'created': datetime.datetime.utcnow(),
                 'last_seen': None,
                 'type': 'user',
-                'uid': _id
+                'uid': _id,
+                'origin': {'type': 'user', 'id': _id}
             })
 
         self.resources.append((resource, _id))

--- a/tests/fixtures/common.py
+++ b/tests/fixtures/common.py
@@ -277,7 +277,6 @@ class DataBuilder(object):
                 'created': datetime.datetime.utcnow(),
                 'last_seen': None,
                 'type': 'user',
-                'uid': _id,
                 'origin': {'type': 'user', 'id': _id}
             })
 
@@ -307,7 +306,7 @@ class DataBuilder(object):
         if resource == 'gear':
             self.api_db.jobs.remove({'gear_id': str(_id)})
         if resource == 'user':
-            self.api_db.apikeys.delete_one({'uid': _id})
+            self.api_db.apikeys.delete_one({'origin.id': _id})
         self.api_db[resource + 's'].remove({'_id': _id})
 
 

--- a/tests/integration_tests/python/test_analyses.py
+++ b/tests/integration_tests/python/test_analyses.py
@@ -47,11 +47,17 @@ def test_online_analysis(data_builder, as_admin, as_drone, file_form, api_db):
     assert r.ok
     analysis = r.json()['_id']
 
+    # Test that permission updates don't make it to analyses
+    r = as_admin.post('/projects/' + project + '/permission', json={
+        '_id': 'user@user.com',
+        'access': 'ro'})
+
     # Verify job was created with it
     r = as_admin.get('/analyses/' + analysis)
     assert r.ok
     job = r.json().get('job')
     assert job
+    assert not r.json().get('permissions')
 
     # Engine upload
     r = as_drone.post('/engine',
@@ -336,23 +342,53 @@ def test_moving_session_moves_analyses(data_builder, as_admin):
     project_1 = data_builder.create_project()
     project_2 = data_builder.create_project()
     session = data_builder.create_session(project=project_1)
+    acquisition = data_builder.create_acquisition(session=session)
 
-    # Create ad-hoc analysis
+    # Create ad-hoc analysis on session
     r = as_admin.post('/sessions/' + session + '/analyses', json={
-        'label': 'offline'
+        'label': 'session_offline'
     })
     assert r.ok
-    analysis = r.json()['_id']
+    session_analysis = r.json()['_id']
 
-    r = as_admin.get('/analyses/' + analysis)
+    # Create ad-hoc analysis on acquisition
+    r = as_admin.post('/acquisitions/' + acquisition + '/analyses', json={
+        'label': 'acquisition_offline'
+    })
+    assert r.ok
+    acquisition_analysis = r.json()['_id']
+
+    # Test that session analysis has current parents
+    r = as_admin.get('/analyses/' + session_analysis)
     assert r.ok
     parents = r.json()['parents']
     assert parents['project'] == project_1
 
+    # Test that acquisition analysis has current parents
+    r = as_admin.get('/analyses/' + acquisition_analysis)
+    assert r.ok
+    parents = r.json()['parents']
+    assert parents['project'] == project_1
+
+    # Move session
     r = as_admin.put('/sessions/' + session, json={'project': project_2})
     assert r.ok
 
-    r = as_admin.get('/analyses/' + analysis)
+    # Test session analysis parents updated
+    r = as_admin.get('/analyses/' + session_analysis)
+    assert r.ok
+    parents = r.json()['parents']
+    assert parents['project'] == project_2
+
+    # Test that acquisition parents are up to date
+    r = as_admin.get('/acquisitions/' + acquisition)
+    assert r.ok
+    assert r.json()['session'] == session
+    assert r.json()['parents']['session'] == session
+    assert r.json()['parents']['project'] == project_2
+
+    # Test acquisition analysis parents updated
+    r = as_admin.get('/analyses/' + acquisition_analysis)
     assert r.ok
     parents = r.json()['parents']
     assert parents['project'] == project_2

--- a/tests/integration_tests/python/test_containers.py
+++ b/tests/integration_tests/python/test_containers.py
@@ -12,6 +12,7 @@ def test_switching_project_between_groups(data_builder, as_admin):
     r = as_admin.get('/projects/' + project)
     assert r.ok
     assert r.json()['group'] == group_2
+    assert r.json()['parents']['group'] == group_2
 
     # Test switching to nonexisting project
     r = as_admin.put('/projects/' + project, json={'group': "doesnotexist"})
@@ -29,6 +30,7 @@ def test_switching_session_between_projects(data_builder, as_admin):
     r = as_admin.get('/sessions/' + session)
     assert r.ok
     assert r.json()['project'] == project_2
+    assert r.json()['parents']['project'] == project_2
 
     # Test switching to nonexisting project
     r = as_admin.put('/sessions/' + session, json={'project': "000000000000000000000000"})
@@ -46,6 +48,7 @@ def test_switching_acquisition_between_sessions(data_builder, as_admin):
     r = as_admin.get('/acquisitions/' + acquisition)
     assert r.ok
     assert r.json()['session'] == session_2
+    assert r.json()['parents']['session'] == session_2
 
     # Test switching to nonexisting project
     r = as_admin.put('/acquisitions/' + acquisition, json={'session': "000000000000000000000000"})

--- a/tests/integration_tests/python/test_containers.py
+++ b/tests/integration_tests/python/test_containers.py
@@ -27,6 +27,7 @@ def test_switching_session_between_projects(data_builder, as_admin):
     r = as_admin.put('/sessions/' + session, json={'project': project_2})
     assert r.ok
 
+    # Test that session parents and projects are up to date
     r = as_admin.get('/sessions/' + session)
     assert r.ok
     assert r.json()['project'] == project_2

--- a/tests/integration_tests/python/test_devices.py
+++ b/tests/integration_tests/python/test_devices.py
@@ -19,7 +19,7 @@ def test_devices(as_public, as_user, as_admin, as_root, as_drone, api_db):
 
     # bw-comp: verify test bootstrapper has api key after first get
     assert as_admin.get('/devices/' + drone_id).ok
-    assert api_db.apikeys.count({'uid': bson.ObjectId(drone_id), 'type': 'device'}) == 1
+    assert api_db.apikeys.count({'origin.id': bson.ObjectId(drone_id), 'type': 'device'}) == 1
 
     # verify users don't have access to device keys, but admins do
     assert 'key' not in drone
@@ -84,7 +84,7 @@ def test_devices(as_public, as_user, as_admin, as_root, as_drone, api_db):
     r = as_root.post('/devices', json={'type': 'test'})
     assert r.ok
     device_id = r.json()['_id']
-    assert api_db.apikeys.count({'uid': bson.ObjectId(device_id), 'type': 'device'}) == 1
+    assert api_db.apikeys.count({'origin.id': bson.ObjectId(device_id), 'type': 'device'}) == 1
     r = as_admin.get('/devices/' + device_id)
     assert r.ok
     device_key = r.json()['key']

--- a/tests/integration_tests/python/test_gears.py
+++ b/tests/integration_tests/python/test_gears.py
@@ -1,3 +1,5 @@
+import bson
+
 def test_gear_add_versioning(default_payload, randstr, data_builder, as_root):
     gear_name = randstr()
     gear_version_1 = '0.0.1'
@@ -400,3 +402,29 @@ def test_gear_context(data_builder, default_payload, as_admin, as_root, randstr)
     assert r.ok
 
 
+def test_filter_gears_read_only_key(randstr, data_builder, default_payload, as_admin, api_db):
+    gear_name = randstr()
+    gear_doc = default_payload['gear']
+    gear_doc['gear']['name'] = gear_name
+    gear_doc['gear']['inputs'] = {
+        'api_key': {
+            'base': 'api-key'
+        }
+    }
+
+    ro_gear = data_builder.create_gear(gear=gear_doc['gear'])
+
+    non_key_gear = data_builder.create_gear()
+
+    # gear_doc['gear']['inputs']['api_key']['read-only'] = False
+    gear_doc['gear']['name'] = randstr()
+    rw_gear = data_builder.create_gear(gear=gear_doc['gear'])
+
+    api_db.gears.update_one({'_id': bson.ObjectId(ro_gear)}, {'$set': {'gear.inputs.api_key.read-only': True}})
+
+
+    r = as_admin.get('/gears', params={'filter': 'read_only_key'})
+    assert r.ok
+    assert len(r.json()) == 2
+    for response_gear in r.json():
+        assert response_gear['_id'] != rw_gear

--- a/tests/integration_tests/python/test_gears.py
+++ b/tests/integration_tests/python/test_gears.py
@@ -402,13 +402,14 @@ def test_gear_context(data_builder, default_payload, as_admin, as_root, randstr)
     assert r.ok
 
 
-def test_filter_gears_read_only_key(randstr, data_builder, default_payload, as_admin, api_db):
+def test_filter_gears_read_only_key(randstr, data_builder, default_payload, as_admin):
     gear_name = randstr()
     gear_doc = default_payload['gear']
     gear_doc['gear']['name'] = gear_name
     gear_doc['gear']['inputs'] = {
         'api_key': {
-            'base': 'api-key'
+            'base': 'api-key',
+            'read-only': True
         }
     }
 
@@ -416,11 +417,10 @@ def test_filter_gears_read_only_key(randstr, data_builder, default_payload, as_a
 
     non_key_gear = data_builder.create_gear()
 
-    # gear_doc['gear']['inputs']['api_key']['read-only'] = False
+    gear_doc['gear']['inputs']['api_key']['read-only'] = False
     gear_doc['gear']['name'] = randstr()
     rw_gear = data_builder.create_gear(gear=gear_doc['gear'])
 
-    api_db.gears.update_one({'_id': bson.ObjectId(ro_gear)}, {'$set': {'gear.inputs.api_key.read-only': True}})
 
 
     r = as_admin.get('/gears', params={'filter': 'read_only_key'})

--- a/tests/integration_tests/python/test_jobs.py
+++ b/tests/integration_tests/python/test_jobs.py
@@ -1118,7 +1118,7 @@ def test_scoped_job_api_key(data_builder, default_payload, as_public, as_admin, 
     assert r.ok
 
     # ensure only ro access
-    r = as_job_key.put('/projects/' + project, json={label='NewLabel'})
+    r = as_job_key.put('/projects/' + project, json={'label': 'NewLabel'})
     assert r.status_code == 403
 
     # ensure api_key can access public projects
@@ -1130,6 +1130,11 @@ def test_scoped_job_api_key(data_builder, default_payload, as_public, as_admin, 
     project_3 = data_builder.create_project(public=False)
     r = as_job_key.get('/projects/' + project_3)
     assert r.status_code == 403
+
+    # test get_all
+    r = as_job_key.get('/projects')
+    assert r.ok
+    assert len(r.json()) == 2
 
     # complete job and ensure API key no longer works
     r = as_root.put('/jobs/' + job_id, json={'state': 'complete'})

--- a/tests/integration_tests/python/test_jobs.py
+++ b/tests/integration_tests/python/test_jobs.py
@@ -1061,7 +1061,7 @@ def test_job_requests(randstr, default_payload, data_builder, as_admin, as_drone
         assert request_input.get('type')
 
 
-def test_scoped_job_api_key(randstr, data_builder, default_payload, as_public, as_admin, as_root, api_db, file_form):
+def test_scoped_job_api_key(randstr, data_builder, default_payload, as_public, as_admin, as_root, file_form):
     gear_doc = default_payload['gear']['gear']
 
     rw_gear_name = randstr()
@@ -1074,9 +1074,13 @@ def test_scoped_job_api_key(randstr, data_builder, default_payload, as_public, a
     rw_gear = data_builder.create_gear(gear=gear_doc)
     gear_name = randstr()
     gear_doc['name'] = gear_name
+    gear_doc['inputs'] = {
+        "api_key": {
+          "base": "api-key",
+          "read-only": True
+        }
+    }
     ro_gear = data_builder.create_gear(gear=gear_doc)
-
-    api_db.gears.update_one({'_id': bson.ObjectId(ro_gear)}, {'$set': {'gear.inputs.api_key.read-only': True}})
 
     group = data_builder.create_group()
     project = data_builder.create_project(public=False)

--- a/tests/integration_tests/python/test_upgrades.py
+++ b/tests/integration_tests/python/test_upgrades.py
@@ -480,7 +480,10 @@ def test_54(randstr, api_db, database):
     analysis = bson.ObjectId()
     api_db.analyses.insert_one({'_id': analysis, 'parent': {'type': 'session', 'id': session_2}})
 
-    # Create Apikey
+    # Create Apikey, also make sure other apikeys follow old schema
+    cursor = api_db.apikeys.find({})
+    for key in cursor:
+        api_db.apikeys.update_one({'_id': key['_id']}, {'$set': {'uid': key['origin']['id']}, '$unset': {'origin': ""}})
     apikey = bson.ObjectId()
     api_db.apikeys.insert_one({'_id': apikey, 'uid': 'Me@some.com', 'type': 'user'})
 

--- a/tests/integration_tests/python/test_upgrades.py
+++ b/tests/integration_tests/python/test_upgrades.py
@@ -480,6 +480,10 @@ def test_54(randstr, api_db, database):
     analysis = bson.ObjectId()
     api_db.analyses.insert_one({'_id': analysis, 'parent': {'type': 'session', 'id': session_2}})
 
+    # Create Apikey
+    apikey = bson.ObjectId()
+    api_db.apikeys.insert_one({'_id': apikey, 'uid': 'Me@some.com', 'type': 'user'})
+
     database.upgrade_to_54()
 
     project_1_parents = api_db.projects.find_one({'_id': project_1})['parents']
@@ -488,6 +492,7 @@ def test_54(randstr, api_db, database):
     session_2_parents = api_db.sessions.find_one({'_id': session_2})['parents']
     acquisition_parents = api_db.acquisitions.find_one({'_id': acquisition})['parents']
     analysis_parents = api_db.analyses.find_one({'_id': analysis})['parents']
+    apikey_origin = api_db.apikeys.find_one({'_id': apikey})['origin']
 
     assert project_1_parents['group'] == group
     assert project_2_parents['group'] == group
@@ -504,6 +509,9 @@ def test_54(randstr, api_db, database):
     assert acquisition_parents['session'] == session_1
     assert analysis_parents['session'] == session_2
 
+    assert apikey_origin['id'] == 'Me@some.com'
+    assert apikey_origin['type'] == 'user'
+
     api_db.groups.delete_one({'_id': group})
     api_db.projects.delete_one({'_id': project_1})
     api_db.projects.delete_one({'_id': project_2})
@@ -511,3 +519,4 @@ def test_54(randstr, api_db, database):
     api_db.sessions.delete_one({'_id': session_2})
     api_db.acquisitions.delete_one({'_id': acquisition})
     api_db.analyses.delete_one({'_id': analysis})
+    api_db.apikeys.delete_one({'_id': apikey})


### PR DESCRIPTION
### Changes
- new key for projects, sessions, acquisitions, and analyses: `parents`
  - ```parents: {project: projectId, group: groupId, ...}```
  - Containers will only have the applicable keys in `parents`
- New type of job api key
  - stores takes a `scope: {level: cont_type, id: cont_id, access: permission level}`
- jobs with tag `auto` that have an api key input get the above type of key
  - scope is set to `{level: project, id: projectId, access: ro}`
- auth layer checks for handler.scope (which is set from the api key)

- [x] __Note to self__: Change tests to not use db updates to set read-only once gear spec is updated
- [x] Add tests for optional inputs in rules
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
