### PR TITLE
Allow after_id to be blank, don't overwrite filter

### DIFF
--- a/api/dao/dbutil.py
+++ b/api/dao/dbutil.py
@@ -71,7 +71,8 @@ def paginate_find(collection, find_kwargs, pagination):
         if 'after_id' in pagination:
             if find_kwargs.get('sort'):
                 raise PaginationError('pagination "after_id" does not support sorting')
-            pagination['filter'] = {'_id': {'$gt': pagination['after_id']}}
+            if pagination['after_id']:
+                pagination.setdefault('filter', {})['_id'] = {'$gt': pagination['after_id']}
             pagination['sort'] = [('_id', pymongo.ASCENDING)]
 
         if 'filter' in pagination:


### PR DESCRIPTION
Super minor change, but fixes two items:

1.  If you specify a filter, no longer overwrite that filter with the `after_id` filter.
2. If you specify an empty `after_id` parameter, then you still get the first page with explicit sorting by id

This allows to clients to do filtered pagination with after_id. e.g.

`GET /api/jobs?filter=gear_info.name=afq&limit=100&after_id`
`GET /api/jobs?filter=gear_info.name=afq&limit=100&after_id=5b855379193b2ce5a0096982`

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
