### PR TITLE
Fix FileCreator finalize in case of cloud storage

### DIFF
--- a/api/create_file.py
+++ b/api/create_file.py
@@ -62,6 +62,7 @@ class FileCreator(object):
             metadata, timestamp, origin, {'uid': self.handler.uid}, self.file_processor, self.handler.log_user_access)
 
         for pending_file in self._files:
+            pending_file.fileobj.close()
             # Not a great practice. See process_upload() for details.
             cgi_field = util.obj_from_map({
                 'filename': pending_file.filename,


### PR DESCRIPTION
I found this issue during running core integration tests with google cloud storage. The file wasn't closed before called the `store_temp_file` method so we got a `ResourceNotFound` error. The file upload finishes only when we close the file. 

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
