### PR TITLE
SDK find functions

### DIFF
--- a/sdk/codegen/src/main/java/io/flywheel/codegen/MatlabGenerator.java
+++ b/sdk/codegen/src/main/java/io/flywheel/codegen/MatlabGenerator.java
@@ -206,6 +206,9 @@ public class MatlabGenerator extends DefaultCodegen implements CodegenConfig {
         supportingFiles.add(new SupportingFile("client.mustache", packageFolder, "Client.m"));
         // Dataview files
         supportingFiles.add(new SupportingFile("ViewBuilder.m", packageFolder, "ViewBuilder.m"));
+        // Finder
+        supportingFiles.add(new SupportingFile("Finder.mustache", packageFolder, "Finder.m"));
+        supportingFiles.add(new SupportingFile("Cursor.m", packageFolder, "Cursor.m"));
 
         // Mixin Files
         final String mixinFolder = packageFolder + "/+mixins";

--- a/sdk/codegen/src/main/java/io/flywheel/codegen/PythonGenerator.java
+++ b/sdk/codegen/src/main/java/io/flywheel/codegen/PythonGenerator.java
@@ -60,6 +60,7 @@ public class PythonGenerator extends PythonClientCodegen implements CodegenConfi
 
         // Other API files
         supportingFiles.add(new SupportingFile("view_builder.py", packageName, "view_builder.py"));
+        supportingFiles.add(new SupportingFile("finder.py", packageName, "finder.py"));
         supportingFiles.add(new SupportingFile("mixins.py", modelFolder, "mixins.py"));
 
         // PIP Files

--- a/sdk/codegen/src/main/resources/fw-python/finder.py
+++ b/sdk/codegen/src/main/resources/fw-python/finder.py
@@ -1,0 +1,119 @@
+"""Provides finder interface for collections"""
+
+class Finder(object):
+    """Finder wrapper for finding objects in a collection"""
+    def __init__(self, context, method, *args):
+        """ Create a new finder object for the given method
+
+        :param object context: The context object (i.e. Flywheel client)
+        :param str method: The name of the method to invoke (must support pagination)
+        :param args: Additional arguments to pass to the find function (e.g. id)
+        """
+        self._context = context
+        self._method = method
+        self._args = args
+        self._fn = None
+
+    def __call__(self, *args, **kwargs):
+        """Invoke the underlying get function directly
+
+        :param str filter: The filter to apply. (e.g. label=my-label,created>2018-09-22)
+        :param str sort: The sort fields and order. (e.g. label:asc,created:desc)
+        :param int limit: The maximum number of entries to return.
+        :param int skip: The number of entries to skip.
+        :param int page: The page number (i.e. skip limit*page entries)
+        :param str after_id: Paginate after the given id. (Cannot be used with sort, page or skip)
+        """
+        return self._func(*(self._args + args), **kwargs)
+
+    def find(self, *args, **kwargs):
+        """Find all items in the collection that match the provided filter
+
+        :param args: The list of filters to apply (e.g. 'label=my-label' , 'created>2018-09-22')
+        :param str sort: The sort fields and order. (e.g. label:asc,created:desc)
+        :param int limit: The maximum number of entries to return.
+        :param int skip: The number of entries to skip.
+        :param int page: The page number (i.e. skip limit*page entries)
+        :param str after_id: Paginate after the given id. (Cannot be used with sort, page or skip)
+        """
+        return self.__find(args, kwargs)
+
+    def find_one(self, *args, **kwargs):
+        """Find exactly one item matching the provided filter. Raises a ValueError if 0 or 2+ items matched.
+
+        :param args: The list of filters to apply (e.g. 'label=my-label' , 'created>2018-09-22')
+        :param str sort: The sort fields and order. (e.g. label:asc,created:desc)
+        :param int limit: The maximum number of entries to return.
+        :param int skip: The number of entries to skip.
+        :param int page: The page number (i.e. skip limit*page entries)
+        :param str after_id: Paginate after the given id. (Cannot be used with sort, page or skip)
+        """
+        return self.__find(args, kwargs, find_one=True)
+
+    def find_first(self, *args, **kwargs):
+        """Find the first item matching the provided filter. Returns None if no items matched.
+
+        :param args: The list of filters to apply (e.g. 'label=my-label' , 'created>2018-09-22')
+        :param str sort: The sort fields and order. (e.g. label:asc,created:desc)
+        :param int limit: The maximum number of entries to return.
+        :param int skip: The number of entries to skip.
+        :param int page: The page number (i.e. skip limit*page entries)
+        :param str after_id: Paginate after the given id. (Cannot be used with sort, page or skip)
+        """
+        return self.__find(args, kwargs, find_first=True)
+
+    def iter(self, limit=250):
+        """Iterate over all items in the collection, without limit.
+
+        :param int limit: The number of entries to return per call (default is 250)
+        """
+        return self.iter_find(limit=limit)
+
+    def iter_find(self, *args, **kwargs):
+        """Find all items in the collection that match the provided filter, without limit.
+
+        :param args: The list of filters to apply (e.g. 'label=my-label' , 'created>2018-09-22')
+        :param int limit: The number of entries to return per call (default is 250)
+        """
+        if 'limit' not in kwargs:
+            kwargs['limit'] = 250
+
+        if args:
+            kwargs['filter'] = ','.join(args)
+
+        kwargs['after_id'] = ''
+
+        while True:
+            results = self._func(*self._args, **kwargs)
+
+            if not results:
+                break
+
+            for item in results:
+                yield item
+
+            kwargs['after_id'] = results[-1].id
+
+    @property
+    def _func(self):
+        if not self._fn:
+            self._fn = getattr(self._context, self._method)
+        return self._fn
+
+    def __find(self, filters, kwargs, find_first=False, find_one=False):
+        if filters:
+            kwargs['filter'] = ','.join(filters)
+
+        results = self._func(*self._args, **kwargs)
+
+        if find_one:
+            if len(results) != 1:
+                raise ValueError('Found {} results instead of 1!'.format(len(results)))
+            return results[0]
+
+        if find_first:
+            if results:
+                return results[0]
+            return None
+
+        return results

--- a/sdk/codegen/src/main/resources/fw-python/flywheel.mustache
+++ b/sdk/codegen/src/main/resources/fw-python/flywheel.mustache
@@ -84,6 +84,7 @@ class Flywheel:
         self.users = Finder(self, 'get_all_users')
         self.groups = Finder(self, 'get_all_groups')
         self.projects = Finder(self, 'get_all_projects')
+        self.subjects = Finder(self, 'get_all_subjects')
         self.sessions = Finder(self, 'get_all_sessions')
         self.acquisitions = Finder(self, 'get_all_acquisitions')
         self.jobs = Finder(self, 'get_all_jobs')

--- a/sdk/codegen/src/main/resources/fw-python/flywheel.mustache
+++ b/sdk/codegen/src/main/resources/fw-python/flywheel.mustache
@@ -21,6 +21,7 @@ log = logging.getLogger('Flywheel')
 from {{packageName}}.configuration import Configuration
 from {{packageName}}.api_client import ApiClient
 from {{packageName}}.view_builder import ViewBuilder
+from {{packageName}}.finder import Finder
 import {{apiPackage}}
 
 SDK_VERSION = "{{packageVersion}}"
@@ -78,6 +79,16 @@ class Flywheel:
         {{#apis}}
         self.{{classVarName}} = {{apiPackage}}.{{classname}}(self.api_client)
         {{/apis}}
+
+        # Finder objects
+        self.users = Finder(self, 'get_all_users')
+        self.groups = Finder(self, 'get_all_groups')
+        self.projects = Finder(self, 'get_all_projects')
+        self.sessions = Finder(self, 'get_all_sessions')
+        self.acquisitions = Finder(self, 'get_all_acquisitions')
+        self.jobs = Finder(self, 'get_all_jobs')
+        self.gears = Finder(self, 'get_all_gears')
+        self.collections = Finder(self, 'get_all_collections')
 
         # Perform version check
         self.check_version = not skip_version_check

--- a/sdk/codegen/src/main/resources/matlab/Cursor.m
+++ b/sdk/codegen/src/main/resources/matlab/Cursor.m
@@ -1,0 +1,50 @@
+classdef Cursor < handle
+    properties
+        generator_
+        pending_
+        index_
+    end
+    methods
+        function obj = Cursor(generator)
+            obj.generator_ = generator;
+            obj.pending_ = true;
+            obj.index_ = 1;
+        end
+        function result = hasNext(obj)
+            % Refill guarantees that pending_ will be an array, or false
+            obj.refill();
+            result = ~islogical(obj.pending_);
+        end
+        function result = next(obj)
+            % Refill guarantees that pending_ will be an array, or false
+            obj.refill();
+            if islogical(obj.pending_)
+                result = [];
+            else
+                result = obj.pending_{obj.index_};
+                obj.index_ = obj.index_ + 1;
+            end
+        end
+    end
+    methods(Hidden)
+        function refill(obj)
+            % Fetch if obj.pending_ is true, or we've consumed every element in pending_
+            fetch = false;
+            if islogical(obj.pending_)
+                fetch = obj.pending_;
+            elseif obj.index_ >= numel(obj.pending_)
+                fetch = true;
+            end
+
+            if fetch
+                obj.index_ = 1;
+                obj.pending_ = obj.generator_();
+                
+                % If we get an empty result, there are no more elements
+                if isempty(obj.pending_)
+                    obj.pending_ = false;
+                end
+            end
+        end
+    end
+end

--- a/sdk/codegen/src/main/resources/matlab/Finder.mustache
+++ b/sdk/codegen/src/main/resources/matlab/Finder.mustache
@@ -1,0 +1,103 @@
+classdef Finder < handle
+    properties(Hidden)
+        context_
+        args_
+        fn_
+    end
+    methods
+        function obj = Finder(context, method, varargin)
+            obj.context_ = context;
+            obj.args_ = varargin;
+            obj.fn_ = str2func(method);
+        end
+        function result = subsref(obj, s)
+            if numel(s) == 1 && strcmp(s.type, '()')
+                % Handle call
+                args = horzcat(obj.args_, s.subs);
+                result = obj.fn_(obj.context_, args{:});
+            else
+                result = builtin('subsref', obj, s);
+            end
+        end
+        function result = find(obj, varargin)
+            result = obj.find_(false, false, varargin);
+        end
+        function result = findOne(obj, varargin)
+            result = obj.find_(false, true, varargin);
+        end
+        function result = findFirst(obj, varargin)
+            result = obj.find_(true, false, varargin);
+        end
+        function result = iter(obj, varargin)
+            p = inputParser;
+            addParameter(p, 'limit', 250);
+            parse(p, varargin{:});
+            result = obj.iterFind('limit', p.Results.limit);
+        end
+        function result = iterFind(obj, varargin)
+            % Parse out filter strings
+            args = obj.makeArgs_(varargin);
+
+            % Ensure that limit is set
+            p = inputParser;
+            p.StructExpand = false;
+            p.KeepUnmatched = true;
+            addParameter(p, 'limit', []);
+            parse(p, args{:});
+            if isempty(p.Results.limit)
+                args = horzcat({'limit', 250}, args)
+            end
+
+            % Generator closure that tracks the last ID
+            afterId = '';
+            function results = generator()
+                currentArgs = horzcat(args, {'afterId', afterId});
+
+                results = obj.fn_(obj.context_, currentArgs{:});
+                if ~isempty(results)
+                    afterId = results{end}.id;
+                end
+            end
+
+            % Return a cursor for generator
+            result = {{packageName}}.Cursor(@generator);
+        end
+    end
+    methods(Hidden)
+        function results = find_(obj, findFirst, findOne, args)
+            args = horzcat(obj.args_, obj.makeArgs_(args));
+            results = obj.fn_(obj.context_, args{:});
+
+            if findOne
+                if numel(results) ~= 1
+                    throw(MException('ApiClient:apiException', 'Found %d results instead of 1!', numel(results)));
+                end
+                results = results{1};
+            end
+            if findFirst
+                if numel(results) > 0
+                    results = results{1};
+                else
+                    results = [];
+                end
+            end
+        end
+        function args = makeArgs_(obj, args)
+            % Concatenate filter strings with ','
+            filter = {};
+            for i = 1:numel(args)
+                if contains(args{i}, {'=', '<', '>'})
+                    filter = [filter; args{i}];
+                else
+                    i = i - 1;
+                    break
+                end
+            end
+            if ~isempty(filter)
+                rest = args(i+1:end);
+                filter = strjoin(filter, ',');
+                args = horzcat({'filter', filter}, rest);
+            end
+        end
+    end
+end

--- a/sdk/codegen/src/main/resources/matlab/api.mustache
+++ b/sdk/codegen/src/main/resources/matlab/api.mustache
@@ -79,7 +79,7 @@ classdef {{classname}} < handle
             {{#queryParams}}
             if ~isempty(x__inp.Results.{{paramName}})
                 {{^isListContainer}}
-                queryParams = [queryParams, '{{baseName}}', x__inp.Results.{{paramName}}];
+                queryParams = [queryParams, '{{baseName}}', {{packageName}}.ApiClient.castParam(x__inp.Results.{{paramName}}, '{{dataType}}')];
                 {{/isListContainer}}
                 {{#isListContainer}}
                 queryParams = {{packageName}}.ApiClient.formatParamCollection(queryParams, '{{baseName}}', x__inp.Results.{{paramName}}, '{{collectionFormat}}');

--- a/sdk/codegen/src/main/resources/matlab/api_client.mustache
+++ b/sdk/codegen/src/main/resources/matlab/api_client.mustache
@@ -59,6 +59,15 @@ classdef ApiClient < handle
             catch
             end
         end
+        function result = castParam(value, type)
+            if strcmp(type, 'integer')
+                result = int64(value);
+            elseif strcmp(type, 'logical')
+                result = logical(value);
+            else
+                result = value;
+            end
+        end
         function params = formatParamCollection(params, name, value, format)
             if iscell(value)
                 if format == 'multi'

--- a/sdk/codegen/src/main/resources/matlab/flywheel.mustache
+++ b/sdk/codegen/src/main/resources/matlab/flywheel.mustache
@@ -39,6 +39,14 @@ classdef Flywheel < handle
         {{classVarName}}
         {{/apis}}
         {{/apiInfo}}
+        users
+        groups
+        projects
+        sessions
+        acquisitions
+        jobs
+        gears
+        collections
         checkVersion
     end
     methods
@@ -65,6 +73,16 @@ classdef Flywheel < handle
             obj.{{classVarName}} = {{apiPackage}}.{{classname}}(obj.apiClient, obj);
             {{/apis}}
             {{/apiInfo}}
+
+            % Initialize finders
+            obj.users = {{packageName}}.Finder(obj, 'getAllUsers');
+            obj.groups = {{packageName}}.Finder(obj, 'getAllGroups');
+            obj.projects = {{packageName}}.Finder(obj, 'getAllProjects');
+            obj.sessions = {{packageName}}.Finder(obj, 'getAllSessions');
+            obj.acquisitions = {{packageName}}.Finder(obj, 'getAllAcquisitions');
+            obj.jobs = {{packageName}}.Finder(obj, 'getAllJobs');
+            obj.gears = {{packageName}}.Finder(obj, 'getAllGears');
+            obj.collections = {{packageName}}.Finder(obj, 'getAllCollections');
 
             % Perform version check
             obj.apiClient.setVersionCheckFn(@() obj.performVersionCheck());

--- a/sdk/codegen/src/main/resources/matlab/flywheel.mustache
+++ b/sdk/codegen/src/main/resources/matlab/flywheel.mustache
@@ -43,6 +43,7 @@ classdef Flywheel < handle
         groups
         projects
         sessions
+        subjects
         acquisitions
         jobs
         gears
@@ -78,6 +79,7 @@ classdef Flywheel < handle
             obj.users = {{packageName}}.Finder(obj, 'getAllUsers');
             obj.groups = {{packageName}}.Finder(obj, 'getAllGroups');
             obj.projects = {{packageName}}.Finder(obj, 'getAllProjects');
+            obj.subjects = {{packageName}}.Finder(obj, 'getAllSubjects');
             obj.sessions = {{packageName}}.Finder(obj, 'getAllSessions');
             obj.acquisitions = {{packageName}}.Finder(obj, 'getAllAcquisitions');
             obj.jobs = {{packageName}}.Finder(obj, 'getAllJobs');

--- a/sdk/codegen/src/main/resources/matlab/mixins/ContainerBase.mustache
+++ b/sdk/codegen/src/main/resources/matlab/mixins/ContainerBase.mustache
@@ -28,8 +28,8 @@ classdef ContainerBase < handle
         function result = getChildren(obj, childName)
             varName = strcat(lower(childName), '_');
             if islogical(obj.(varName)) && obj.(varName) == false
-                fn = str2func(sprintf('get%s%s', obj.containerType_, childName));
-                obj.(varName) = fn(obj.context_, obj.get('id'));
+                fname = sprintf('get%s%s', obj.containerType_, childName);
+                obj.(varName) = {{packageName}}.Finder(obj.context_, fname, obj.get('id'));
             end
             result = obj.(varName);
         end

--- a/sdk/codegen/src/main/resources/matlab/model_base.mustache
+++ b/sdk/codegen/src/main/resources/matlab/model_base.mustache
@@ -151,7 +151,7 @@ classdef ModelBase < handle & matlab.mixin.CustomDisplay
                             result = builtin('subsref', obj, s);
                         end
                     else
-                        result = {{packageName}}.ModelBase.recursiveRef(obj.(subs), s(2:end));
+                        result = builtin('subsref', obj, s);
                     end
                 elseif s(1).type == '{}'
                     if length(subs) > 1
@@ -159,9 +159,7 @@ classdef ModelBase < handle & matlab.mixin.CustomDisplay
                     end
                     result = {{packageName}}.ModelBase.recursiveRef(obj{subs{1}}, s(2:end));
                 else
-                    for i = 1:length(subs)
-                        result = {{packageName}}.ModelBase.recursiveRef(obj(subs{i}), s(2:end));
-                    end
+                    result = builtin('subsref', obj, s);
                 end
             end
         end

--- a/sdk/src/matlab/testDrive.m
+++ b/sdk/src/matlab/testDrive.m
@@ -128,10 +128,10 @@ fw.addSessionTag(sessionId, 'blue');
 fw.modifySession(sessionId, struct('label', 'testdrive'));
 fw.addSessionNote(sessionId, 'This is a note');
 
-sessions = project.sessions;
+sessions = project.sessions();
 assert(~isempty(sessions), errMsg)
 
-sessions = fw.getAllSessions();
+sessions = fw.sessions();
 assert(~isempty(sessions), errMsg)
 
 fw.uploadFileToSession(sessionId, filename);
@@ -166,10 +166,10 @@ fw.addAcquisitionTag(acqId, 'blue');
 fw.modifyAcquisition(acqId, struct('label', 'testdrive'));
 fw.addAcquisitionNote(acqId, 'This is a note');
 
-acqs = fw.getSessionAcquisitions(sessionId);
+acqs = session.acquisitions();
 assert(~isempty(acqs), errMsg)
 
-acqs = fw.getAllAcquisitions();
+acqs = fw.acquisitions();
 assert(~isempty(acqs), errMsg)
 
 fw.uploadFileToAcquisition(acqId, filename);
@@ -241,13 +241,19 @@ disp('Testing Collections')
 colId = fw.addCollection(struct('label', testString));
 collection = fw.getCollection(colId);
 
+collSessions = collection.sessions();
+assert(isempty(collSessions), errMsg)
+
+collAqs = collection.acquisitions();
+assert(isempty(collAqs), errMsg)
+
 collection.addSessions(sessionId);
 collection.addAcquisitions(acqId);
 
-collSessions = collection.sessions;
+collSessions = collection.sessions();
 assert(~isempty(collSessions), errMsg)
 
-collAqs = collection.acquisitions;
+collAqs = collection.acquisitions();
 assert(~isempty(collAqs), errMsg)
 
 collection.addNote('This is a note');

--- a/sdk/src/python/tests/integration_tests/test_collection.py
+++ b/sdk/src/python/tests/integration_tests/test_collection.py
@@ -45,12 +45,12 @@ class CollectionsTestCases(SdkTestCase):
         saved_collection.add_acquisitions(acquisition_id)
 
         # Get sessions
-        saved_sessions = saved_collection.sessions
+        saved_sessions = saved_collection.sessions()
         self.assertEqual(len(saved_sessions), 1)
         self.assertEqual(saved_sessions[0].id, session_id)
 
         # Get acquisitions
-        saved_acquisitions = saved_collection.acquisitions
+        saved_acquisitions = saved_collection.acquisitions()
         self.assertEqual(len(saved_acquisitions), 1)
         self.assertEqual(saved_acquisitions[0].id, acquisition_id)
 
@@ -67,13 +67,13 @@ class CollectionsTestCases(SdkTestCase):
         saved_collection = saved_collection.reload()
         
         # Get sessions
-        saved_sessions = saved_collection.sessions
+        saved_sessions = saved_collection.sessions()
         self.assertEqual(len(saved_sessions), 2)
         self.assertEqual(len(list(filter(lambda x: x.id == session_id, saved_sessions))), 1)
         self.assertEqual(len(list(filter(lambda x: x.id == session_id2, saved_sessions))), 1)
 
         # Get acquisitions
-        saved_acquisitions = saved_collection.acquisitions
+        saved_acquisitions = saved_collection.acquisitions()
         self.assertEqual(len(saved_acquisitions), 2)
         self.assertEqual(len(list(filter(lambda x: x.id == acquisition_id, saved_acquisitions))), 1)
         self.assertEqual(len(list(filter(lambda x: x.id == acquisition_id2, saved_acquisitions))), 1)

--- a/sdk/src/python/tests/integration_tests/test_mixins.py
+++ b/sdk/src/python/tests/integration_tests/test_mixins.py
@@ -43,7 +43,7 @@ class MixinTestCases(SdkTestCase):
 
         # GROUP
         r_group = fw.get_group(self.group_id)
-        projects = r_group.projects
+        projects = r_group.projects()
 
         self.assertIsNotNone(projects)
         self.assertEqual(len(projects), 1)
@@ -52,8 +52,9 @@ class MixinTestCases(SdkTestCase):
         self.assertEqual(r_project.id, self.project_id)
         self.assertEqual(r_project.container_type, 'project')
 
-        self.assertEqual(1, len(r_project.sessions))
-        r_session = r_project.sessions[0]
+        sessions = r_project.sessions()
+        self.assertEqual(1, len(sessions))
+        r_session = sessions[0]
         self.assertEqual(r_session.id, self.session_id)
         self.assertEqual(r_session.project, self.project_id)
 
@@ -75,9 +76,9 @@ class MixinTestCases(SdkTestCase):
         self.assertEqual(data, poem)
 
         # Get url
-        ticket_url1 = r_file.url
+        ticket_url1 = r_file.url()
         self.assertIsNotNone(ticket_url1)
-        ticket_url2 = r_file.url
+        ticket_url2 = r_file.url()
         self.assertNotEqual(ticket_url1, ticket_url2)
 
         # Download file
@@ -94,7 +95,7 @@ class MixinTestCases(SdkTestCase):
             os.remove(path)
 
         # Read acquisitions
-        acquisitions = r_session.acquisitions
+        acquisitions = r_session.acquisitions()
         self.assertIsNotNone(acquisitions)
         self.assertEqual(len(acquisitions), 1)
 

--- a/swagger/README.md
+++ b/swagger/README.md
@@ -70,6 +70,15 @@ Then the template arguments for the `templates/tags.yaml` template invocation wi
 * `tag`: tags
 * `parameter`: GroupId
 
+#### x-fw-pagination: true
+Adds the following pagination fields at doc generation time:
+
+* filter - Limit returned values based on criteria
+* sort - Set the sort fields and sort order
+* limit - Limit the number of returned records
+* skip - Skip N records
+* page - Skip page number * limit records (instead of skip)
+
 ### JSON Schemas
 
 JSON Schemas are used both for input validation and as the definitions for the Swagger documentation.

--- a/swagger/paths/collections.yaml
+++ b/swagger/paths/collections.yaml
@@ -8,6 +8,7 @@ $template_arguments:
   get:
     summary: List all collections.
     operationId: get_all_collections
+    x-fw-pagination: true
     tags:
     - collections
     responses:

--- a/swagger/paths/gears.yaml
+++ b/swagger/paths/gears.yaml
@@ -2,6 +2,7 @@
   get:
     summary: List all gears
     operationId: get_all_gears
+    x-fw-pagination: true
     tags:
     - gears
     responses:

--- a/swagger/paths/groups.yaml
+++ b/swagger/paths/groups.yaml
@@ -7,6 +7,7 @@ $template_arguments:
   get:
     summary: List all groups
     operationId: get_all_groups
+    x-fw-pagination: true
     tags:
     - groups
     responses:
@@ -87,6 +88,7 @@ $template_arguments:
   get:
     summary: Get all projects in a group
     operationId: get_group_projects
+    x-fw-pagination: true
     tags:
     - groups
     responses:

--- a/swagger/paths/jobs.yaml
+++ b/swagger/paths/jobs.yaml
@@ -2,6 +2,8 @@
   get:
     summary: Return all jobs
     operationId: get_all_jobs
+    x-fw-pagination: true
+    x-fw-default-limit: 1000
     tags:
     - jobs
     parameters:
@@ -13,27 +15,6 @@
         type: string
         name: tags
         description: filter results by job tags
-      - in: query
-        type: integer
-        name: skip
-        description: Skip number of jobs
-      - in: query
-        type: integer
-        name: limit
-        description: Limit number of returned jobs
-        x-sdk-default: 1000
-      - in: query
-        type: string
-        name: after_id
-        description: Return jobs after the given id
-      - in: query
-        type: string
-        name: filter
-        description: Filter to apply
-      - in: query
-        type: string
-        name: sort
-        description: The sorting algorithm to use
     responses:
       '200':
         description: ''

--- a/swagger/paths/projects.yaml
+++ b/swagger/paths/projects.yaml
@@ -57,6 +57,7 @@ $template_arguments:
   get:
     summary: List all sessions for the given project.
     operationId: get_project_sessions
+    x-fw-pagination: true
     tags:
     - projects
     responses:
@@ -74,6 +75,7 @@ $template_arguments:
   get:
     summary: List all acquisitions for the given project.
     operationId: get_project_acquisitions
+    x-fw-pagination: true
     tags:
     - projects
     responses:

--- a/swagger/paths/sessions.yaml
+++ b/swagger/paths/sessions.yaml
@@ -28,6 +28,7 @@ $template_arguments:
   get:
     summary: Return any jobs that use inputs from this session
     operationId: get_session_jobs
+    x-fw-pagination: true
     tags:
     - 'sessions'
     parameters:
@@ -76,6 +77,7 @@ $template_arguments:
   get:
     summary: List acquisitions in a session
     operationId: get_session_acquisitions
+    x-fw-pagination: true
     tags:
     - 'sessions'
     responses:

--- a/swagger/paths/users.yaml
+++ b/swagger/paths/users.yaml
@@ -2,6 +2,7 @@
   get:
     summary: Return a list of all users
     operationId: get_all_users
+    x-sdk-pagination: true
     tags:
     - users
     responses:

--- a/swagger/templates/analyses-list.yaml
+++ b/swagger/templates/analyses-list.yaml
@@ -21,6 +21,7 @@ template: |
     summary: Get analyses for {{resource}}.
     description: Returns analyses that directly belong to this resource.
     operationId: get_{{resource}}_analyses
+    x-fw-pagination: true
     tags:
     - '{{tag}}'
     responses:

--- a/swagger/templates/container.yaml
+++ b/swagger/templates/container.yaml
@@ -16,6 +16,7 @@ template: |
     summary: Get a list of {{#pluralize}}{{resource}}{{/pluralize}}
     operationId: get_all_{{#pluralize}}{{resource}}{{/pluralize}}
     x-fw-pagination: true
+    x-fw-default-limit: 1000
     tags:
       - '{{tag}}'
     responses:

--- a/swagger/templates/container.yaml
+++ b/swagger/templates/container.yaml
@@ -15,6 +15,7 @@ template: |
   get:
     summary: Get a list of {{#pluralize}}{{resource}}{{/pluralize}}
     operationId: get_all_{{#pluralize}}{{resource}}{{/pluralize}}
+    x-fw-pagination: true
     tags:
       - '{{tag}}'
     responses:


### PR DESCRIPTION
Depends on #1378, #1380

- Adds pagination parameters to relevant Swagger endpoints.
- Provides SDK finder functionality at the root level:
```python
sessions = fw.sessions() # Default limit is 1000
fw.sessions.find('label=control', limit=500)
```
- Provides SDK finder functionality at the container level:
```python
sessions = project.sessions()
project.sessions.find_one('subject.code=ex1001')
```
- Provides unbounded iteration over an entire collection:
```python
# Find dicom-mr-classifier jobs, 250 at a time
for job in fw.jobs.iter_find('gear_info.name=dicom-mr-classifier'):
  print('Job: {} - {}'.format(job.id, job.state))

# Walk all jobs, 500 at a time
for job in fw.jobs.iter(limit=500):
  print('Job: {} - {}'.format(job.id, job.state))
```

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
