### PR TITLE
Skip pickling lint results

### DIFF
--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -12,7 +12,7 @@
 ignore=CVS
 
 # Pickle collected data for later comparisons.
-persistent=yes
+persistent=no
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.


### PR DESCRIPTION
Running the test suite differently (eg. fly/fly - coreplus branch) pylint fails due to trying to write pickled results directly under `/`. Disabled unused feature.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
