### PR TITLE
Subject Upgrade: Don't warn on null replace, no top level history

### DIFF
--- a/tests/integration_tests/python/test_upgrades.py
+++ b/tests/integration_tests/python/test_upgrades.py
@@ -624,7 +624,6 @@ def test_55(api_db, data_builder, database):
     merge_subject = get_subject(test_merge)
     assert merge_subject['key'] == 'value3'
     assert merge_subject['info']['key_history'] == ['value1', 'value2']
-    print merge_subject
 
     # verify merging works in nested docs like info
     deep_merge_subject = get_subject(test_deep_merge)

--- a/tests/integration_tests/python/test_upgrades.py
+++ b/tests/integration_tests/python/test_upgrades.py
@@ -623,7 +623,8 @@ def test_55(api_db, data_builder, database):
     # verify merging works as expected
     merge_subject = get_subject(test_merge)
     assert merge_subject['key'] == 'value3'
-    assert merge_subject['key_history'] == ['value1', 'value2']
+    assert merge_subject['info']['key_history'] == ['value1', 'value2']
+    print merge_subject
 
     # verify merging works in nested docs like info
     deep_merge_subject = get_subject(test_deep_merge)


### PR DESCRIPTION
Two minor changes to how the subject upgrade works, examples below:
1. Don't warn or store previous null values that are replaced
2. Store top level keys that have historic values on the info block to not pollute the top level of a subject.
```
Merging `subject_b` on top of `subject_a`:

# subject_a
{
    "code": "subject_1",
    "firstname" : null,
    "lastname": "oldLastName"
} 

# subject_b
{
    "code": "subject_1",
    "firstname": "AFirstName",
    "lastname": "newLastName"
}

# OLD RESULT:
{
    "code": "subject_1",
    "firstname": "AFirstName",
    "firstname_history:" [null],
    "lastname_history": ["oldLastName"]
}

# NEW RESULT:

{
    "code": "subject_1",
    "firstname": "AFirstName",
    "info": {
         "lastname_history": ["oldLastName"]
    }
}

```


### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
