### PR TITLE
Fix packfile upload

### DIFF
--- a/api/files.py
+++ b/api/files.py
@@ -91,23 +91,20 @@ class FileProcessor(object):
 
         return form
 
-    def hash_file_formatted(self, filepath, f_system, hash_alg=None, buffer_size=65536):
+    @staticmethod
+    def hash_file_formatted(file_obj, hash_alg=None, buffer_size=65536):
         """
         Return the scitran-formatted hash of a file, specified by path.
         """
 
-        if not isinstance(filepath, unicode):
-            filepath = six.u(filepath)
-
         hash_alg = hash_alg or DEFAULT_HASH_ALG
         hasher = hashlib.new(hash_alg)
 
-        with f_system.open(filepath, 'rb') as f:
-            while True:
-                data = f.read(buffer_size)
-                if not data:
-                    break
-                hasher.update(data)
+        while True:
+            data = file_obj.read(buffer_size)
+            if not data:
+                break
+            hasher.update(data)
 
         return util.format_hash(hash_alg, hasher.hexdigest())
 

--- a/api/handlers/refererhandler.py
+++ b/api/handlers/refererhandler.py
@@ -531,7 +531,7 @@ class AnalysesHandler(RefererHandler):
             file_path, _ = files.get_valid_file(f)
             targets.append((file_path,
                             '/'.join([util.sanitize_string_to_filename(analysis['label']), dirname, f['name']]),
-                            'analyses', analysis['_id'], f['size']))
+                            'analyses', analysis['_id'], f['size'], f['modified']))
             total_size += f['size']
             total_cnt += 1
         return targets, total_size, total_cnt

--- a/api/placer.py
+++ b/api/placer.py
@@ -585,7 +585,7 @@ class PackfilePlacer(Placer):
             'id': uid
         }
         with open(self.local_path, 'rb') as f:
-            hash = files.FileProcessor.hash_file_formatted(f)
+            _hash = files.FileProcessor.hash_file_formatted(f)
         os.remove(self.local_path)
 
         # Create an anyonmous object in the style of our augmented file fields.
@@ -594,7 +594,7 @@ class PackfilePlacer(Placer):
             'filename': self.name,
             'path': self.path,
             'size': int(self.file_processor.temp_fs.getsize(self.path)),
-            'hash': hash,
+            'hash': _hash,
             'uuid': str(uuid.uuid4()),
             'mimetype': util.guess_mimetype('lol.zip'),
             'modified': self.timestamp

--- a/tests/fixtures/common.py
+++ b/tests/fixtures/common.py
@@ -139,6 +139,7 @@ def bootstrap_users(session, api_db):
     yield data_builder
     api_db.users.delete_many({})
     api_db.singletons.delete_one({'_id': 'bootstrap'})
+    api_db.apikeys.delete_many({})
 
 
 @pytest.fixture(scope='session')

--- a/tests/unit_tests/python/test_download.py
+++ b/tests/unit_tests/python/test_download.py
@@ -1,0 +1,83 @@
+import cStringIO
+import tarfile
+
+import webob.exc
+
+from mock import MagicMock
+from requests import exceptions
+
+
+def test_archive_stream(mocker, data_builder, file_form, as_drone):
+    def iter_content_mock():
+        yield 'test'
+
+    get_return_value = MagicMock()
+    get_return_value.iter_content.return_value = iter_content_mock()
+    mocked_files = mocker.patch('api.files.get_signed_url')
+
+    project = data_builder.create_project(label='project1')
+    session = data_builder.create_session(label='session1', project=project)
+    session2 = data_builder.create_session(label='session1', project=project)
+    acquisition = data_builder.create_acquisition(session=session)
+    acquisition2 = data_builder.create_acquisition(session=session2)
+
+    # upload the same file to each container created and use different tags to
+    # facilitate download filter tests:
+    # acquisition: [], session: ['plus'], project: ['plus', 'minus']
+    file_name = 'test.csv'
+    as_drone.post('/acquisitions/' + acquisition + '/files', POST=file_form(
+        file_name, meta={'name': file_name, 'type': 'csv'}))
+
+    as_drone.post('/acquisitions/' + acquisition2 + '/files', POST=file_form(
+        file_name, meta={'name': file_name, 'type': 'csv'}))
+
+    r = as_drone.post('/download', json={
+        'optional': False,
+        'nodes': [
+            {'level': 'acquisition', '_id': acquisition},
+            {'level': 'acquisition', '_id': acquisition2},
+        ]
+    })
+    assert r.ok
+    ticket = r.json['ticket']
+
+    with mocker.patch('api.download.requests.Session.get', return_value=get_return_value) as mocked_session:
+        # Perform the download
+        r = as_drone.get('/download?ticket=%s' % ticket)
+        assert r.ok
+
+        tar_file = cStringIO.StringIO(r.body)
+        tar = tarfile.open(mode="r", fileobj=tar_file)
+
+        # Verify a single file in tar with correct file name
+        tarinfo_list = list(tar)
+        # it contains two files
+        assert len(tarinfo_list) == 2
+
+        assert mocked_files.called
+        assert get_return_value.iter_content.called
+
+    def iter_content_error_mock():
+        yield 'test'
+        raise exceptions.ConnectionError()
+
+    get_return_value = MagicMock()
+    get_return_value.iter_content.return_value = iter_content_error_mock()
+
+    with mocker.patch('api.download.requests.Session.get', return_value=get_return_value) as mocked_session:
+        r = as_drone.post('/download', json={
+            'optional': False,
+            'nodes': [
+                {'level': 'acquisition', '_id': acquisition},
+                {'level': 'acquisition', '_id': acquisition2},
+            ]
+        })
+        assert r.ok
+        ticket = r.json['ticket']
+
+        # Perform the download
+        r = as_drone.get('/download?ticket=%s' % ticket)
+        try:
+            assert r.body
+        except webob.exc.HTTPInternalServerError as e:
+            assert (str(e).startswith('Error happened during sending file content in archive stream'))

--- a/tests/unit_tests/python/test_uploads.py
+++ b/tests/unit_tests/python/test_uploads.py
@@ -1,6 +1,3 @@
-import requests_mock
-
-
 def test_signed_url_reaper_upload(as_drone, mocker):
 
     payload = {


### PR DESCRIPTION
To calculate the hash of the zip file we need to read the whole file after the zip is done. 
When we use OBS it uploads the file continuously during write operations. 
Since OBS cache is not implemented yet, we have to download the whole zipfile to calc its hash. 
The connection hangs during the download and the connection can be closed before the placer finished processing the zip.
Creating a zip with the same content, enable us to calculate the hash without downloading the zip.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
