### PR TITLE
Exclude README from matlab toolbox manifest

### DIFF
--- a/sdk/src/matlab/build.gradle
+++ b/sdk/src/matlab/build.gradle
@@ -148,7 +148,7 @@ task configureToolbox(dependsOn: [copyToolboxFiles, copyRestApi, copySwaggerApi,
 		configureXml(intDir + '/metadata/filesystemManifest.xml', { root ->
 			FileTree tree = fileTree(fsrootDir)
 			tree.visit{ element ->
-				if( !element.isDirectory() ) {
+				if( !element.isDirectory() && element.name != 'README' ) {
 					def f = element.getFile();
 					// Hardcoded permissions - would these ever change?
 					def modified = dateToIso(new Date(f.lastModified()))


### PR DESCRIPTION
Fixes installation of matlab toolbox.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
