### PR TITLE
Job retry

### DIFF
--- a/api/dao/containerstorage.py
+++ b/api/dao/containerstorage.py
@@ -513,16 +513,6 @@ class AnalysisStorage(ContainerStorage):
         except:
             raise Exception('No job with id {} found.'.format(analysis['job']))
 
-        # If the job currently tied to the analysis failed, try to find one that didn't
-        while job.state == 'failed' and job.id_ is not None:
-            next_job = config.db.jobs.find_one({'previous_job_id': job.id_})
-            if next_job is None:
-                break
-            job = Job.load(next_job)
-        if job.id_ != str(analysis['job']):
-            # Update analysis if job has changed
-            self.update_el(analysis['_id'], {'job': job.id_})
-
         analysis['job'] = job
         return analysis
 

--- a/api/dao/containerutil.py
+++ b/api/dao/containerutil.py
@@ -317,7 +317,7 @@ class FileReference(ContainerReference):
         container = super(FileReference, self).get()
 
         for file in container.get('files', []):
-            if file['name'] == self.name:
+            if file['name'] == self.name and not file.get('deleted'):
                 return file
 
         raise APINotFoundException('No such file {} on {} {} in database'.format(self.name, self.type, self.id))

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -622,7 +622,7 @@ class JobHandler(base.RequestHandler):
         j = Job.get(_id)
 
         # Permission check
-        if not self.superuser_request:
+        if not self.user_is_admin:
 
             if j.inputs is not None:
                 for x in j.inputs:

--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -19,8 +19,8 @@ from ..web.errors import APINotFoundException
 class Job(object):
     def __init__(self, gear, inputs, destination=None, tags=None,
                  attempt=1, previous_job_id=None, created=None,
-                 modified=None, state='pending', request=None,
-                 id_=None, config_=None, origin=None,
+                 modified=None, retried=None, state='pending',
+                 request=None, id_=None, config_=None, origin=None,
                  saved_files=None, produced_metadata=None, batch=None,
                  failed_output_accepted=False, profile=None):
         """
@@ -106,6 +106,7 @@ class Job(object):
         self.previous_job_id    = previous_job_id
         self.created            = created
         self.modified           = modified
+        self.retried            = retried
         self.state              = state
         self.request            = request
         self.id_                = id_
@@ -179,6 +180,7 @@ class Job(object):
             previous_job_id=d.get('previous_job_id'),
             created=d['created'],
             modified=d['modified'],
+            retried=d.get('retried'),
             state=d['state'],
             request=d.get('request'),
             id_=d['_id'],
@@ -229,6 +231,8 @@ class Job(object):
             d.pop('request')
         if d['failed_output_accepted'] is False:
             d.pop('failed_output_accepted')
+        if d['retried'] is None:
+            d.pop('retried')
 
         return d
 

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -109,9 +109,9 @@ class Queue(object):
 
         if job.state in ['cancelled', 'complete']:
             if only_failed:
-                raise Exception('Can only retry a job that is failed, please use only_failed parameter')
+                raise InputValidationException('Can only retry a job that is failed, please use only_failed parameter')
         elif job.state != 'failed':
-            raise Exception('Can not retry running or pending job')
+            raise InputValidationException('Can not retry running or pending job')
 
 
         if job.request is None:

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -144,7 +144,7 @@ class Queue(object):
 
         result = config.db.jobs.update_one({"_id": bson.ObjectId(job.id_)}, {'$set': {"retried": new_job.created}})
         if result.modified_count != 1:
-            raise Exception('Could not set retried time for job {}'.format(job.id_))
+            log.error('Could not set retried time for job {}'.format(job.id_))
 
         new_id = new_job.insert(ignore_insertion_block=True)
         log.info('respawned job %s as %s (attempt %d)', job.id_, new_id, new_job.attempt)

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -97,7 +97,7 @@ class Queue(object):
             Queue.retry(job)
 
     @staticmethod
-    def retry(job, force=False):
+    def retry(job, force=False, only_failed=True):
         """
         Given a failed job, either retry the job or fail it permanently, based on the attempt number.
         Can override the attempt limit by passing force=True.
@@ -107,8 +107,12 @@ class Queue(object):
             log.info('Permanently failed job %s (after %d attempts)', job.id_, job.attempt)
             return
 
-        if job.state != 'failed':
-            raise Exception('Can only retry a job that is failed')
+        if job.state in ['cancelled', 'complete']:
+            if only_failed:
+                raise Exception('Can only retry a job that is failed, please use only_failed parameter')
+        elif job.state != 'failed':
+            raise Exception('Can not retry running or pending job')
+
 
         if job.request is None:
             raise Exception('Cannot retry a job without a request')
@@ -121,20 +125,22 @@ class Queue(object):
             found = Job.load(check)
             raise Exception('Job ' + job.id_ + ' has already been retried as ' + str(found.id_))
 
-        new_job = copy.deepcopy(job)
-        new_job.id_ = bson.ObjectId()
+        new_job_map = job.map()
+        new_job_map['config'] = new_job_map['config']['config']
+        new_job = Queue.enqueue_job(new_job_map, dict(job.origin))
         new_job.previous_job_id = job.id_
-
-        new_job.state = 'pending'
         new_job.attempt += 1
-
-        now = datetime.datetime.utcnow()
-        new_job.created = now
-        new_job.modified = now
+        new_job.request = copy.deepcopy(job.request)
+        new_job.id_ = bson.ObjectId()
 
         # update input uris that reference the old job id
-        for i in new_job.request['inputs']:
+        for i in new_job.request['inputs']+new_job.request['outputs']:
             i['uri'] = i['uri'].replace(str(job.id_), str(new_job.id_))
+
+        if new_job.destination.type == 'analysis':
+            config.db.analyses.update_one({'_id': bson.ObjectId(new_job.destination.id)},
+                                          {'$set': {'job': str(new_job.id_),
+                                                    'modified': datetime.datetime.utcnow()}})
 
         new_id = new_job.insert(ignore_insertion_block=True)
         log.info('respawned job %s as %s (attempt %d)', job.id_, new_id, new_job.attempt)
@@ -212,6 +218,8 @@ class Queue(object):
         destination = None
         if job_map.get('destination', None) is not None:
             destination = create_containerreference_from_dictionary(job_map['destination'])
+            # Check that it exists
+            destination.get()
         else:
             destination = None
             for key in inputs.keys():

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -140,7 +140,11 @@ class Queue(object):
         if new_job.destination.type == 'analysis':
             config.db.analyses.update_one({'_id': bson.ObjectId(new_job.destination.id)},
                                           {'$set': {'job': str(new_job.id_),
-                                                    'modified': datetime.datetime.utcnow()}})
+                                                    'modified': new_job.created}})
+
+        result = config.db.jobs.update_one({"_id": bson.ObjectId(job.id_)}, {'$set': {"retried": new_job.created}})
+        if result.modified_count != 1:
+            raise Exception('Could not set retried time for job {}'.format(job.id_))
 
         new_id = new_job.insert(ignore_insertion_block=True)
         log.info('respawned job %s as %s (attempt %d)', job.id_, new_id, new_job.attempt)

--- a/swagger/paths/jobs.yaml
+++ b/swagger/paths/jobs.yaml
@@ -169,6 +169,11 @@
     operationId: retry_job
     tags:
     - jobs
+    parameters:
+      - name: ignoreState
+        in: query
+        required: false
+        type: boolean
     responses:
       '200':
         description: ''

--- a/swagger/schemas/definitions/created-modified.json
+++ b/swagger/schemas/definitions/created-modified.json
@@ -15,6 +15,11 @@
       "type": "string",
       "format": "date-time",
       "description": "Last replaced time (automatically updated)"
+    },
+    "retried": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Retried time (automatically set)"
     }
   }
 }

--- a/swagger/schemas/definitions/job.json
+++ b/swagger/schemas/definitions/job.json
@@ -142,6 +142,7 @@
         "attempt":{"$ref":"#/definitions/attempt"},
         "created":{"$ref":"created-modified.json#/definitions/created"},
         "modified":{"$ref":"created-modified.json#/definitions/modified"},
+        "retried": {"$ref": "created-modified.json#/definitions/retried"},
         "config":{"$ref":"#/definitions/config"},
         "request":{"$ref":"#/definitions/request"},
         "saved_files":{"$ref":"#/definitions/saved_files"}
@@ -164,6 +165,7 @@
         "attempt":{"$ref":"#/definitions/attempt"},
         "created":{"$ref":"created-modified.json#/definitions/created"},
         "modified":{"$ref":"created-modified.json#/definitions/modified"},
+        "retried": {"$ref": "created-modified.json#/definitions/retried"},
         "config":{"$ref":"#/definitions/config"},
         "request":{"$ref":"#/definitions/request"},
         "saved_files":{"$ref":"#/definitions/saved_files"}

--- a/tests/integration_tests/python/test_jobs.py
+++ b/tests/integration_tests/python/test_jobs.py
@@ -235,23 +235,6 @@ def test_jobs(data_builder, default_payload, as_public, as_user, as_admin, as_ro
     r = as_root.put('/jobs/' + next_job_id, json={'state': 'failed'})
     assert r.ok
 
-    # retry failed job
-    r = as_root.post('/jobs/' + next_job_id + '/retry')
-    assert r.ok
-
-    # get next job as admin
-    r = as_admin.get('/jobs/next', params={'tags': 'test-tag'})
-    assert r.ok
-    next_job_id = r.json()['id']
-
-    # set next job to failed
-    r = as_root.put('/jobs/' + next_job_id, json={'state': 'failed'})
-    assert r.ok
-
-    # retry failed job w/o root
-    r = as_admin.post('/jobs/' + next_job_id + '/retry')
-    assert r.ok
-
     # set as_user perms to ro
     r = as_user.get('/users/self')
     assert r.ok
@@ -727,8 +710,8 @@ def test_job_context(data_builder, default_payload, as_admin, as_root, file_form
     assert r_inputs['test_context_value']['value'] == { 'session_value': 3 }
 
 
-def test_job_api_key(data_builder, default_payload, as_public, as_admin, as_root, api_db, file_form):
-
+def test_job_api_key(data_builder, default_payload, as_public, as_admin, as_user, as_root, api_db, file_form):
+    project = data_builder.create_project()
     acquisition = data_builder.create_acquisition()
     assert as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form('test.zip')).ok
 
@@ -856,7 +839,7 @@ def test_job_api_key(data_builder, default_payload, as_public, as_admin, as_root
     assert found_config_uri
 
     # get config
-    r = as_root.get('/jobs/'+ retried_job_id +'/config.json')
+    r = as_root.get('/jobs/' + retried_job_id + '/config.json')
     assert r.ok
     config = r.json()
 
@@ -877,6 +860,40 @@ def test_job_api_key(data_builder, default_payload, as_public, as_admin, as_root
 
     r = as_job_key.get('/users/self')
     assert r.status_code == 401
+
+    # Test that user can retry their own jobs, otherwise only admins can
+    # Test rw user can't retry another's job
+    user_id = as_user.get('/users/self').json()['_id']
+    r = as_admin.post('/projects/' + project + '/permissions', json={'_id': user_id, 'access': 'rw'})
+    assert r.ok
+
+    r = as_user.post('/jobs/' + retried_job_id + '/retry', params={'ignoreState': True})
+    assert r.status_code == 403
+
+    # Start job as rw user
+    r = as_user.post('/jobs/add', json=job1)
+    assert r.ok
+    job_id = r.json()['_id']
+
+    # fail job and ensure API key no longer works
+    r = as_root.get('/jobs/next')
+    assert r.ok
+    r = as_root.put('/jobs/' + job_id, json={'state': 'failed'})
+    assert r.ok
+
+    # Retry it as the user
+    r = as_user.post('/jobs/' + job_id + '/retry')
+    assert r.ok
+    retried_job_id = r.json()['_id']
+
+    r = as_root.get('/jobs/next')
+    assert r.ok
+    r = as_root.put('/jobs/' + retried_job_id, json={'state': 'failed'})
+    assert r.ok
+
+    # Make sure admins can retry any job
+    r = as_admin.post('/jobs/' + retried_job_id + '/retry')
+    assert r.ok
 
 
 def test_job_tagging(data_builder, default_payload, as_admin, as_root, api_db, file_form):
@@ -1276,9 +1293,197 @@ def test_scoped_job_api_key(randstr, data_builder, default_payload, as_public, a
     })
     assert r.status_code == 403
 
-    # complete job and ensure API key no longer works
-    r = as_root.put('/jobs/' + job_id, json={'state': 'complete'})
+    # fail job and ensure API key no longer works
+    r = as_root.put('/jobs/' + job_id, json={'state': 'failed'})
     assert r.ok
 
     r = as_job_key.get('/projects/' + project)
     assert r.status_code == 401
+
+    # Retry job
+    r = as_admin.post('/jobs/' + job_id + '/retry')
+    assert r.ok
+
+    # get next job as admin
+    r = as_root.get('/jobs/next')
+    assert r.ok
+    retried_job_id = r.json()['id']
+
+    # Make sure a new api key was created and the old one didn't magically start working again
+    r = as_job_key.get('/projects/' + project)
+    assert r.status_code == 401
+
+    # get config
+    r = as_root.get('/jobs/' + retried_job_id + '/config.json')
+    assert r.ok
+    config = r.json()
+
+    assert config['destination']['id'] == acquisition
+    assert type(config['config']) is dict
+    retried_api_key = config['inputs']['api_key']['key']
+    # ensure api_key works
+    as_job_key.headers.update({'Authorization': 'scitran-user ' + retried_api_key.split(':')[-1]})
+
+    r = as_job_key.get('/projects/' + project)
+    assert r.ok
+
+def test_retry_jobs(data_builder, default_payload, as_admin, as_user, as_root, as_drone, file_form):
+    # Not testing sdk jobs here, those are tested in the test_api_jobs
+    gear_doc = default_payload['gear']['gear']
+    gear_doc['inputs'] = {
+        'dicom': {
+            'base': 'file'
+        }
+    }
+    gear = data_builder.create_gear(gear=gear_doc)
+    invalid_gear = data_builder.create_gear(gear={'custom': {'flywheel': {'invalid': True}}})
+    project = data_builder.create_project()
+
+    # Add user with r/w permission
+    user_id = as_user.get('/users/self').json()['_id']
+    r = as_admin.post('/projects/' + project + '/permissions', json={'_id': user_id, 'access': 'rw'})
+    assert r.ok
+
+    session = data_builder.create_session()
+    acquisition = data_builder.create_acquisition()
+    assert as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form('test.zip')).ok
+    job_data = {
+        'gear_id': gear,
+        'inputs': {
+            'dicom': {
+                'type': 'acquisition',
+                'id': acquisition,
+                'name': 'test.zip'
+            }
+        },
+        'config': { 'two-digit multiple of ten': 20 },
+        'destination': {
+            'type': 'acquisition',
+            'id': acquisition
+        },
+        'tags': [ 'test-tag' ]
+    }
+    # add job with explicit destination
+    r = as_admin.post('/jobs/add', json=job_data)
+    assert r.ok
+    job0_id = r.json()['_id']
+
+    # get job0
+    r = as_root.get('/jobs/' + job0_id)
+    assert r.ok
+    job0 = r.json()
+
+    # start job0 (Adds logs)
+    r = as_root.get('/jobs/next')
+    assert r.ok
+
+    # set job0 to failed
+    r = as_root.put('/jobs/' + job0_id, json={'state': 'failed'})
+    assert r.ok
+
+    # retry failed job0 w/o admin as job1
+    r = as_user.post('/jobs/' + job0_id + '/retry')
+    assert r.ok
+    job1_id = r.json()['_id']
+
+    # try retry failed job0 as job1 again
+    r = as_root.post('/jobs/' + job0_id + '/retry')
+    assert r.status_code == 500
+
+    # get job0
+    r = as_root.get('/jobs/' + job1_id)
+    assert r.ok
+    job1 = r.json()
+
+    # Make sure config, inputs, and destination are the same
+    assert job0['inputs'] == job1['inputs']
+    assert job0['destination'] == job1['destination']
+    assert job0['config'] == job1['config']
+
+    # start job1 as admin
+    r = as_admin.get('/jobs/next', params={'tags': 'test-tag'})
+    assert r.ok
+
+    # set job1 to failed
+    r = as_root.put('/jobs/' + job1_id, json={'state': 'failed'})
+    assert r.ok
+
+    # retry failed job1 w/o root as job2
+    r = as_admin.post('/jobs/' + job1_id + '/retry')
+    assert r.ok
+
+    # get job2 as admin
+    r = as_admin.get('/jobs/next', params={'tags': 'test-tag'})
+    assert r.ok
+    job2_id = r.json()['id']
+
+    # set job2 to running
+    r = as_drone.put('/jobs/' + job2_id, json={'state': 'running'})
+    assert r.ok
+
+    # try retry runnning job2 as job3
+    r = as_root.post('/jobs/' + job2_id + '/retry')
+    assert r.status_code == 500
+
+    # try retry runnning job2 as job3 ignoring state
+    r = as_root.post('/jobs/' + job2_id + '/retry', params={'ignoreState': True})
+    assert r.status_code == 500
+
+    # set job2 to complete
+    r = as_root.put('/jobs/' + job2_id, json={'state': 'complete'})
+    assert r.ok
+
+    # try retry complete job2 as job3
+    r = as_root.post('/jobs/' + job2_id + '/retry')
+    assert r.status_code == 500
+
+    # retry complete job2 as job3
+    r = as_root.post('/jobs/' + job2_id + '/retry', params={'ignoreState': True})
+    assert r.ok
+
+    # get job3 as admin
+    r = as_admin.get('/jobs/next', params={'tags': 'test-tag'})
+    assert r.ok
+    job3_id = r.json()['id']
+
+    # set job3 to failed
+    r = as_root.put('/jobs/' + job3_id, json={'state': 'failed'})
+    assert r.ok
+
+    # Delete input file
+    r = as_admin.delete('/acquisitions/' + acquisition + '/files/test.zip')
+    assert r.ok
+
+    # try retry failed job3
+    r = as_root.post('/jobs/' + job3_id + '/retry')
+    assert r.status_code == 404
+
+    # Use session input file, but delete destination acquisition
+    assert as_admin.post('/sessions/' + session + '/files', files=file_form('session_test.zip')).ok
+
+    job_data['inputs']['dicom'] = {
+        'type': 'session',
+        'id': session,
+        'name': 'session_test.zip'
+    }
+
+    # add job with explicit destination
+    r = as_admin.post('/jobs/add', json=job_data)
+    assert r.ok
+    job4_id = r.json()['_id']
+
+    # start job3 (Adds logs)
+    r = as_root.get('/jobs/next')
+    assert r.ok
+
+    # set job4 to failed
+    r = as_root.put('/jobs/' + job4_id, json={'state': 'failed'})
+    assert r.ok
+
+    # Delete input file
+    r = as_admin.delete('/acquisitions/' + acquisition)
+    assert r.ok
+
+    # try retry failed job4 as job5
+    r = as_root.post('/jobs/' + job4_id + '/retry')
+    assert r.status_code == 404


### PR DESCRIPTION
### Changes
- Wrote up some tests for the retry jobs endpoint
- Job retry endpoint goes through enqueue logic to generate the job object which we then modify
- Analysis jobs are updated to point to the latest job
  - If the analysis has outputs, superuser is required
- sdk gears use original user's api key
- job origin is the identical as well

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
