### PR TITLE
Allow empty contents on upload

### DIFF
--- a/sdk/codegen/src/main/resources/fw-python/file_spec.mustache
+++ b/sdk/codegen/src/main/resources/fw-python/file_spec.mustache
@@ -11,7 +11,7 @@ class FileSpec:
         self.content_type = content_type
 
     def to_file_tuple(self):
-        if not self.contents:
+        if self.contents is None:
             if not self.name:
                 raise RuntimeError('FileSpec is invalid, file or content is required!')
             # TODO: Switch to library that supports file streaming


### PR DESCRIPTION
Trying to upload a valid, but empty file fails. This corrects the check for contents.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
