### PR TITLE
Pin urllib3 to universally compatible version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,5 @@ strict-rfc3339==0.7
 unicodecsv==0.9.0
 webapp2==2.5.2
 WebOb==1.8.2
+urllib3==1.23
 git+https://github.com/flywheel-io/gears.git@v0.1.8#egg=gears


### PR DESCRIPTION
pip is (erroneously?) resolving urllib3 to `1.24` which is breaking the requests library in core. 
This pins the version to the *hopefully* compatible 1.23

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
