### PR TITLE
Add regex operator to pagination filter

### DIFF
--- a/api/util.py
+++ b/api/util.py
@@ -428,7 +428,8 @@ def parse_pagination_filter_param(filter_param):
                   '=':  '$eq',
                   '!=': '$ne',
                   '>=': '$gte',
-                  '>':  '$gt'}
+                  '>':  '$gt',
+                  '=~': '$regex'}
     for filter_str in filter_param.split(','):
         for filter_op in sorted(filter_ops, key=len, reverse=True):
             key, op, value = filter_str.partition(filter_op)

--- a/tests/integration_tests/python/test_data_views.py
+++ b/tests/integration_tests/python/test_data_views.py
@@ -1280,6 +1280,19 @@ def test_data_view_filtering(data_builder, file_form, as_admin):
     rows = r.json()['data']
     assert len(rows) == 1
 
+    # Regex filter=subject.code~=\d+
+    r = as_admin.post('/views/data?containerId={}&filter=subject.code=~%5Cd%2B'.format(project), json={
+        'includeIds': True,
+        'includeLabels': True,
+        'columns': [
+            { 'src': 'session.label' },
+        ]
+    })
+
+    assert r.ok
+    rows = r.json()['data']
+    assert len(rows) == 2
+
     assert rows[0]['project.id'] == project
     assert rows[0]['project.label'] == 'test-project'
     assert rows[0]['subject.label'] == subject1['code']

--- a/tests/integration_tests/python/test_pagination.py
+++ b/tests/integration_tests/python/test_pagination.py
@@ -202,6 +202,12 @@ def test_filter(data_builder, as_admin):
     r = as_admin.get('/acquisitions?filter=label>=b')
     assert {aq['_id'] for aq in r.json()} == {b, c}
 
+    r = as_admin.get('/acquisitions?filter=label=~(a|c)')
+    assert {aq['_id'] for aq in r.json()} == {a, c}
+
+    r = as_admin.get('/acquisitions?filter=label=~[ab]')
+    assert {aq['_id'] for aq in r.json()} == {a, b}
+
     r = as_admin.get('/acquisitions?filter=label>b')
     assert {aq['_id'] for aq in r.json()} == {c}
 


### PR DESCRIPTION
Allow regex filtering in pagination via `=~` operator.
e.g. `?filter=subject.code=~control.*`

Also is a workaround for #1288 

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
