### PR TITLE
Allow Read-Write Users to Move Sessions

### DIFF
--- a/api/auth/containerauth.py
+++ b/api/auth/containerauth.py
@@ -43,9 +43,13 @@ def default_container(handler, container=None, target_parent_container=None):
                     errors = {'reason': 'permission_denied'}
 
             elif method == 'PUT' and target_parent_container is not None:
+                if target_parent_container.get('cont_name') == 'project' or target_parent_container.get('cont_name') == 'subject':
+                    required_perm = 'rw'
+                else:
+                    required_perm = 'admin'
                 has_access = (
-                    _get_access(handler.uid, container, scope=handler.scope) >= INTEGER_PERMISSIONS['rw'] and
-                    _get_access(handler.uid, target_parent_container, scope=handler.scope) >= INTEGER_PERMISSIONS['rw']
+                    _get_access(handler.uid, container, scope=handler.scope) >= INTEGER_PERMISSIONS[required_perm] and
+                    _get_access(handler.uid, target_parent_container, scope=handler.scope) >= INTEGER_PERMISSIONS[required_perm]
                 )
             elif method == 'PUT' and target_parent_container is None:
                 required_perm = 'rw'

--- a/api/auth/containerauth.py
+++ b/api/auth/containerauth.py
@@ -43,7 +43,7 @@ def default_container(handler, container=None, target_parent_container=None):
                     errors = {'reason': 'permission_denied'}
 
             elif method == 'PUT' and target_parent_container is not None:
-                if target_parent_container.get('cont_name') == 'project' or target_parent_container.get('cont_name') == 'subject':
+                if target_parent_container.get('cont_name') in ['project', 'session', 'subject']:
                     required_perm = 'rw'
                 else:
                     required_perm = 'admin'

--- a/api/auth/containerauth.py
+++ b/api/auth/containerauth.py
@@ -44,8 +44,8 @@ def default_container(handler, container=None, target_parent_container=None):
 
             elif method == 'PUT' and target_parent_container is not None:
                 has_access = (
-                    _get_access(handler.uid, container, scope=handler.scope) >= INTEGER_PERMISSIONS['admin'] and
-                    _get_access(handler.uid, target_parent_container, scope=handler.scope) >= INTEGER_PERMISSIONS['admin']
+                    _get_access(handler.uid, container, scope=handler.scope) >= INTEGER_PERMISSIONS['rw'] and
+                    _get_access(handler.uid, target_parent_container, scope=handler.scope) >= INTEGER_PERMISSIONS['rw']
                 )
             elif method == 'PUT' and target_parent_container is None:
                 required_perm = 'rw'

--- a/tests/integration_tests/python/test_containers.py
+++ b/tests/integration_tests/python/test_containers.py
@@ -17,6 +17,9 @@ def test_switching_project_between_groups(data_builder, as_admin, as_user):
     # Change permissions to read-write
     user_id = as_user.get('/users/self').json()['_id']
     assert as_admin.post('/projects/' + project + '/permissions', json={'_id': user_id, 'access': 'rw'}).ok
+    assert as_admin.post('/groups/' + group_1 + '/permissions', json={'_id': user_id, 'access': 'rw'}).ok
+    assert as_admin.post('/groups/' + group_2 + '/permissions', json={'_id': user_id, 'access': 'rw'}).ok
+
 
     # Read-write users shouldn't be able to switch projects to a diff group
     r = as_user.put('/projects/' + project, json={'group': group_2})

--- a/tests/integration_tests/python/test_subjects.py
+++ b/tests/integration_tests/python/test_subjects.py
@@ -361,7 +361,7 @@ def test_subject_move_via_session(data_builder, as_admin, as_user):
     assert subject_2 in [s['_id'] for s in as_admin.get('/projects/' + project_1 + '/subjects').json()]
 
     # Change user permissions to read-write on both projects
-    ser_id = as_user.get('/users/self').json()['_id']
+    user_id = as_user.get('/users/self').json()['_id']
     assert as_admin.post('/projects/' + project_1 + '/permissions', json={'_id': user_id, 'access': 'rw'}).ok
     assert as_admin.post('/projects/' + project_2 + '/permissions', json={'_id': user_id, 'access': 'rw'}).ok
 


### PR DESCRIPTION
# Summary of changes
Decreased permission level on `PUT` for containers that have parents from admin to read-write. This allows for read-write users to move sessions from one project to another and to move session subjects as well. Related to a requirement for: https://github.com/flywheel-io/frontend/pull/1700