### PR TITLE
Add explicit string and null to pagination filter

### DIFF
--- a/api/util.py
+++ b/api/util.py
@@ -407,10 +407,14 @@ class PaginationParseError(ValueError):
 
 def parse_pagination_value(value):
     """Return casted value (ObjectId|datetime|float) from user input (str) for use in mongo queries."""
-    if bson.ObjectId.is_valid(value):
+    if len(value) > 1 and value[0] == '"' and value[-1] == '"':
+        return value[1:-1]
+    elif bson.ObjectId.is_valid(value):
         return bson.ObjectId(value)
     elif datetime_from_str(value):
         return datetime_from_str(value)
+    elif value == 'null':
+        return None
     else:
         try:
             # Note: querying for floats also yields ints (=> no need for int casting here)

--- a/tests/integration_tests/python/test_pagination.py
+++ b/tests/integration_tests/python/test_pagination.py
@@ -217,9 +217,22 @@ def test_filter(data_builder, as_admin):
     r = as_admin.get('/acquisitions?filter=_id=' + b)
     assert {aq['_id'] for aq in r.json()} == {b}
 
+    # Filter for unset/null
+    r = as_admin.get('/acquisitions?filter=uid=null')
+    assert {aq['_id'] for aq in r.json()} == {a, b, c}
+
     b_created = as_admin.get('/acquisitions/' + b).json()['created'][:-6]
     r = as_admin.get('/acquisitions?filter=created=' + b_created)
     assert {aq['_id'] for aq in r.json()} == {b}
+
+    # Force string match
+    dec = data_builder.create_acquisition(label='1001')
+
+    r = as_admin.get('/acquisitions?filter=label=1001')
+    assert len(r.json()) == 0
+
+    r = as_admin.get('/acquisitions?filter=label="1001"')
+    assert {aq['_id'] for aq in r.json()} == {dec}
 
     r = as_admin.get('/gears?filter=single_input')
     assert r.ok


### PR DESCRIPTION
1. Allow explicitly specifying a string by surrounding with quotes (e.g. `code="1001"`)
2. Allow the `null` token

Closes #1288 

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
