### PR TITLE
Billing report

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -19,6 +19,7 @@ from .handlers.userhandler              import UserHandler
 from .jobs.handlers                     import BatchHandler, JobsHandler, JobHandler, GearsHandler, GearHandler, RulesHandler, RuleHandler
 from .metrics.handler                   import MetricsHandler
 from .upload                            import Upload
+from .reports                           import ReportTypes
 from .reports.handler                   import ReportHandler
 from .data_views.handlers               import DataViewHandler
 from .web.base                          import RequestHandler
@@ -54,7 +55,10 @@ routing_regexes = {
     'fclass': '.+(?=/classification)',
 
     # Schema path
-    'schema': r'[^/.]{3,60}/[^/.]{3,60}\.json'
+    'schema': r'[^/.]{3,60}/[^/.]{3,60}\.json',
+
+    # Report types
+    'report_type': '|'.join(ReportTypes.keys())
 }
 
 
@@ -106,8 +110,9 @@ endpoints = [
         route('/lookup',                                        ResolveHandler, h='lookup',         m=['POST']),
         route('/resolve',                                       ResolveHandler, h='resolve',        m=['POST']),
         route('/schemas/<schema:{schema}>',                     SchemaHandler,                      m=['GET']),
-        route('/report/<report_type:site|project|accesslog|usage>',   ReportHandler,                m=['GET']),
+        route('/report/<report_type:{report_type}>',            ReportHandler,                      m=['GET']),
         route('/report/accesslog/types',                        ReportHandler,  h='get_types',      m=['GET']),
+        route('/report/<report_type:{report_type}>/collect',    ReportHandler,  h='collect',        m=['GET']),
 
 
         # Search

--- a/api/api.py
+++ b/api/api.py
@@ -103,16 +103,17 @@ endpoints = [
 
 
         # Top-level endpoints
-        route('/login',                                         RequestHandler, h='log_in',         m=['POST']),
-        route('/login/saml',                                    RequestHandler, h='saml_log_in',    m=['GET']),
-        route('/auth/status',                                   RequestHandler, h='auth_status',    m=['GET']),
-        route('/logout',                                        RequestHandler, h='log_out',        m=['POST']),
-        route('/lookup',                                        ResolveHandler, h='lookup',         m=['POST']),
-        route('/resolve',                                       ResolveHandler, h='resolve',        m=['POST']),
-        route('/schemas/<schema:{schema}>',                     SchemaHandler,                      m=['GET']),
-        route('/report/<report_type:{report_type}>',            ReportHandler,                      m=['GET']),
-        route('/report/accesslog/types',                        ReportHandler,  h='get_types',      m=['GET']),
-        route('/report/<report_type:{report_type}>/collect',    ReportHandler,  h='collect',        m=['GET']),
+        route('/login',                                           RequestHandler, h='log_in',           m=['POST']),
+        route('/login/saml',                                      RequestHandler, h='saml_log_in',      m=['GET']),
+        route('/auth/status',                                     RequestHandler, h='auth_status',      m=['GET']),
+        route('/logout',                                          RequestHandler, h='log_out',          m=['POST']),
+        route('/lookup',                                          ResolveHandler, h='lookup',           m=['POST']),
+        route('/resolve',                                         ResolveHandler, h='resolve',          m=['POST']),
+        route('/schemas/<schema:{schema}>',                       SchemaHandler,                        m=['GET']),
+        route('/report/<report_type:{report_type}>',              ReportHandler,                        m=['GET']),
+        route('/report/accesslog/types',                          ReportHandler,  h='get_types',        m=['GET']),
+        route('/report/<report_type:{report_type}>/availability', ReportHandler,  h='get_availability', m=['GET']),
+        route('/report/<report_type:{report_type}>/collect',      ReportHandler,  h='collect',          m=['GET']),
 
 
         # Search

--- a/api/config.py
+++ b/api/config.py
@@ -190,6 +190,7 @@ def initialize_db():
     db.batch.create_index('jobs')
     db.project_rules.create_index('project_id')
     db.data_views.create_index('parent')
+    db.file_job_origin.create_index('value.created')
 
     if __config['core']['access_log_enabled']:
         log_db.access_log.create_index('context.ticket_id')

--- a/api/config.py
+++ b/api/config.py
@@ -191,7 +191,7 @@ def initialize_db():
     db.project_rules.create_index('project_id')
     db.data_views.create_index('parent')
     db.file_job_origin.create_index('value.created')
-    db.usage_data.create_index([('group', 1), ('project', 1), ('year', 1), ('month', 1)])
+    db.usage_data.create_index([('group', 1), ('project', 1), ('year', 1), ('month', 1)], unique=True)
 
     if __config['core']['access_log_enabled']:
         log_db.access_log.create_index('context.ticket_id')

--- a/api/config.py
+++ b/api/config.py
@@ -191,6 +191,7 @@ def initialize_db():
     db.project_rules.create_index('project_id')
     db.data_views.create_index('parent')
     db.file_job_origin.create_index('value.created')
+    db.usage_data.create_index([('group', 1), ('project', 1), ('year', 1), ('month', 1)])
 
     if __config['core']['access_log_enabled']:
         log_db.access_log.create_index('context.ticket_id')

--- a/api/jobs/file_job_origin.py
+++ b/api/jobs/file_job_origin.py
@@ -3,6 +3,7 @@ Maintains (via Map/Reduce) a map of job ids to gear details.
 This collection exists largely to support joining file origin 
 to gear version for the billing report.
 """
+import bson
 import datetime
 
 from .. import config
@@ -29,9 +30,9 @@ def update_file_job_origin():
     # For performance, only merge in jobs that were created after the last run
     start = datetime.datetime.now()
     query = {}
-    last_rec = config.db.file_job_origin.find_one({}, sort=[('created', -1)])
+    last_rec = config.db.file_job_origin.find_one({}, {'_id':1}, sort=[('_id', -1)])
     if last_rec:
-        query['created'] = {'$gt': last_rec['value']['created']}
+        query['_id'] = {'$gt': bson.ObjectId(last_rec['_id'])}
 
     log.info('Updating file_job_origin collection')
     config.db.jobs.map_reduce(map_fn, reduce_fn, out, query=query)

--- a/api/jobs/file_job_origin.py
+++ b/api/jobs/file_job_origin.py
@@ -1,0 +1,40 @@
+"""
+Maintains (via Map/Reduce) a map of job ids to gear details.
+This collection exists largely to support joining file origin 
+to gear version for the billing report.
+"""
+import datetime
+
+from .. import config
+
+log = config.log
+
+def update_file_job_origin():
+    """Update the file_job_origin collection ensuring that it contains all jobs"""
+    # Map to string id, include creation date and gear info
+    map_fn = '''
+        function() {
+            var key = "" + this._id;
+            var value = {
+                created: this.created,
+                gear_info: this.gear_info
+            };
+            emit(key, value);
+        }
+    '''
+    # No-op reduce, since we have unique records
+    reduce_fn = 'function() {}'
+    out = { 'merge': 'file_job_origin' } 
+
+    # For performance, only merge in jobs that were created after the last run
+    start = datetime.datetime.now()
+    query = {}
+    last_rec = config.db.file_job_origin.find_one({}, sort=[('created', -1)])
+    if last_rec:
+        query['value.created'] = {'$gte': last_rec['value']['created']}
+
+    log.info('Updating file_job_origin collection')
+    config.db.jobs.map_reduce(map_fn, reduce_fn, out, query=query)
+    end = datetime.datetime.now()
+
+    log.info('Updated file_job_origin collection in %4.2f seconds', (end-start).total_seconds())

--- a/api/jobs/file_job_origin.py
+++ b/api/jobs/file_job_origin.py
@@ -31,7 +31,7 @@ def update_file_job_origin():
     query = {}
     last_rec = config.db.file_job_origin.find_one({}, sort=[('created', -1)])
     if last_rec:
-        query['value.created'] = {'$gte': last_rec['value']['created']}
+        query['created'] = {'$gt': last_rec['value']['created']}
 
     log.info('Updating file_job_origin collection')
     config.db.jobs.map_reduce(map_fn, reduce_fn, out, query=query)

--- a/api/metrics/values.py
+++ b/api/metrics/values.py
@@ -55,6 +55,12 @@ USER_LOGIN_COUNT = Gauge('fw_user_login_count', 'The number of access logs of ty
 # Last Event Timestamps: events: session_created, user_login, job_queued[_by_system, by_user]
 LAST_EVENT_TIME = Gauge('fw_last_event_time', 'The seconds since an event as happened', ['event'], multiprocess_mode='max')
 
+# ===== Reports =====
+# Last time a report was collected
+LAST_REPORT_COLLECTION = Gauge('fw_last_report_collection', 'Last report collection time, in seconds since epoch', ['name'], multiprocess_mode='max')
+# Number of usage report collection errors
+REPORT_COLLECTION_ERROR_COUNT = Counter('fw_report_collection_errors', 'Observed report collection errors', ['name'])
+
 # ===== Meta =====
 COLLECT_METRICS_TIME = Summary('uwsgi_collect_metrics_time_seconds', 'Observed time to collect metrics, in seconds', [])
 

--- a/api/reports/__init__.py
+++ b/api/reports/__init__.py
@@ -2,6 +2,7 @@ from . import (
     site_report,
     project_report,
     access_log_report,
+    legacy_usage_report,
     usage_report,
 )
 
@@ -9,5 +10,6 @@ ReportTypes = {
     'site'            : site_report.SiteReport,
     'project'         : project_report.ProjectReport,
     'accesslog'       : access_log_report.AccessLogReport,
+    'legacy-usage'    : legacy_usage_report.UsageReport,
     'usage'           : usage_report.UsageReport,
 }

--- a/api/reports/__init__.py
+++ b/api/reports/__init__.py
@@ -4,6 +4,7 @@ from . import (
     access_log_report,
     legacy_usage_report,
     usage_report,
+    daily_usage_report,
 )
 
 ReportTypes = {
@@ -12,4 +13,5 @@ ReportTypes = {
     'accesslog'       : access_log_report.AccessLogReport,
     'legacy-usage'    : legacy_usage_report.UsageReport,
     'usage'           : usage_report.UsageReport,
+    'daily-usage'     : daily_usage_report.DailyUsageReport,
 }

--- a/api/reports/daily_usage_report.py
+++ b/api/reports/daily_usage_report.py
@@ -1,0 +1,101 @@
+import bson
+import datetime
+
+from .report import Report
+from .. import config
+from ..web.errors import APIReportParamsException
+
+class DailyUsageReport(Report):
+    """
+    Creates a site usage report, aggregated by group and project, daily.
+
+    This report uses usage_data collected in UsageReport. See that class for more detail.
+    """
+    can_collect = True
+    columns = [
+        'year', 'month', 'day', 'group', 'project',
+        'project_label', 'session_count',
+        'center_job_count', 'group_job_count',
+        'center_compute_ms', 'group_compute_ms',
+        'center_storage_bytes', 'group_storage_bytes'
+    ]
+
+    def __init__(self, params):
+        """
+        Initialize a Usage Report
+
+        Possible keys in :params:
+        :year:      The 4-digit requested report year
+        :month:     The 1-indexed requested report month
+        :group:     Limit report to one particular group
+        :project:   Limit report to one particular project
+        """
+        super(DailyUsageReport, self).__init__(params)
+
+        self.group = params.get('group')
+        self.project = params.get('project')
+
+        try:
+            # Get date parameters, validating ints
+            if 'year' in params:
+                self.year = int(params['year'])
+            else:
+                self.year = None
+
+            if 'month' in params:
+                self.month = int(params['month'])
+            else:
+                self.month = None
+        except (TypeError, ValueError) as e:
+            raise APIReportParamsException('Invalid date specified: {}'.format(e))
+
+    def user_can_generate(self, uid):
+        """
+        User generating report must be superuser
+        """
+        if config.db.users.count({'_id': uid, 'root': True}) > 0:
+            return True
+        return False
+
+    def build(self):
+        # Take year, month (or current year month)
+        if self.year or self.month:
+            # Require both values be set
+            if not self.year or not self.month:
+                raise APIReportParamsException('Must specify both year and month')
+        else:
+            now = datetime.datetime.now()
+            self.year = now.year
+            self.month = now.month
+
+        # Generate report on current year/month
+        query = {'year': self.year, 'month': self.month}
+        if self.group:
+            query['group'] = self.group
+        if self.project:
+            query['project'] = bson.ObjectId(self.project)
+
+        # Remove unwanted fields via projection
+        projection = {'year': 0, 'month': 0, 'total': 0}
+        sort = [('year', 1), ('month', 1), ('group', 1), ('project_label', 1)]
+
+        # No roll-up of groups in the detail report
+        records = []
+        for row in config.db.usage_data.find(query, projection, sort=sort):
+            # Produce one record per collected day, updating with common keys
+            row_keys = {
+                'year': self.year,
+                'month': self.month,
+                'group': row['group'],
+                'project': row['project'],
+                'project_label': row['project_label']
+            }
+
+            for day in range(1, 32):
+                day_record = row['days'].get(str(day))
+                if day_record:
+                    day_record.update(row_keys)
+                    day_record['day'] = day
+                    records.append(day_record)
+
+        return records

--- a/api/reports/handler.py
+++ b/api/reports/handler.py
@@ -46,6 +46,9 @@ class ReportHandler(base.RequestHandler):
         if not report.can_collect:
             raise NotImplementedError('Report type {} does not support collection'.format(report_type))
 
+        # Invoke input validation for report collection
+        report.before_collect()
+
         def sse_handler(environ, start_response): # pylint: disable=unused-argument
             write = start_response('200 OK', [
                 ('Content-Type', 'text/event-stream; charset=utf-8'),

--- a/api/reports/handler.py
+++ b/api/reports/handler.py
@@ -87,6 +87,14 @@ class ReportHandler(base.RequestHandler):
 
         return sse_handler
 
+    def get_availability(self, report_type):
+        """Get report availability"""
+        report = self._get_report(report_type)
+        if not report.has_availability:
+            raise NotImplementedError('Report type {} does not provide availability'.format(report_type))
+
+        return report.get_availability()
+
     def _get_report(self, report_type):
         """Get report for report_type and validate permissions"""
         if report_type in ReportTypes:

--- a/api/reports/handler.py
+++ b/api/reports/handler.py
@@ -1,5 +1,5 @@
 from .. import config
-from ..web import base
+from ..web import base, encoder
 from ..reports import ReportTypes
 from ..web.request import AccessTypeList
 from ..web.errors import APIPermissionException
@@ -61,7 +61,10 @@ class ReportHandler(base.RequestHandler):
             # - Exceptions add some error json to the response, which is not SSE-sanitized.
             for item in report.collect():
                 try:
-                    write(item)
+                    write(encoder.json_sse_pack({
+                        'event': 'progress',
+                        'data': item
+                    }))
                 except Exception: # pylint: disable=broad-except
                     log.info('SSE upload progress failed to send; continuing')
 

--- a/api/reports/handler.py
+++ b/api/reports/handler.py
@@ -1,6 +1,10 @@
+from .. import config
 from ..web import base
 from ..reports import ReportTypes
 from ..web.request import AccessTypeList
+from ..web.errors import APIPermissionException
+
+log = config.log
 
 class ReportHandler(base.RequestHandler):
     """Handles report requests
@@ -12,38 +16,68 @@ class ReportHandler(base.RequestHandler):
         return AccessTypeList
 
     def get(self, report_type):
+        report = self._get_report(report_type)
 
-        report = None
+        if self.is_true('csv'):
+            download_format = 'csv'
+        else:
+            download_format = self.get_param('download')
 
+        if download_format:
+            # Stream the response
+            def response_handler(environ, start_response): # pylint: disable=unused-argument
+                report_writer = report.get_writer(download_format)
+
+                write = start_response('200 OK', [
+                    ('Content-Type', report_writer.get_content_type()),
+                    ('Content-Disposition', 'attachment; filename="{}"'.format(report_writer.get_filename())),
+                    ('Connection', 'keep-alive')
+                ])
+
+                report_writer.execute(write)
+                return ''
+
+            return response_handler
+        else:
+            return report.build()
+
+    def collect(self, report_type):
+        report = self._get_report(report_type)
+        if not report.can_collect:
+            raise NotImplementedError('Report type {} does not support collection'.format(report_type))
+
+        def sse_handler(environ, start_response): # pylint: disable=unused-argument
+            write = start_response('200 OK', [
+                ('Content-Type', 'text/event-stream; charset=utf-8'),
+                ('Connection', 'keep-alive')
+            ])
+
+            # Instead of handing the iterator off to response.app_iter, send it ourselves.
+            # This prevents disconnections from leaving the API in a partially-complete state.
+            #
+            # Timing out between events or throwing an exception will result in undefinied behaviour.
+            # Right now, in our environment:
+            # - Timeouts may result in nginx-created 500 Bad Gateway HTML being added to the response.
+            # - Exceptions add some error json to the response, which is not SSE-sanitized.
+            for item in report.collect():
+                try:
+                    write(item)
+                except Exception: # pylint: disable=broad-except
+                    log.info('SSE upload progress failed to send; continuing')
+
+            return ''
+
+        return sse_handler
+
+    def _get_report(self, report_type):
+        """Get report for report_type and validate permissions"""
         if report_type in ReportTypes:
             report_class = ReportTypes[report_type]
             report = report_class(self.request.params)
         else:
             raise NotImplementedError('Report type {} is not supported'.format(report_type))
 
-        if self.superuser_request or report.user_can_generate(self.uid):
-            if self.is_true('csv'):
-                download_format = 'csv'
-            else:
-                download_format = self.get_param('download')
+        if not self.superuser_request and not report.user_can_generate(self.uid):
+            raise APIPermissionException('User {} does not have permissions to generate report'.format(self.uid))
 
-            if download_format:
-                # Stream the response
-                def response_handler(environ, start_response): # pylint: disable=unused-argument
-                    report_writer = report.get_writer(download_format)
-
-                    write = start_response('200 OK', [
-                        ('Content-Type', report_writer.get_content_type()),
-                        ('Content-Disposition', 'attachment; filename="{}"'.format(report_writer.get_filename())),
-                        ('Connection', 'keep-alive')
-                    ])
-
-                    report_writer.execute(write)
-                    return ''
-
-                return response_handler
-            else:
-                return report.build()
-        else:
-            self.abort(403, 'User {} does not have required permissions to generate report'.format(self.uid))
-
+        return report

--- a/api/reports/legacy_usage_report.py
+++ b/api/reports/legacy_usage_report.py
@@ -1,0 +1,366 @@
+import copy
+import datetime
+import dateutil
+
+from .report import Report
+
+from .. import config
+
+from ..web.errors import APIReportException, APIReportParamsException
+
+
+BYTES_IN_MEGABYTE = float(1<<20)
+
+
+class UsageReport(Report):
+    """
+    Creates a usage report, aggregated by month or project.
+
+    Specify a date range to only return stats for that range.
+
+    Report includes:
+      - count of gears executed (jobs completed successfully)
+      - count of sessions
+      - aggregation of file size in megabytes
+    """
+
+    def __init__(self, params):
+        """
+        Initialize a Usage Report
+
+        Possible keys in :params:
+        :start_date:    ISO formatted timestamp
+        :end_date:      ISO formatted timestamp
+        :type:          <'project'|'month'>, type of aggregation for results
+        """
+
+        super(UsageReport, self).__init__(params)
+
+        start_date = params.get('start_date')
+        end_date = params.get('end_date')
+        report_type = params.get('type')
+
+        if not report_type or report_type not in ['month', 'project']:
+            raise APIReportParamsException('Report type must be "month" or "project".')
+
+        if start_date:
+            start_date = dateutil.parser.parse(start_date)
+        if end_date:
+            end_date = dateutil.parser.parse(end_date)
+        if end_date and start_date and end_date < start_date:
+            raise APIReportParamsException('End date {} is before start date {}'.format(end_date, start_date))
+
+        self.start_date  = start_date
+        self.end_date    = end_date
+        self.report_type = report_type
+
+        # Used for month calculation:
+        self.first_month = start_date
+        self.last_month = end_date
+
+
+    def user_can_generate(self, uid):
+        """
+        User generating report must be superuser
+        """
+        if config.db.users.count({'_id': uid, 'root': True}) > 0:
+            return True
+        return False
+
+
+    def build(self):
+        query = {}
+
+        if self.start_date or self.end_date:
+            query['created'] = {}
+        if self.start_date:
+            query['created']['$gte'] = self.start_date
+        if self.end_date:
+            query['created']['$lte'] = self.end_date
+
+        if self.report_type == 'project':
+            return self._build_project_report(query)
+        else:
+            return self._build_month_report(query)
+
+    def _create_default(self, month=None, year=None, project=None, ignore_minmax=False):
+        """
+        Returns a zerod out usage report for month/project type usage reports
+
+        If proveded with a month and year, adds info to the report as well as updates first and last seen months
+        If provided with a project, adds id and label to the report
+        """
+        obj = {
+            'gear_execution_count': 0,
+            'file_mbs': 0,
+            'session_count': 0
+        }
+        if month:
+            obj['month'] = month
+        if year:
+            obj['year'] = year
+        if project:
+            obj['project'] = {'_id': project['_id'], 'label': project['label']}
+
+        if month and year and not ignore_minmax:
+            # update the first or last month if this is outside the known bounds
+            date = dateutil.parser.parse(year+'-'+month+'-01T00:00.000Z')
+            if self.first_month is None or date < self.first_month:
+                self.first_month = date
+            if self.last_month is None or date > self.last_month:
+                self.last_month = date
+
+        return obj
+
+    def _build_month_report(self, base_query):
+        """
+        Builds a usage report for file size, session count and gear execution count
+        Aggregates this information by month.
+
+        Will return all months between the first_month and last_month, zero'd out if no
+        data was created or jobs run in that time.
+          - `first_month` is determined by the start_date of the query, if available, otherwise
+            the earliest month with data/jobs
+          - `last_month` is the end_date of the query or the last month with data/jobs
+
+        Returns an ordered list of each month in the range `first_month` -> `last_month` with stats:
+        {
+            'month':                    <month_int>,
+            'year':                     <year_int>,
+            'gear_execution_count':     0,
+            'session_count':            0,
+            'file_mbs':                 0
+        }
+        """
+
+        report = {}
+
+        # Count jobs that completed successfully, by month
+        job_q = copy.deepcopy(base_query)
+        job_q['state'] = 'complete'
+
+        pipeline = [
+            {'$match': job_q},
+            {'$project': {'month': {'$month': '$created'}, 'year': {'$year': '$created'}}},
+            {'$group': {'_id': {'month': '$month', 'year': '$year'}, 'jobs_completed': {'$sum':1}}}
+        ]
+
+        try:
+            results = self._get_result_list('jobs', pipeline)
+        except APIReportException:
+            results = []
+
+        for r in results:
+            month = str(r['_id']['month'])
+            year = str(r['_id']['year'])
+            key = year+month
+
+            # Check to see if we already have a record for this month/year combo, create and update first/last if not
+            if key not in report:
+                report[key] = self._create_default(month=month, year=year)
+
+            report[key]['gear_execution_count'] = r['jobs_completed']
+
+        # Count sessions by month
+        pipeline = [
+            {'$match': base_query},
+            {'$project': {'month': {'$month': '$created'}, 'year': {'$year': '$created'}}},
+            {'$group': {'_id': {'month': '$month', 'year': '$year'}, 'session_count': {'$sum':1}}}
+        ]
+
+        try:
+            results = self._get_result_list('sessions', pipeline)
+        except APIReportException:
+            results = []
+
+        for r in results:
+            month = str(r['_id']['month'])
+            year = str(r['_id']['year'])
+            key = year+month
+
+            # Check to see if we already have a record for this month/year combo, create and update first/last if not
+            if key not in report:
+                report[key] = self._create_default(month=month, year=year)
+
+            report[key]['session_count'] = r['session_count']
+
+        file_q = {'deleted': {'$exists': False}}
+        analysis_q = {'analyses.files.output': True}
+
+        if 'created' in base_query:
+            file_q['files.created'] = base_query['created']
+            analysis_q['analyses.created'] = base_query['created']
+
+        for cont_name in ['groups', 'projects', 'sessions', 'acquisitions']:
+            # For each type of container that would contain files or analyses:
+
+            # Count file mbs by month
+            pipeline = [
+                {'$unwind': '$files'},
+                {'$match': file_q},
+                {'$project': {'month': {'$month': '$files.created'}, 'year': {'$year': '$files.created'}, 'mbs': {'$divide': ['$files.size', BYTES_IN_MEGABYTE]}}},
+                {'$group': {'_id': {'month': '$month', 'year': '$year'}, 'mb_total': {'$sum':'$mbs'}}}
+            ]
+
+            try:
+                results = self._get_result_list(cont_name, pipeline)
+            except APIReportException:
+                results = []
+
+            for r in results:
+                month = str(r['_id']['month'])
+                year = str(r['_id']['year'])
+                key = year+month
+
+                # Check to see if we already have a record for this month/year combo, create and update first/last if not
+                if key not in report:
+                    report[key] = self._create_default(month=month, year=year)
+
+                report[key]['file_mbs'] += r['mb_total']
+
+            # Count file mbs by month in analyses
+            pipeline = [
+                {'$unwind': '$analyses'},
+                {'$unwind': '$analyses.files'},
+                {'$match': analysis_q},
+                {'$project': {'month': {'$month': '$analyses.created'}, 'year': {'$year': '$analyses.created'}, 'mbs': {'$divide': ['$analyses.files.size', BYTES_IN_MEGABYTE]}}},
+                {'$group': {'_id': {'month': '$month', 'year': '$year'}, 'mb_total': {'$sum':'$mbs'}}}
+            ]
+
+            try:
+                results = self._get_result_list(cont_name, pipeline)
+            except APIReportException:
+                results = []
+
+            for r in results:
+                month = str(r['_id']['month'])
+                year = str(r['_id']['year'])
+                key = year+month
+
+                # Check to see if we already have a record for this month/year combo, create and update first/last if not
+                if key not in report:
+                    report[key] = self._create_default(month=month, year=year)
+
+                report[key]['file_mbs'] += r['mb_total']
+
+
+        # For each month between `first_month` and `last_month`:
+        #  - add the month from the dictionary of report objects if it exists
+        #  - OR create a zero'd out report object for the month
+
+        # Set `first_month` and `last_month` to current month in case they weren't specified
+        # AND there was no data in mongo to get defaults
+        self.first_month = self.first_month or datetime.datetime.utcnow()
+        self.last_month = self.last_month or self.first_month
+
+        curr_month = self.first_month.month
+        curr_year = self.first_month.year
+
+        last_month = self.last_month.month
+        last_year = self.last_month.year
+
+        final_report_list = []
+
+        # While we're not in the year of the last month we want to record OR we are and we haven't hit the last month yet:
+        while curr_year < last_year or (curr_month <= last_month and curr_year == last_year):
+            key = str(curr_year)+str(curr_month)
+            if key in report:
+                # We have a record for this month/year combo, add it to the report
+                final_report_list.append(report[key])
+            else:
+                # We don't have a record for this month/year combo, create a zero'd out version
+                final_report_list.append(self._create_default(month=str(curr_month), year=str(curr_year), ignore_minmax=True))
+            curr_month += 1
+            if curr_month > 12:
+                curr_year += 1
+                curr_month = 1
+
+        # Return ordered list of report objects for each month in range
+        return final_report_list
+
+
+    def _build_project_report(self, base_query):
+        """
+        Builds a usage report for file size, session count and gear execution count
+        Aggregates this information by project.
+
+        Returns an unordered list of each project with stats:
+        {
+            'project': {
+                '_id':      <project_id>,
+                'label':    <project_label>
+            },
+            'gear_execution_count':     0,
+            'session_count':            0,
+            'file_mbs':                 0
+        }
+        """
+        projects = config.db.projects.find({'deleted': {'$exists': False}})
+        final_report_list = []
+
+        for p in projects:
+            report_obj = self._create_default(project=p)
+
+            # Grab sessions and their ids
+            sessions = config.db.sessions.find({'project': p['_id'], 'deleted': {'$exists': False}}, {'_id': 1})
+            session_ids = [s['_id'] for s in sessions]
+
+            # Grab acquisitions and their ids
+            acquisitions = config.db.acquisitions.find({'session': {'$in': session_ids}, 'deleted': {'$exists': False}}, {'_id': 1})
+            acquisition_ids = [a['_id'] for a in acquisitions]
+
+            # For the project and each session and acquisition, create a list of analysis ids
+            parent_ids = session_ids + acquisition_ids + [p['_id']]
+            analysis_ids = [an['_id'] for an in config.db.analyses.find({'parent.id': {'$in': parent_ids}, 'deleted': {'$exists': False}})]
+
+            report_obj['session_count'] = len(session_ids)
+
+            # for each type of container below it will have a slightly modified match query
+            cont_query = {
+                'projects': {'_id': {'project': p['_id']}},
+                'sessions': {'project': p['_id']},
+                'acquisitions': {'session': {'$in': session_ids}},
+                'analyses': {'parent.id' : {'$in':parent_ids}}
+            }
+
+            # Create queries for files and analyses based on created date if a range was provided
+            file_q = {'deleted': {'$exists': False}}
+            analysis_q = {'analyses.files.output': True}
+
+            if 'created' in base_query:
+                file_q['files.created'] = base_query['created']
+                analysis_q['analyses.created'] = base_query['created']
+
+            for cont_name in ['projects', 'sessions', 'acquisitions', 'analyses']:
+
+                # Aggregate file size in megabytes
+                pipeline = [
+                    {'$match': cont_query[cont_name]},
+                    {'$unwind': '$files'},
+                    {'$match': file_q},
+                    {'$project': {'mbs': {'$divide': [{'$cond': ['$files.input', 0, '$files.size']}, BYTES_IN_MEGABYTE]}}},
+                    {'$group': {'_id': 1, 'mb_total': {'$sum':'$mbs'}}}
+                ]
+
+                try:
+                    result = self._get_result(cont_name, pipeline)
+                except APIReportException:
+                    result = None
+
+                if result:
+                    report_obj['file_mbs'] += result['mb_total']
+
+            # Create a list of all possible ids in this project hierarchy
+            id_list = analysis_ids+acquisition_ids+session_ids
+            id_list.append(p['_id'])
+
+            # Look for all completed jobs that have a destination in the id
+            job_query = copy.deepcopy(base_query)
+            job_query['state'] = 'complete'
+            job_query['destination.id'] = {'$in': [str(id_) for id_ in id_list]}
+
+            report_obj['gear_execution_count'] = config.db.jobs.count(job_query)
+
+            final_report_list.append(report_obj)
+
+        return final_report_list

--- a/api/reports/report.py
+++ b/api/reports/report.py
@@ -33,6 +33,13 @@ class Report(object):
         """
         raise NotImplementedError()
 
+    def before_collect(self):
+        """
+        Called before the collect method, and before the SSE handler is started.
+        This method should perform any last minute validation to raise a status
+        """
+        pass
+
     def collect(self):
         """
         Periodically collect data for a report.

--- a/api/reports/report.py
+++ b/api/reports/report.py
@@ -11,6 +11,7 @@ class Report(object):
     filename = 'report'
     columns = None
     can_collect = False
+    has_availability = False  # Whether or not availability is supported
 
     def __init__(self, params):
         """
@@ -45,7 +46,7 @@ class Report(object):
         Periodically collect data for a report.
         Can/should return a genrator that yields dict progress results.
         """
-        raise APIReportException("Collect not implemented for this report type")
+        raise APIReportException('Collect not implemented for this report type')
 
     def get_writer(self, out_format):
         """
@@ -61,6 +62,12 @@ class Report(object):
         Perform any necessary conversions to write the given flattened row.
         """
         pass
+
+    def get_availability(self):
+        """
+        Get a list of available times for the report
+        """
+        raise APIReportException('Availability reporting not implemented for this report type')
 
     @staticmethod
     def _get_result_list(cont_name, pipeline):

--- a/api/reports/report.py
+++ b/api/reports/report.py
@@ -10,6 +10,7 @@ class Report(object):
 
     filename = 'report'
     columns = None
+    can_collect = False
 
     def __init__(self, params):
         """
@@ -31,6 +32,13 @@ class Report(object):
         Build and return a json report
         """
         raise NotImplementedError()
+
+    def collect(self):
+        """
+        Periodically collect data for a report.
+        Can/should return a genrator that yields dict progress results.
+        """
+        raise APIReportException("Collect not implemented for this report type")
 
     def get_writer(self, out_format):
         """

--- a/api/reports/usage_report.py
+++ b/api/reports/usage_report.py
@@ -1,63 +1,85 @@
-import copy
 import datetime
-import dateutil
+
+from pymongo.operations import UpdateOne
 
 from .report import Report
-
 from .. import config
+from ..web.errors import APIReportParamsException
+from ..jobs import file_job_origin
 
-from ..web.errors import APIReportException, APIReportParamsException
+log = config.log
 
-
+BULK_UPDATE_BLOCK_SIZE = 100
 BYTES_IN_MEGABYTE = float(1<<20)
+MILLISECONDS_IN_HOUR = float(1000 * 60 * 60)
 
+# Tuple of collection name, file size key
+FILE_COLLECTIONS = ['projects', 'subjects', 'sessions', 'acquisitions', 'analyses']
 
 class UsageReport(Report):
     """
-    Creates a usage report, aggregated by month or project.
+    Creates a site usage report, aggregated by group and project.
 
-    Specify a date range to only return stats for that range.
+    Specify a year/month to get a report for that time period.
 
     Report includes:
-      - count of gears executed (jobs completed successfully)
-      - count of sessions
-      - aggregation of file size in megabytes
+        - Count of sessions
+        - Count of complete jobs, grouped by data/analysis
+        - Aggregation of gear execution time in hours, grouped by center/group 
+        - Aggregation of total storage size in megabytes, grouped by center/group 
+
+    Collection is done nightly, and stored in the usage_data database collection, using the below structure:
+        group: The group id
+        project: The project id
+        project_label: The project label (at last collection)
+        year: The collection year
+        month: The collection month
+        days: A map of day_of_month to collection record for that date, as follows:
+            session_count: The number of sessions that exist at time of collection
+            center_job_count: The number of jobs ran attributed to the center
+            group_job_count: The number of jobs ran attributed to the group
+            center_storage_bytes: The size of storage usage allocated to the center, in bytes
+            group_storage_bytes: The size of storage usage allocated to the group, in bytes
+            center_compute_ms: The amount of compute used attributed to the center, in seconds
+            group_compute_ms: The amount of compute used attributed to the group, in seconds
+        total: A usage total (to-date), same format as the day record, with additional:
+            days: The number of days collated for this month
+
+    NOTE: Storage is reported in byte days (i.e. how many bytes were in use for that day)
     """
+    can_collect = True
+    columns = [
+        'group', 'project_id', 'project_label', 'session_count',
+        'center_job_count', 'group_job_count', 'total_job_count',
+        'center_compute_hours', 'group_compute_hours', 'total_compute_hours',
+        'center_storage_mb', 'group_storage_mb', 'total_storage_mb'
+    ]
 
     def __init__(self, params):
         """
         Initialize a Usage Report
 
         Possible keys in :params:
-        :start_date:    ISO formatted timestamp
-        :end_date:      ISO formatted timestamp
-        :type:          <'project'|'month'>, type of aggregation for results
+        :year:      The 4-digit requested report year
+        :month:     The 1-indexed requested report month
+        :day:       The day of the month (used for collection only)
         """
-
         super(UsageReport, self).__init__(params)
 
-        start_date = params.get('start_date')
-        end_date = params.get('end_date')
-        report_type = params.get('type')
+        now = datetime.datetime.now()
 
-        if not report_type or report_type not in ['month', 'project']:
-            raise APIReportParamsException('Report type must be "month" or "project".')
+        # TODO: Use configured gear names
+        self.center_gears = [ 'dicom-mr-classifier', 'dcm2niix', 'mriqc' ]
 
-        if start_date:
-            start_date = dateutil.parser.parse(start_date)
-        if end_date:
-            end_date = dateutil.parser.parse(end_date)
-        if end_date and start_date and end_date < start_date:
-            raise APIReportParamsException('End date {} is before start date {}'.format(end_date, start_date))
+        try:
+            year = int(params.get('year', str(now.year)))
+            month = int(params.get('month', str(now.month)))
+            day = int(params.get('day', str(now.day)))
 
-        self.start_date  = start_date
-        self.end_date    = end_date
-        self.report_type = report_type
-
-        # Used for month calculation:
-        self.first_month = start_date
-        self.last_month = end_date
-
+            # Does validation
+            self.date = datetime.datetime(year=year, month=month, day=day)
+        except ValueError as e:
+            raise APIReportParamsException('Invalid date specified: {}'.format(e))
 
     def user_can_generate(self, uid):
         """
@@ -67,300 +89,250 @@ class UsageReport(Report):
             return True
         return False
 
-
     def build(self):
-        query = {}
+        # TODO: Implement
+        return None
 
-        if self.start_date or self.end_date:
-            query['created'] = {}
-        if self.start_date:
-            query['created']['$gte'] = self.start_date
-        if self.end_date:
-            query['created']['$lte'] = self.end_date
+    def collect(self):
+        """Collect daily usage data. NOTE: We deliberately include deleted collections/files"""
+        # Set start and end dates. Jobs that completed between start & end will be included
+        # Files and sessions created before end will be included
+        start_date = self.date
+        end_date = self.date + datetime.timedelta(days=1)
 
-        if self.report_type == 'project':
-            return self._build_project_report(query)
-        else:
-            return self._build_month_report(query)
+        # First update the file_job_origin collection, for joins
+        yield { 'status': 'Updating file_job_origin collection' }
+        file_job_origin.update_file_job_origin()
 
-    def _create_default(self, month=None, year=None, project=None, ignore_minmax=False):
-        """
-        Returns a zerod out usage report for month/project type usage reports
+        # Create empty record for each project
+        report_entries = {}
+        yield { 'status': 'Initializing collection...' }
+        for project in config.db.projects.find({}, {'group': True, 'label': True}):
+            project_id = project['_id']
+            report_entries[project_id] = self._default_record(project['group'], project_id, project['label'])
 
-        If proveded with a month and year, adds info to the report as well as updates first and last seen months
-        If provided with a project, adds id and label to the report
-        """
-        obj = {
-            'gear_execution_count': 0,
-            'file_mbs': 0,
-            'session_count': 0
-        }
-        if month:
-            obj['month'] = month
-        if year:
-            obj['year'] = year
-        if project:
-            obj['project'] = {'_id': project['_id'], 'label': project['label']}
+        # Count sessions created in timeframe, returns cursor
+        yield { 'status': 'Getting session counts...' }
+        for entry in self._get_session_counts(end_date):
+            _id = entry['_id']
+            report_entries[_id['project']]['session_count'] = entry['count']
 
-        if month and year and not ignore_minmax:
-            # update the first or last month if this is outside the known bounds
-            date = dateutil.parser.parse(year+'-'+month+'-01T00:00.000Z')
-            if self.first_month is None or date < self.first_month:
-                self.first_month = date
-            if self.last_month is None or date > self.last_month:
-                self.last_month = date
+        # Count files created in timeframe
+        skipped = 0
+        for coll_name in FILE_COLLECTIONS:
+            yield { 'status': 'Getting {} storage usage...'.format(coll_name) }
+            for entry in self._get_file_size_counts(coll_name, end_date):
+                _id = entry['_id']
+                size = entry['bytes']
 
-        return obj
+                # Safety check
+                if 'project' not in _id:
+                    skipped +=1
+                    continue
 
-    def _build_month_report(self, base_query):
-        """
-        Builds a usage report for file size, session count and gear execution count
-        Aggregates this information by month.
+                project_rec = report_entries.get(_id['project'])
+                if project_rec:
+                    # if origin is device, then bill to center
+                    if _id.get('origin') == 'device' or self._is_center_gear(_id):
+                        key = 'center_storage_bytes'
+                    else:
+                        key = 'group_storage_bytes'
 
-        Will return all months between the first_month and last_month, zero'd out if no
-        data was created or jobs run in that time.
-          - `first_month` is determined by the start_date of the query, if available, otherwise
-            the earliest month with data/jobs
-          - `last_month` is the end_date of the query or the last month with data/jobs
+                    project_rec[key] += size
 
-        Returns an ordered list of each month in the range `first_month` -> `last_month` with stats:
-        {
-            'month':                    <month_int>,
-            'year':                     <year_int>,
-            'gear_execution_count':     0,
-            'session_count':            0,
-            'file_mbs':                 0
-        }
-        """
+        if skipped:
+            log.warn('Skipped %d records because of invalid keys', skipped)
 
-        report = {}
+        # Aggregate jobs counts run with execution time (in milliseconds) in timeframe
+        yield { 'status': 'Getting compute usage...' }
+        for entry in self._get_job_stats(start_date, end_date):
+            _id = entry['_id']
 
-        # Count jobs that completed successfully, by month
-        job_q = copy.deepcopy(base_query)
-        job_q['state'] = 'complete'
+            project_rec = report_entries.get(_id['project'])
+            if project_rec:
+                if self._is_center_gear(_id):
+                    count_key = 'center_job_count'
+                    time_key = 'center_compute_ms'
+                else:
+                    count_key = 'group_job_count'
+                    time_key = 'group_compute_ms'
 
-        pipeline = [
-            {'$match': job_q},
-            {'$project': {'month': {'$month': '$created'}, 'year': {'$year': '$created'}}},
-            {'$group': {'_id': {'month': '$month', 'year': '$year'}, 'jobs_completed': {'$sum':1}}}
-        ]
+                project_rec[count_key] += entry['count']
+                project_rec[time_key] += entry['total_ms']
 
-        try:
-            results = self._get_result_list('jobs', pipeline)
-        except APIReportException:
-            results = []
+        # Bulk updates
+        update_count = 0
+        record_count = len(report_entries)
+        year = self.date.year
+        month = self.date.month
+        day = self.date.day
+        day_entry = 'day.{}'.format(day)
+        bulk_updates = []
 
-        for r in results:
-            month = str(r['_id']['month'])
-            year = str(r['_id']['year'])
-            key = year+month
+        for row in report_entries.itervalues():
+            # Yield progress every time we empty out bulk_updates
+            if not bulk_updates:
+                yield { 
+                    'status': 'Updating records', 
+                    'progress': '{}/{}'.format(update_count, record_count) 
+                }
 
-            # Check to see if we already have a record for this month/year combo, create and update first/last if not
-            if key not in report:
-                report[key] = self._create_default(month=month, year=year)
+            group = row.pop('group')
+            project = row.pop('project')
+            project_label = row.pop('project_label')
 
-            report[key]['gear_execution_count'] = r['jobs_completed']
-
-        # Count sessions by month
-        pipeline = [
-            {'$match': base_query},
-            {'$project': {'month': {'$month': '$created'}, 'year': {'$year': '$created'}}},
-            {'$group': {'_id': {'month': '$month', 'year': '$year'}, 'session_count': {'$sum':1}}}
-        ]
-
-        try:
-            results = self._get_result_list('sessions', pipeline)
-        except APIReportException:
-            results = []
-
-        for r in results:
-            month = str(r['_id']['month'])
-            year = str(r['_id']['year'])
-            key = year+month
-
-            # Check to see if we already have a record for this month/year combo, create and update first/last if not
-            if key not in report:
-                report[key] = self._create_default(month=month, year=year)
-
-            report[key]['session_count'] = r['session_count']
-
-        file_q = {'deleted': {'$exists': False}}
-        analysis_q = {'analyses.files.output': True}
-
-        if 'created' in base_query:
-            file_q['files.created'] = base_query['created']
-            analysis_q['analyses.created'] = base_query['created']
-
-        for cont_name in ['groups', 'projects', 'sessions', 'acquisitions']:
-            # For each type of container that would contain files or analyses:
-
-            # Count file mbs by month
-            pipeline = [
-                {'$unwind': '$files'},
-                {'$match': file_q},
-                {'$project': {'month': {'$month': '$files.created'}, 'year': {'$year': '$files.created'}, 'mbs': {'$divide': ['$files.size', BYTES_IN_MEGABYTE]}}},
-                {'$group': {'_id': {'month': '$month', 'year': '$year'}, 'mb_total': {'$sum':'$mbs'}}}
-            ]
-
-            try:
-                results = self._get_result_list(cont_name, pipeline)
-            except APIReportException:
-                results = []
-
-            for r in results:
-                month = str(r['_id']['month'])
-                year = str(r['_id']['year'])
-                key = year+month
-
-                # Check to see if we already have a record for this month/year combo, create and update first/last if not
-                if key not in report:
-                    report[key] = self._create_default(month=month, year=year)
-
-                report[key]['file_mbs'] += r['mb_total']
-
-            # Count file mbs by month in analyses
-            pipeline = [
-                {'$unwind': '$analyses'},
-                {'$unwind': '$analyses.files'},
-                {'$match': analysis_q},
-                {'$project': {'month': {'$month': '$analyses.created'}, 'year': {'$year': '$analyses.created'}, 'mbs': {'$divide': ['$analyses.files.size', BYTES_IN_MEGABYTE]}}},
-                {'$group': {'_id': {'month': '$month', 'year': '$year'}, 'mb_total': {'$sum':'$mbs'}}}
-            ]
-
-            try:
-                results = self._get_result_list(cont_name, pipeline)
-            except APIReportException:
-                results = []
-
-            for r in results:
-                month = str(r['_id']['month'])
-                year = str(r['_id']['year'])
-                key = year+month
-
-                # Check to see if we already have a record for this month/year combo, create and update first/last if not
-                if key not in report:
-                    report[key] = self._create_default(month=month, year=year)
-
-                report[key]['file_mbs'] += r['mb_total']
-
-
-        # For each month between `first_month` and `last_month`:
-        #  - add the month from the dictionary of report objects if it exists
-        #  - OR create a zero'd out report object for the month
-
-        # Set `first_month` and `last_month` to current month in case they weren't specified
-        # AND there was no data in mongo to get defaults
-        self.first_month = self.first_month or datetime.datetime.utcnow()
-        self.last_month = self.last_month or self.first_month
-
-        curr_month = self.first_month.month
-        curr_year = self.first_month.year
-
-        last_month = self.last_month.month
-        last_year = self.last_month.year
-
-        final_report_list = []
-
-        # While we're not in the year of the last month we want to record OR we are and we haven't hit the last month yet:
-        while curr_year < last_year or (curr_month <= last_month and curr_year == last_year):
-            key = str(curr_year)+str(curr_month)
-            if key in report:
-                # We have a record for this month/year combo, add it to the report
-                final_report_list.append(report[key])
-            else:
-                # We don't have a record for this month/year combo, create a zero'd out version
-                final_report_list.append(self._create_default(month=str(curr_month), year=str(curr_year), ignore_minmax=True))
-            curr_month += 1
-            if curr_month > 12:
-                curr_year += 1
-                curr_month = 1
-
-        # Return ordered list of report objects for each month in range
-        return final_report_list
-
-
-    def _build_project_report(self, base_query):
-        """
-        Builds a usage report for file size, session count and gear execution count
-        Aggregates this information by project.
-
-        Returns an unordered list of each project with stats:
-        {
-            'project': {
-                '_id':      <project_id>,
-                'label':    <project_label>
-            },
-            'gear_execution_count':     0,
-            'session_count':            0,
-            'file_mbs':                 0
-        }
-        """
-        projects = config.db.projects.find({'deleted': {'$exists': False}})
-        final_report_list = []
-
-        for p in projects:
-            report_obj = self._create_default(project=p)
-
-            # Grab sessions and their ids
-            sessions = config.db.sessions.find({'project': p['_id'], 'deleted': {'$exists': False}}, {'_id': 1})
-            session_ids = [s['_id'] for s in sessions]
-
-            # Grab acquisitions and their ids
-            acquisitions = config.db.acquisitions.find({'session': {'$in': session_ids}, 'deleted': {'$exists': False}}, {'_id': 1})
-            acquisition_ids = [a['_id'] for a in acquisitions]
-
-            # For the project and each session and acquisition, create a list of analysis ids
-            parent_ids = session_ids + acquisition_ids + [p['_id']]
-            analysis_ids = [an['_id'] for an in config.db.analyses.find({'parent.id': {'$in': parent_ids}, 'deleted': {'$exists': False}})]
-
-            report_obj['session_count'] = len(session_ids)
-
-            # for each type of container below it will have a slightly modified match query
-            cont_query = {
-                'projects': {'_id': {'project': p['_id']}},
-                'sessions': {'project': p['_id']},
-                'acquisitions': {'session': {'$in': session_ids}},
-                'analyses': {'parent.id' : {'$in':parent_ids}}
+            query = {
+                'group': group,
+                'project': project, 
+                'year': year,
+                'month': month,
+                day_entry: {'$exists': False}
             }
 
-            # Create queries for files and analyses based on created date if a range was provided
-            file_q = {'deleted': {'$exists': False}}
-            analysis_q = {'analyses.files.output': True}
+            # Create the bulk update
+            bulk_updates.append(UpdateOne(
+                query,
+                { 
+                    '$set': {
+                        'project_label': project_label,
+                        day: row,
+                        'total.sessions': row['session_count']
+                    },
+                    '$inc': {
+                        'total.days': 1,
+                        'total.center_job_count': row['center_job_count'],
+                        'total.group_job_count': row['group_job_count'],
+                        'total.center_storage_bytes': row['center_storage_bytes'],
+                        'total.group_storage_bytes': row['group_storage_bytes'],
+                        'total.center_compute_ms': row['center_compute_ms'],
+                        'total.group_compute_ms': row['group_compute_ms'],
+                    },
+                    '$setOnInsert': {
+                        'group': group,
+                        'project':  project,
+                        'year': year,
+                        'month': month
+                    }
+                },
+                upsert=True
+            ))
 
-            if 'created' in base_query:
-                file_q['files.created'] = base_query['created']
-                analysis_q['analyses.created'] = base_query['created']
+            if len(bulk_updates) >= BULK_UPDATE_BLOCK_SIZE:
+                # Do bulk update block
+                config.db.bulk_write(bulk_updates, ordered=False)
+                bulk_updates = []
 
-            for cont_name in ['projects', 'sessions', 'acquisitions', 'analyses']:
+            update_count += 1
 
-                # Aggregate file size in megabytes
-                pipeline = [
-                    {'$match': cont_query[cont_name]},
-                    {'$unwind': '$files'},
-                    {'$match': file_q},
-                    {'$project': {'mbs': {'$divide': [{'$cond': ['$files.input', 0, '$files.size']}, BYTES_IN_MEGABYTE]}}},
-                    {'$group': {'_id': 1, 'mb_total': {'$sum':'$mbs'}}}
-                ]
+        yield {'status': 'Complete'} 
 
-                try:
-                    result = self._get_result(cont_name, pipeline)
-                except APIReportException:
-                    result = None
+        # TODO: Set metric for last successful usage collection date
+        # TODO: Set metric counter for usage collection failure
 
-                if result:
-                    report_obj['file_mbs'] += result['mb_total']
+    def _is_center_gear(self, key): # pylint: disable=unused-argument
+        """Check if the given key is a center gear. 
 
-            # Create a list of all possible ids in this project hierarchy
-            id_list = analysis_ids+acquisition_ids+session_ids
-            id_list.append(p['_id'])
+        key is a dict, with 'gear_name' and 'gear_version' properties.
+        """
+        return key.get('gear_name') in self.center_gears
 
-            # Look for all completed jobs that have a destination in the id
-            job_query = copy.deepcopy(base_query)
-            job_query['state'] = 'complete'
-            job_query['destination.id'] = {'$in': [str(id_) for id_ in id_list]}
+    @staticmethod
+    def _get_session_counts(end_date):
+        """
+        Get count of sessions created within date_query.
+        Grouped by project_id
+        """
+        # Aggregation query
+        pipeline = [
+            {'$match': {
+                'created': {'$lt': end_date}
+            }},
+            {'$group': {
+                '_id': {'project': 'project'},
+                'count': {'$sum': 1}
+            }}
+        ]
 
-            report_obj['gear_execution_count'] = config.db.jobs.count(job_query)
+        return config.db.sessions.aggregate(pipeline)
 
-            final_report_list.append(report_obj)
+    @staticmethod
+    def _get_file_size_counts(coll_name, end_date):
+        """
+        Get total file size in bytes, for files created before end_date
+        Grouped by project_id, origin, gear_name and gear_version
+        """
+        file_q = {'files.created': {'$lt': end_date}}
 
-        return final_report_list
+        if coll_name == 'projects':
+            group_id = {'project': '$_id'}
+        else:
+            group_id = {'project': '$parents.project'}
+
+        group_id['origin'] = '$files.origin.type'
+        group_id['gear_name'] = '$job_origin.0.value.gear_info.name'
+        group_id['gear_version'] = '$job_origin.0.value.gear_info.version'
+
+        pipeline = [
+            {'$unwind': '$files'},
+            {'$match': file_q },
+            {'$lookup': {
+                'from': 'file_job_origin',
+                'localField': 'origin.id',
+                'foreignField': '_id',
+                'as': 'job_origin' 
+            }},
+            {'$group': {
+                '_id': group_id,
+                'bytes': {'$sum': '$files.size'}
+            }}
+        ]
+
+        return config.db[coll_name].aggregate(pipeline)
+
+    @staticmethod
+    def _get_job_stats(start_date, end_date):
+        """
+        Get count and runtime duration of jobs created within date_query.
+        Grouped by project_id, gear_name and gear_version
+        """
+        # Note: We require the "new" job records in order to aggregate them
+        date_query = { '$gte': start_date, '$lt': end_date }
+
+        # Query for jobs that completed in the time window
+        match = {
+            'parents': {'$exists': True},
+            'state': {'$in': ['complete', 'failed', 'cancelled']},
+            '$or': [
+                {'transitions.complete': date_query},
+                {'transitions.cancelled': date_query},
+                {'transitions.failed': date_query}
+            ]
+        }
+
+        pipeline = [
+            {'$match': match},
+            {'$group': {
+                '_id': {'project': '$project', 'gear_name': '$gear_info.name', 'gear_version': '$gear_info.version'},
+                'count': {'$sum': 1},
+                'total_ms': {'$sum': '$profile.total_time_ms'},
+            }}
+        ]
+
+        return config.db.jobs.aggregate(pipeline)
+
+    @staticmethod
+    def _default_record(group, project_id, project_label):
+        return {
+            'group': group,
+            'project_id': project_id,
+            'project_label': project_label,
+            'session_count': 0,
+            'center_job_count': 0,
+            'group_job_count': 0,
+            'center_storage_bytes': 0,
+            'group_storage_bytes': 0,
+            'center_compute_ms': 0,
+            'group_compute_ms': 0,
+        }
+
+

--- a/api/reports/usage_report.py
+++ b/api/reports/usage_report.py
@@ -68,6 +68,8 @@ class UsageReport(Report):
         super(UsageReport, self).__init__(params)
 
         self._center_gears = None
+        self.start_date = None
+        self.end_date = None
 
         try:
             # Get date parameters, validating ints

--- a/api/reports/usage_report.py
+++ b/api/reports/usage_report.py
@@ -2,6 +2,7 @@ import bson
 import datetime
 
 from pymongo.operations import UpdateOne
+from pymongo.errors import BulkWriteError
 
 from .report import Report
 from .. import config
@@ -11,8 +12,6 @@ from ..jobs import file_job_origin
 log = config.log
 
 BULK_UPDATE_BLOCK_SIZE = 100
-BYTES_IN_MEGABYTE = float(1<<20)
-MILLISECONDS_IN_HOUR = float(1000 * 60 * 60)
 
 # Tuple of collection name, file size key
 FILE_COLLECTIONS = ['projects', 'subjects', 'sessions', 'acquisitions', 'analyses']
@@ -39,8 +38,8 @@ class UsageReport(Report):
             session_count: The number of sessions that exist at time of collection
             center_job_count: The number of jobs ran attributed to the center
             group_job_count: The number of jobs ran attributed to the group
-            center_storage_bytes: The size of storage usage allocated to the center, in bytes
-            group_storage_bytes: The size of storage usage allocated to the group, in bytes
+            center_storage_bytes: The size of storage usage allocated to the center, in byte-days
+            group_storage_bytes: The size of storage usage allocated to the group, in byte-days
             center_compute_ms: The amount of compute used attributed to the center, in seconds
             group_compute_ms: The amount of compute used attributed to the group, in seconds
         total: A usage total (to-date), same format as the day record, with additional:
@@ -50,10 +49,11 @@ class UsageReport(Report):
     """
     can_collect = True
     columns = [
-        'group', 'project_id', 'project_label', 'session_count',
+        'group', 'project', 'project_label', 'session_count',
         'center_job_count', 'group_job_count', 'total_job_count',
-        'center_compute_hours', 'group_compute_hours', 'total_compute_hours',
-        'center_storage_mb', 'group_storage_mb', 'total_storage_mb'
+        'center_compute_ms', 'group_compute_ms', 'total_compute_ms',
+        'center_storage_byte_day', 'group_storage_byte_day', 'total_storage_byte_day',
+        'days'
     ]
 
     def __init__(self, params):
@@ -67,18 +67,25 @@ class UsageReport(Report):
         """
         super(UsageReport, self).__init__(params)
 
-        now = datetime.datetime.now()
-
         self._center_gears = None
 
         try:
-            year = int(params.get('year', str(now.year)))
-            month = int(params.get('month', str(now.month)))
-            day = int(params.get('day', str(now.day)))
+            # Get date parameters, validating ints
+            if 'year' in params:
+                self.year = int(params['year'])
+            else:
+                self.year = None
 
-            # Does validation
-            self.date = datetime.datetime(year=year, month=month, day=day)
-        except ValueError as e:
+            if 'month' in params:
+                self.month = int(params['month'])
+            else:
+                self.month = None
+
+            if 'day' in params:
+                self.day = int(params['day'])
+            else:
+                self.day = None
+        except (TypeError, ValueError) as e:
             raise APIReportParamsException('Invalid date specified: {}'.format(e))
 
     @property
@@ -103,16 +110,71 @@ class UsageReport(Report):
         return False
 
     def build(self):
-        # TODO: Implement
-        return None
+        # Take year, month (or current year month)
+        if self.year or self.month:
+            # Require both values be set
+            if not self.year or not self.month:
+                raise APIReportParamsException('Must specify both year and month')
+        else:
+            now = datetime.datetime.now()
+            self.year = now.year
+            self.month = now.month
+
+        # Generate report on current year/month
+        query = {'year': self.year, 'month': self.month}
+        # Remove unwanted fields via projection
+        projection = {'_id': 0, 'year': 0, 'month': 0, 'days': 0}
+        sort = [('group', 1), ('project_label', 1)]
+
+        records = [] # Sequential list of records
+        group_record = {} # Current group record
+
+        # Run the query, project just totals
+        for row in config.db.usage_data.find(query, projection, sort=sort):
+            group = row['group']
+
+            if group_record and group_record['group'] != group:
+                # Total the prior group record
+                self._total_record(group_record)
+                group_record = None
+
+            if not group_record:
+                # Create group roll-up record
+                group_record = self._default_record(group, None, None)
+                records.append(group_record)
+
+            # Produce the project record by flattening the total record, and removing/adjusting fields
+            row.update(row.pop('total'))
+
+            # Sum group record
+            self._sum_records(row, group_record)
+
+            # Total the project record
+            self._total_record(row)
+            records.append(row)
+
+        # Total the remaining group record
+        if group_record:
+            self._total_record(group_record)
+
+        return records
+
+    def before_collect(self):
+        # Set start and end dates. Jobs that completed between start & end will be included
+        # Files and sessions created before end will be included
+        try:
+            if self.year or self.month or self.day:
+                self.start_date = datetime.datetime(year=self.year, month=self.month, day=self.day)
+            else:
+                now = datetime.datetime.now()
+                self.start_date = datetime.datetime(year=now.year, month=now.month, day=now.day) -  datetime.timedelta(days=1)
+        except (TypeError, ValueError) as e:
+            raise APIReportParamsException('Invalid date specified: {}'.format(e))
+
+        self.end_date = self.start_date + datetime.timedelta(days=1)
 
     def collect(self):
         """Collect daily usage data. NOTE: We deliberately include deleted collections/files"""
-        # Set start and end dates. Jobs that completed between start & end will be included
-        # Files and sessions created before end will be included
-        start_date = self.date
-        end_date = self.date + datetime.timedelta(days=1)
-
         # First update the file_job_origin collection, for joins
         yield { 'status': 'Updating file_job_origin collection' }
         file_job_origin.update_file_job_origin()
@@ -126,7 +188,7 @@ class UsageReport(Report):
 
         # Count sessions created in timeframe, returns cursor
         yield { 'status': 'Getting session counts...' }
-        for entry in self._get_session_counts(end_date):
+        for entry in self._get_session_counts(self.end_date):
             _id = entry['_id']
             report_entries[_id['project']]['session_count'] = entry['count']
 
@@ -134,7 +196,7 @@ class UsageReport(Report):
         skipped = 0
         for coll_name in FILE_COLLECTIONS:
             yield { 'status': 'Getting {} storage usage...'.format(coll_name) }
-            for entry in self._get_file_size_counts(coll_name, end_date):
+            for entry in self._get_file_size_counts(coll_name, self.end_date):
                 _id = entry['_id']
                 size = entry['bytes']
 
@@ -158,7 +220,7 @@ class UsageReport(Report):
 
         # Aggregate jobs counts run with execution time (in milliseconds) in timeframe
         yield { 'status': 'Getting compute usage...' }
-        for entry in self._get_job_stats(start_date, end_date):
+        for entry in self._get_job_stats(self.start_date, self.end_date):
             _id = entry['_id']
 
             project_rec = report_entries.get(_id['project'])
@@ -176,9 +238,9 @@ class UsageReport(Report):
         # Bulk updates
         update_count = 0
         record_count = len(report_entries)
-        year = self.date.year
-        month = self.date.month
-        day = str(self.date.day)
+        year = self.start_date.year
+        month = self.start_date.month
+        day = str(self.start_date.day)
         day_entry = 'days.{}'.format(day)
         bulk_updates = []
 
@@ -191,7 +253,7 @@ class UsageReport(Report):
                 }
 
             group = row.pop('group')
-            project = row.pop('project_id')
+            project = row.pop('project')
             project_label = row.pop('project_label')
 
             query = {
@@ -209,7 +271,7 @@ class UsageReport(Report):
                     '$set': {
                         'project_label': project_label,
                         day_entry: row,
-                        'total.sessions': row['session_count']
+                        'total.session_count': row['session_count']
                     },
                     '$inc': {
                         'total.days': 1,
@@ -232,19 +294,37 @@ class UsageReport(Report):
 
             if len(bulk_updates) >= BULK_UPDATE_BLOCK_SIZE:
                 # Do bulk update block
-                config.db.usage_data.bulk_write(bulk_updates, ordered=False)
+                self._batch_insert(bulk_updates)
                 bulk_updates = []
 
             update_count += 1
 
         # Send final bulk update
-        if bulk_updates:
-            config.db.usage_data.bulk_write(bulk_updates, ordered=False)
+        self._batch_insert(bulk_updates)
 
         yield {'status': 'Complete'} 
 
-        # TODO: Set metric for last successful usage collection date
-        # TODO: Set metric counter for usage collection failure
+    @staticmethod
+    def _batch_insert(updates):
+        if not updates:
+            return
+
+        conflicts = 0
+
+        try:
+            config.db.usage_data.bulk_write(updates, ordered=False)
+        except BulkWriteError as e:
+            for err in e.details.get('writeErrors', []) + e.details.get('writeConcernErrors', []):
+                code = err.get('code', 0)
+                if code == 11000:
+                    conflicts += 1
+                else:
+                    config.log.error('usage-report collection insertion error: %d - %s',
+                        code, err.get('errmsg', 'UNKNOWN ERROR'))
+
+        if conflicts:
+            config.log.warning('usage-report - %d entries not created due to conflicts', conflicts)
+
 
     def _is_center_gear(self, key): # pylint: disable=unused-argument
         """Check if the given key is a center gear. 
@@ -345,7 +425,7 @@ class UsageReport(Report):
     def _default_record(group, project_id, project_label):
         return {
             'group': group,
-            'project_id': project_id,
+            'project': project_id,
             'project_label': project_label,
             'session_count': 0,
             'center_job_count': 0,
@@ -356,4 +436,22 @@ class UsageReport(Report):
             'group_compute_ms': 0,
         }
 
+    @staticmethod
+    def _sum_records(src, dst):
+        dst['center_job_count'] += src['center_job_count']
+        dst['group_job_count'] += src['group_job_count']
+        dst['center_storage_bytes'] += src['center_storage_bytes']
+        dst['group_storage_bytes'] += src['group_storage_bytes']
+        dst['center_compute_ms'] += src['center_compute_ms']
+        dst['group_compute_ms'] += src['group_compute_ms']
+        dst['session_count'] += src['session_count']
+        dst['days'] = max(src.get('days', 0), dst.get('days', 0))
+
+    @staticmethod
+    def _total_record(record):
+        record['center_storage_byte_day'] = record.pop('center_storage_bytes')
+        record['group_storage_byte_day'] = record.pop('group_storage_bytes')
+        record['total_job_count'] = record['center_job_count'] + record['group_job_count']
+        record['total_storage_byte_day'] = record['center_storage_byte_day'] + record['group_storage_byte_day']
+        record['total_compute_ms'] = record['center_compute_ms'] + record['group_compute_ms']
 

--- a/api/reports/usage_report.py
+++ b/api/reports/usage_report.py
@@ -437,10 +437,20 @@ class UsageReport(Report):
 
         pipeline = [
             {'$match': match},
+            {'$project': {
+                'parents': '$parents',
+                'gear_info': '$gear_info',
+                'total_time_ms': {
+                    '$multiply': [
+                        '$profile.total_time_ms',
+                        {'$ifNull': [ '$profile.executor.cpu_cores', 1]}
+                    ]
+                }
+            }},
             {'$group': {
                 '_id': {'project': '$parents.project', 'gear_name': '$gear_info.name', 'gear_version': '$gear_info.version'},
                 'count': {'$sum': 1},
-                'total_ms': {'$sum': '$profile.total_time_ms'},
+                'total_ms': {'$sum': '$total_time_ms'},
             }}
         ]
 

--- a/api/reports/usage_report.py
+++ b/api/reports/usage_report.py
@@ -40,8 +40,8 @@ class UsageReport(Report):
             group_job_count: The number of jobs ran attributed to the group
             center_storage_bytes: The size of storage usage allocated to the center, in byte-days
             group_storage_bytes: The size of storage usage allocated to the group, in byte-days
-            center_compute_ms: The amount of compute used attributed to the center, in seconds
-            group_compute_ms: The amount of compute used attributed to the group, in seconds
+            center_compute_ms: The amount of compute used attributed to the center, in milliseconds
+            group_compute_ms: The amount of compute used attributed to the group, in milliseconds
         total: A usage total (to-date), same format as the day record, with additional:
             days: The number of days collated for this month
 
@@ -164,14 +164,20 @@ class UsageReport(Report):
     def before_collect(self):
         # Set start and end dates. Jobs that completed between start & end will be included
         # Files and sessions created before end will be included
+        now = datetime.datetime.now()
+        today = datetime.datetime(year=now.year, month=now.month, day=now.day)
+
         try:
             if self.year or self.month or self.day:
                 self.start_date = datetime.datetime(year=self.year, month=self.month, day=self.day)
             else:
-                now = datetime.datetime.now()
-                self.start_date = datetime.datetime(year=now.year, month=now.month, day=now.day) -  datetime.timedelta(days=1)
+                self.start_date = today - datetime.timedelta(days=1)
         except (TypeError, ValueError) as e:
-            raise APIReportParamsException('Invalid date specified: {}'.format(e))
+            raise APIReportParamsException('Invalid date specified - specify year, month and day, or nothing: {}'.format(e))
+
+        # Verify that start date is before today
+        if self.start_date >= today:
+            raise APIReportParamsException('Invalid date specified, must specify a date in the past')
 
         self.end_date = self.start_date + datetime.timedelta(days=1)
 

--- a/swagger/paths/report.yaml
+++ b/swagger/paths/report.yaml
@@ -89,10 +89,98 @@
         schema:
           $ref: schemas/output/report-access-type-list.json
 
+/report/usage/collect:
+  get:
+    summary: Collect daily usage statistics.
+    description: Collects usage statistics for the selected day (or yesterday if no day is given)
+    operationId: collect_usage
+    tags:
+    - 'reports'
+    parameters:
+      - in: query
+        type: integer
+        name: year
+        description: The year portion of the date
+      - in: query
+        type: integer
+        name: month
+        description: The month portion of the date
+      - in: query
+        type: integer
+        name: day
+        description: The day portion of the date
+    produces:
+      - text/event-stream
+    responses:
+      '200':
+        description: ''
+
 /report/usage:
   get:
-    summary: Get a usage report for the site grouped by month or project
+    summary: Get a usage report for the given month.
+    description: If no year/month pair is given, the current month will be used.
     operationId: get_usage_report
+    tags:
+    - 'reports'
+    parameters:
+      - in: query
+        type: integer
+        name: year
+        description: The year portion of the date
+      - in: query
+        type: integer
+        name: month
+        description: The month portion of the date
+      - in: query
+        type: boolean
+        name: csv
+        description: Download the report as a CSV file
+    responses:
+      '200':
+        description: Returns the usage report
+        schema:
+          $ref: schemas/output/report-usage.json
+
+/report/daily-usage:
+  get:
+    summary: Get a daily usage report for the given month.
+    description: If no year/month pair is given, the current month will be used.
+    operationId: get_daily_usage_report
+    tags:
+    - 'reports'
+    parameters:
+      - in: query
+        type: integer
+        name: year
+        description: The year portion of the date
+      - in: query
+        type: integer
+        name: month
+        description: The month portion of the date
+      - in: query
+        type: string
+        name: group
+        description: Limit the report to the given group id
+      - in: query
+        type: string
+        name: project
+        description: Limit the report to the given project id
+      - in: query
+        type: boolean
+        name: csv
+        description: Download the report as a CSV file
+    responses:
+      '200':
+        description: Returns the usage report
+        schema:
+          $ref: schemas/output/report-daily-usage.json
+
+
+/report/legacy-usage:
+  get:
+    summary: Get a usage report for the site grouped by month or project
+    description: This report is DEPRECATED and will be removed in a future release
+    operationId: get_legacy_usage_report
     tags:
     - 'reports'
     parameters:
@@ -116,5 +204,5 @@
       '200':
         description: Returns the usage report
         schema:
-          $ref: schemas/output/report-usage.json
+          $ref: schemas/output/report-legacy-usage.json
 

--- a/swagger/paths/report.yaml
+++ b/swagger/paths/report.yaml
@@ -115,6 +115,18 @@
       '200':
         description: ''
 
+/report/usage/availability:
+  get:
+    summary: Get year/month combinations where report data is available.
+    operationId: get_usage_availability
+    tags:
+    - 'reports'
+    responses:
+      '200':
+        description: Returns the list of months where report data is available
+        schema:
+          $ref: schemas/output/report-availability-list.json
+
 /report/usage:
   get:
     summary: Get a usage report for the given month.

--- a/swagger/schemas/definitions/report.json
+++ b/swagger/schemas/definitions/report.json
@@ -84,7 +84,7 @@
                 "session_count":{"type":"integer"}
             },
             "additionalProperties":false,
-            "required":["project_count", "label", "session_count"]            
+            "required":["project_count", "label", "session_count"]
         },
 
         "report-project": {
@@ -94,7 +94,7 @@
                     "type":"array",
                     "items":{"$ref":"#/definitions/demographics-grid"}
                 }
-            }            
+            }
         },
         "report-site": {
             "type":"object",
@@ -106,7 +106,7 @@
                 }
             },
             "additionalProperties":false,
-            "required":["group_count", "groups"]            
+            "required":["group_count", "groups"]
         },
         "report-access-type": {
             "type": "string",
@@ -185,7 +185,7 @@
             },
             "required": ["_id"],
             "description": "The project that this entry reports on"
-        },        
+        },
         "report-legacy-usage-entry": {
             "type": "object",
             "properties": {
@@ -337,6 +337,25 @@
                 "center_storage_bytes", "group_storage_bytes"
             ],
             "description": "An entry in the usage report, describing storage and gear usage by group"
+        },
+        "report-time-period": {
+            "type": "object",
+            "properties": {
+                "year": {
+                    "type": "integer",
+                    "description": "The year that this report row represents"
+                },
+                "month": {
+                    "type": "integer",
+                    "description": "The month that this report row represents"
+                },
+                "day": {
+                    "type": "integer",
+                    "description": "The day that this report row represents"
+                }
+            },
+            "required": ["year", "month"],
+            "description": "Represents a time-period where report data is available"
         }
     }
 }

--- a/swagger/schemas/definitions/report.json
+++ b/swagger/schemas/definitions/report.json
@@ -177,7 +177,7 @@
             },
             "description": "A single entry in the access log report"
         },
-        "report-usage-project-entry": {
+        "report-legacy-usage-project-entry": {
             "type": "object",
             "properties": {
                 "_id": {"$ref":"container.json#/definitions/_id"},
@@ -186,7 +186,7 @@
             "required": ["_id"],
             "description": "The project that this entry reports on"
         },        
-        "report-usage-entry": {
+        "report-legacy-usage-entry": {
             "type": "object",
             "properties": {
                 "file_mbs": {
@@ -210,11 +210,133 @@
                     "description": "The month portion of the entry date"
                 },
                 "project": {
-                    "$ref": "#/definitions/report-usage-project-entry"
+                    "$ref": "#/definitions/report-legacy-usage-project-entry"
                 }
             },
             "required": ["file_mbs", "gear_execution_count", "session_count"],
             "description": "An entry in the usage report, describing storage and gear usage"
+        },
+        "report-usage-entry": {
+            "type": "object",
+            "properties": {
+                "group": {"$ref": "group.json#/definitions/label"},
+                "project": {
+                    "type": ["string", "null"],
+                    "description": "The project id, or null if this is a group summary row"
+                },
+                "project_label": {
+                    "type": ["string", "null"],
+                    "description": "The project label, or null if this is a group summary row"
+                },
+                "session_count": {
+                    "type": "integer",
+                    "description": "The number of sessions that existed at the last collection time"
+                },
+                "center_job_count": {
+                    "type": "integer",
+                    "description": "The number of jobs that completed during the time frame that are billable to the center"
+                },
+                "group_job_count": {
+                    "type": "integer",
+                    "description": "The number of jobs that completed during the time frame that are billable to the group"
+                },
+                "total_job_count": {
+                    "type": "integer",
+                    "description": "The total number of jobs completed during the time frame"
+                },
+                "center_compute_ms": {
+                    "type": "integer",
+                    "description": "The compute time of jobs completed during the time frame, billable to the center"
+                },
+                "group_compute_ms": {
+                    "type": "integer",
+                    "description": "The compute time of jobs completed during the time frame, billable to the group"
+                },
+                "total_compute_ms": {
+                    "type": "integer",
+                    "description": "The total compute time of jobs completed during the time frame"
+                },
+                "center_storage_byte_day": {
+                    "type": "integer",
+                    "description": "The total storage used, in byte-days, billable to the center"
+                },
+                "group_storage_byte_day": {
+                    "type": "integer",
+                    "description": "The total storage used, in byte-days, billable to the group"
+                },
+                "total_storage_byte_day": {
+                    "type": "integer",
+                    "description": "The total storage used, in byte-days"
+                },
+                "days": {
+                    "type": "integer",
+                    "description": "The number of days collected in this report"
+                }
+            },
+            "required": [
+                "group", "project", "project_label", "session_count",
+                "center_job_count", "group_job_count", "total_job_count",
+                "center_compute_ms", "group_compute_ms", "total_compute_ms",
+                "center_storage_byte_day", "group_storage_byte_day", "total_storage_byte_day",
+                "days"
+            ],
+            "description": "An entry in the usage report, describing storage and gear usage by group and project"
+        },
+        "report-daily-usage-entry": {
+            "type": "object",
+            "properties": {
+                "year": {
+                    "type": "integer",
+                    "description": "The year that this report row represents"
+                },
+                "month": {
+                    "type": "integer",
+                    "description": "The month that this report row represents"
+                },
+                "day": {
+                    "type": "integer",
+                    "description": "The day that this report row represents"
+                },
+                "group": {"$ref": "group.json#/definitions/label"},
+                "project": {"$ref":"container.json#/definitions/_id"},
+                "project_label": {"$ref": "common.json#/definitions/label"},
+                "session_count": {
+                    "type": "integer",
+                    "description": "The number of sessions that existed at the last collection time"
+                },
+                "center_job_count": {
+                    "type": "integer",
+                    "description": "The number of jobs that completed during the time frame that are billable to the center"
+                },
+                "group_job_count": {
+                    "type": "integer",
+                    "description": "The number of jobs that completed during the time frame that are billable to the group"
+                },
+                "center_compute_ms": {
+                    "type": "integer",
+                    "description": "The compute time of jobs completed during the time frame, billable to the center"
+                },
+                "group_compute_ms": {
+                    "type": "integer",
+                    "description": "The compute time of jobs completed during the time frame, billable to the group"
+                },
+                "center_storage_bytes": {
+                    "type": "integer",
+                    "description": "The total storage used on this day, billable to the center"
+                },
+                "group_storage_bytes": {
+                    "type": "integer",
+                    "description": "The total storage used on this day, billable to the group"
+                }
+            },
+            "required": [
+                "year", "month", "day", "group", "project",
+                "project_label", "session_count",
+                "center_job_count", "group_job_count",
+                "center_compute_ms", "group_compute_ms",
+                "center_storage_bytes", "group_storage_bytes"
+            ],
+            "description": "An entry in the usage report, describing storage and gear usage by group"
         }
     }
 }

--- a/swagger/schemas/output/report-availability-list.json
+++ b/swagger/schemas/output/report-availability-list.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type":"array",
+    "items":{
+        "allOf":[{"$ref":"../definitions/report.json#/definitions/report-time-period"}]
+    },
+    "example": [
+        { "year" : 2019, "month" : 1 },
+        { "year" : 2018, "month" : 12 },
+        { "year" : 2018, "month" : 11 },
+        { "year" : 2018, "month" : 10 }
+    ]
+}

--- a/swagger/schemas/output/report-daily-usage.json
+++ b/swagger/schemas/output/report-daily-usage.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "array",
+    "items": {"$ref":"../definitions/report.json#/definitions/report-daily-usage-entry"},
+    "example": [
+        {
+            "project_label": "usage-test",
+            "group_compute_ms": 0,
+            "group": "group1",
+            "session_count": 0,
+            "center_job_count": 0,
+            "project": "5c102a404026b30019f9fc60",
+            "group_job_count": 0,
+            "center_storage_bytes": 0,
+            "year": 2018,
+            "month": 12,
+            "group_storage_bytes": 0,
+            "center_compute_ms": 0,
+            "day": 10
+        },
+        {
+            "project_label": "usage-test",
+            "group_compute_ms": 1800000,
+            "group": "group1",
+            "session_count": 1,
+            "center_job_count": 0,
+            "project": "5c102a404026b30019f9fc60",
+            "group_job_count": 1,
+            "center_storage_bytes": 0,
+            "year": 2018,
+            "month": 12,
+            "group_storage_bytes": 2048,
+            "center_compute_ms": 0,
+            "day": 11
+        }
+    ]
+}

--- a/swagger/schemas/output/report-legacy-usage.json
+++ b/swagger/schemas/output/report-legacy-usage.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "array",
+    "items": {"$ref":"../definitions/report.json#/definitions/report-legacy-usage-entry"},
+    "example": [{
+        "project": {
+            "_id": "576be50c59b2b6346719ee4d",
+            "label": "Anxiety Study"
+        },
+        "file_mbs": 3722.1714448928833,
+        "session_count": 9,
+        "gear_execution_count": 708
+    }]
+}
+
+

--- a/swagger/schemas/output/report-usage.json
+++ b/swagger/schemas/output/report-usage.json
@@ -2,15 +2,38 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "array",
     "items": {"$ref":"../definitions/report.json#/definitions/report-usage-entry"},
-    "example": [{
-        "project": {
-            "_id": "576be50c59b2b6346719ee4d",
-            "label": "Anxiety Study"
+    "example": [
+        {
+            "project_label": null,
+            "group_compute_ms": 3600000,
+            "days": 2,
+            "total_storage_byte_day": 46080,
+            "total_job_count": 4,
+            "total_compute_ms": 7200000,
+            "session_count": 5,
+            "center_compute_ms": 3600000,
+            "project": null,
+            "group_job_count": 2,
+            "center_storage_byte_day": 18432,
+            "group": "group1",
+            "center_job_count": 2,
+            "group_storage_byte_day": 27648
         },
-        "file_mbs": 3722.1714448928833,
-        "session_count": 9,
-        "gear_execution_count": 708
-    }]
+        {
+            "project_label": "usage-test",
+            "group_compute_ms": 3600000,
+            "group": "group1",
+            "total_job_count": 4,
+            "center_compute_ms": 3600000,
+            "total_compute_ms": 7200000,
+            "days": 2,
+            "center_job_count": 2,
+            "project": "5c102a424026b30019f9fc67",
+            "group_job_count": 2,
+            "center_storage_byte_day": 18432,
+            "session_count": 5,
+            "total_storage_byte_day": 46080,
+            "group_storage_byte_day": 27648
+        }
+    ]
 }
-
-

--- a/tests/integration_tests/python/test_billing_report.py
+++ b/tests/integration_tests/python/test_billing_report.py
@@ -1,0 +1,254 @@
+import bson
+import calendar
+import collections
+import datetime
+import json
+
+FILE_DATA = 'a' * 1024
+INPUT_FILE = ('input.txt', FILE_DATA)
+EXTRA_FILE = ('extra.txt', FILE_DATA)
+OUTPUT_FILE = ('output.txt', FILE_DATA)
+
+def test_collect_todays_usage(data_builder, file_form, as_user, as_admin, as_drone, api_db, default_payload):
+    group = data_builder.create_group()
+    project = data_builder.create_project(label='usage', group=group)
+    session = data_builder.create_session()
+    acquisition = data_builder.create_acquisition()
+    analysis = as_admin.post('/sessions/' + session + '/analyses', files=file_form(meta={'label': 'test'})).json()['_id']
+    as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form(INPUT_FILE))
+
+    gear_doc = default_payload['gear']['gear']
+    gear_doc['inputs'] = {
+        'usage': {
+            'base': 'file'
+        }
+    }
+    gear = data_builder.create_gear(gear=gear_doc)
+
+    job = data_builder.create_job(gear_id=gear, inputs={'usage': {'type': 'acquisition', 'id': acquisition, 'name': 'input.txt'}})
+    assert as_drone.get('/jobs/next', params={'root': 'true'}).ok
+    r = as_drone.post('/engine',
+        params={'root': 'true', 'level': 'analysis', 'id': analysis, 'job': job},
+        files=file_form(OUTPUT_FILE, meta={'type': 'text', 'value': {'label': 'test'}})
+    )
+    assert r.ok
+    assert as_drone.put('/jobs/' + job, params={'root': 'true'}, json={'state': 'complete'}).ok
+
+    # Set execution time for job (30 minutes)
+    result = api_db.jobs.update({'_id': bson.ObjectId(job)}, {'$set': {'profile.total_time_ms': 30 * 60 * 1000}})
+
+    # Run default collection
+    now = datetime.datetime.now()
+    r = as_admin.get('/report/usage/collect', stream=True)
+
+    status = []
+    for line in r.iter_lines():
+        if line.strip().startswith('data: '):
+            status.append(json.loads(line.strip()[6:]))
+
+    assert r.ok
+    assert status[-1]['status'] == 'Complete'
+
+    # Verify collection of "today's" record
+    record = api_db.usage_data.find_one({'group': group, 'project': bson.ObjectId(project), 'year': now.year, 'month': now.month})
+    assert record
+
+    day = str(now.day)
+    assert day in record['days']
+
+    assert record['project_label'] == 'usage'
+    assert record['days'][day]['center_compute_ms'] == 0
+    assert record['days'][day]['center_job_count'] == 0
+    assert record['days'][day]['center_storage_bytes'] == 0
+    assert record['days'][day]['group_compute_ms'] == 30 * 60 * 1000
+    assert record['days'][day]['group_job_count'] == 1
+    assert record['days'][day]['group_storage_bytes'] == 2 * len(FILE_DATA)
+    assert record['days'][day]['session_count'] == 1
+    assert record['total']['center_compute_ms'] == 0
+    assert record['total']['center_job_count'] == 0
+    assert record['total']['center_storage_bytes'] == 0
+    assert record['total']['group_compute_ms'] == 30 * 60 * 1000
+    assert record['total']['group_job_count'] == 1
+    assert record['total']['group_storage_bytes'] == 2 * len(FILE_DATA)
+    assert record['total']['sessions'] == 1
+
+    # Verify that re-collection after creating new data in the day does not update
+    # (i.e. once a day has been collected, it's a no-op to collect that day again)
+
+    as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form(EXTRA_FILE))
+    r = as_admin.get('/report/usage/collect')
+    assert r.ok
+
+    record2 = api_db.usage_data.find_one({'group': group, 'project': bson.ObjectId(project), 'year': now.year, 'month': now.month})
+    assert record == record2
+
+def test_usage_report(data_builder, file_form, as_user, as_admin, as_drone, api_db, default_payload):
+    # Test multiple days that cross a monthly boundary
+    # Test center vs group gears
+    # Test reaper vs analysis vs uploaded data
+    group = data_builder.create_group()
+    project = data_builder.create_project(label='usage', group=group)
+
+    gear_doc = default_payload['gear']['gear']
+    gear_doc['inputs'] = {
+        'usage': {
+            'base': 'file'
+        }
+    }
+    group_gear = data_builder.create_gear(gear=gear_doc)
+
+    gear_doc['name'] = 'usage-report-center-gear'
+    center_gear = data_builder.create_gear(gear=gear_doc)
+
+    previous_site = api_db.singletons.find_one_and_update({'_id': 'site'}, {'$set': {'center_gears': ['usage-report-center-gear']}}, upsert=True)
+
+    try:
+        def populate_day(year, month, day):
+            dt = datetime.datetime.now().replace(year=year, month=month, day=day)
+
+            def update_created(ctype, cid, files=0):
+                update = {'$set': {'created': dt}}
+                for i in range(files):
+                    update['$set']['files.{}.created'.format(i)] = dt
+
+                api_db[ctype].update({'_id': bson.ObjectId(cid)}, update)
+
+            def update_job(job_id):
+                # Fake some numbers
+                update = {'$set': {
+                    'created': dt,
+                    'modified': dt,
+                    'profile.total_time_ms': 30 * 60 * 1000,
+                    'transitions.running': dt,
+                    'transitions.complete': dt
+                }}
+                api_db.jobs.update_one({'_id': bson.ObjectId(job_id)}, update)
+
+            # Add session
+            session = data_builder.create_session(project=project)
+            as_admin.post('/sessions/' + session + '/files', files=file_form(INPUT_FILE))
+
+            # Add acquisition
+            acquisition = data_builder.create_acquisition(session=session)
+            as_drone.post('/acquisitions/' + acquisition + '/files', files=file_form(INPUT_FILE))
+            as_admin.post('/acquisitions/' + acquisition + '/files', files=file_form(EXTRA_FILE))
+
+            # Run center-pays job
+            center_job = data_builder.create_job(gear_id=center_gear, inputs={'usage': {'type': 'acquisition', 'id': acquisition, 'name': 'input.txt'}})
+            assert as_drone.get('/jobs/next', params={'root': 'true'}).ok
+            r = as_drone.post('/engine',
+                params={'root': 'true', 'level': 'acquisition', 'id': acquisition, 'job': center_job},
+                files=file_form(OUTPUT_FILE, meta={'acquisition': {'files': [{'name': 'output.txt', 'type': 'text'}]}})
+            )
+            assert r.ok
+            assert as_drone.put('/jobs/' + center_job, params={'root': 'true'}, json={'state': 'complete'}).ok
+
+            r = as_admin.get('/acquisitions/' + acquisition)
+            assert r.ok
+            r_acq = r.json()
+            assert len(r_acq['files']) == 3
+
+            # Add analysis via job
+            analysis = as_admin.post('/sessions/' + session + '/analyses', files=file_form(meta={'label': 'test'})).json()['_id']
+
+            group_job = data_builder.create_job(gear_id=group_gear, inputs={'usage': {'type': 'acquisition', 'id': acquisition, 'name': 'input.txt'}})
+            assert as_drone.get('/jobs/next', params={'root': 'true'}).ok
+            r = as_drone.post('/engine',
+                params={'root': 'true', 'level': 'analysis', 'id': analysis, 'job': group_job},
+                files=file_form(OUTPUT_FILE, meta={'type': 'text', 'value': {'label': 'test'}})
+            )
+            assert r.ok
+            assert as_drone.put('/jobs/' + group_job, params={'root': 'true'}, json={'state': 'complete'}).ok
+
+            # Set execution time for job (30 minutes)
+            update_created('sessions', session, files=1)
+            update_created('acquisitions', acquisition, files=3)
+            update_created('analyses', analysis, files=1)
+            update_job(center_job)
+            update_job(group_job)
+
+            return {
+                'center_compute_ms': 30 * 60 * 1000,
+                'center_job_count': 1,
+                'center_storage_bytes': 2 * len(FILE_DATA),
+                'group_compute_ms': 30 * 60 * 1000,
+                'group_job_count': 1,
+                'group_storage_bytes': 3 * len(FILE_DATA),
+                'session_count': 1
+            }
+
+        expected = collections.OrderedDict()
+
+        # Ensure file_job_origin is empty before starting
+        api_db.file_job_origin.remove({})
+
+        previous_day = None
+        previous_month = None
+
+        # We're collecting over 5 days and verifying the collection records
+        for i in range(5):
+            year = 2018
+            day = 1 + ((28 + i) % 31)
+
+            if day < 25:
+                month = 11
+            else:
+                month = 10
+
+            # Generate data
+            day_stats = populate_day(year, month, day)
+
+            date_key = (year, month, day)
+            total_key = (year, month)
+
+            expected[date_key] = day_stats
+            total = expected.get(total_key)
+
+            if previous_day:
+                day_stats['center_storage_bytes'] += previous_day['center_storage_bytes']
+                day_stats['group_storage_bytes'] += previous_day['group_storage_bytes']
+                day_stats['session_count'] += previous_day['session_count']
+
+            if not previous_month:
+                previous_day = day_stats
+            elif previous_month != month:
+                previous_day = None
+
+            # Collect usage data
+            r = as_admin.get('/report/usage/collect?year={}&month={}&day={}'.format(year, month, day))
+            assert r.ok
+
+            if not total:
+                total = day_stats.copy()
+                total['days'] = 1
+                expected[total_key] = total
+            else:
+                total['center_compute_ms'] += day_stats['center_compute_ms']
+                total['group_compute_ms'] += day_stats['group_compute_ms']
+                total['center_job_count'] += day_stats['center_job_count']
+                total['group_job_count'] += day_stats['group_job_count']
+                total['center_storage_bytes'] += day_stats['center_storage_bytes']
+                total['group_storage_bytes'] += day_stats['group_storage_bytes']
+                total['session_count'] = day_stats['session_count']
+                total['days'] += 1
+
+            # Verify collection of "today's" record
+            record = api_db.usage_data.find_one({'group': group, 'project': bson.ObjectId(project), 'year': year, 'month': month})
+            assert record
+            assert record['days'].get(str(day)) == day_stats
+            total = total.copy()
+            total['sessions'] = total.pop('session_count')
+            assert record['total'] == total
+
+        # Now, build the usage report
+
+        # Then build the billing report
+
+
+    finally:
+        # Cleanup site
+        if previous_site is not None:
+            api_db.singletons.update({'_id': 'site'}, previous_site)
+        else:
+            api_db.singletons.remove({'_id': 'site'})
+

--- a/tests/integration_tests/python/test_reports.py
+++ b/tests/integration_tests/python/test_reports.py
@@ -234,21 +234,21 @@ def test_access_log_report(data_builder, with_user, as_user, as_admin):
 
 def test_usage_report(data_builder, file_form, as_user, as_admin, api_db):
     # try to get usage report as user
-    r = as_user.get('/report/usage', params={'type': 'month'})
+    r = as_user.get('/report/legacy-usage', params={'type': 'month'})
     assert r.status_code == 403
 
     # try to get usage report w/o type
-    r = as_admin.get('/report/usage')
+    r = as_admin.get('/report/legacy-usage')
     assert r.status_code == 400
 
     # try to get usage report w/ invalid date filter (end < start)
-    r = as_admin.get('/report/usage', params={
+    r = as_admin.get('/report/legacy-usage', params={
         'type': 'month', 'start_date': tomorrow_ts, 'end_date': yesterday_ts
     })
     assert r.status_code == 400
 
     # get month-aggregated usage report
-    r = as_admin.get('/report/usage', params={'type': 'month'})
+    r = as_admin.get('/report/legacy-usage', params={'type': 'month'})
     assert r.ok
     usage = r.json()
     assert len(usage) == 1
@@ -259,7 +259,7 @@ def test_usage_report(data_builder, file_form, as_user, as_admin, api_db):
     assert usage[0]['gear_execution_count'] == 0
 
     # get project-aggregated usage report
-    r = as_admin.get('/report/usage', params={'type': 'project'})
+    r = as_admin.get('/report/legacy-usage', params={'type': 'project'})
     assert r.ok
     assert len(r.json()) == 0
 
@@ -284,7 +284,7 @@ def test_usage_report(data_builder, file_form, as_user, as_admin, api_db):
     monthrange = calendar.monthrange(today.year, today.month)
     start_ts = ts_format.format(today.replace(day=1))
     end_ts = ts_format.format(today.replace(day=monthrange[1], hour=23, minute=59, second=59))
-    r = as_admin.get('/report/usage', params={
+    r = as_admin.get('/report/legacy-usage', params={
         'type': 'month', 'start_date': start_ts, 'end_date': end_ts
     })
     assert r.ok
@@ -297,7 +297,7 @@ def test_usage_report(data_builder, file_form, as_user, as_admin, api_db):
     assert usage[0]['gear_execution_count'] == 1
 
     # get project-aggregated usage report
-    r = as_admin.get('/report/usage', params={
+    r = as_admin.get('/report/legacy-usage', params={
         'type': 'project', 'start_date': yesterday_ts, 'end_date': tomorrow_ts
     })
     assert r.ok
@@ -314,14 +314,14 @@ def test_usage_report(data_builder, file_form, as_user, as_admin, api_db):
     project2 = r.json()['_id']
 
     # get project-aggregated usage report
-    r = as_admin.get('/report/usage', params={'type': 'project'})
+    r = as_admin.get('/report/legacy-usage', params={'type': 'project'})
     assert r.ok
 
     # Test that deleted files are not counted
     assert as_admin.post('/projects/' + project2 + '/files', files=file_form('project.csv')).ok
     assert as_admin.delete('/projects/' + project2 + '/files/' + 'project.csv').ok
 
-    r = as_admin.get('/report/usage', params={
+    r = as_admin.get('/report/legacy-usage', params={
         'type': 'project', 'start_date': yesterday_ts, 'end_date': tomorrow_ts
     })
     assert r.ok

--- a/tests/integration_tests/python/test_usage_report.py
+++ b/tests/integration_tests/python/test_usage_report.py
@@ -395,6 +395,15 @@ def test_usage_report(data_builder, file_form, as_user, as_admin, as_drone, api_
             assert record['days'].get(str(day)) == day_stats
             assert record['total'] == total
 
+        # Check report availability
+        r = as_admin.get('/report/usage/availability')
+        assert r.ok
+        availability = r.json()
+
+        assert len(availability) >= 2
+        assert {'year': 2018, 'month': 10} in availability
+        assert {'year': 2018, 'month': 11} in availability
+
         # Run the usage report for both months
         for month in [10, 11]:
             r = as_admin.get('/report/usage?year={}&month={}'.format(year, month))


### PR DESCRIPTION
## Deprecation
The old usage report endpoint has been moved to `/api/report/legacy-usage`

## Summary
In the new reports, storage usage is tracked as byte-days. (e.g. if a 1-byte file is stored on flywheel for three days, that would be 3 byte-days of storage, as would a 3-byte file stored for one day)
In addition, compute time and storage is divided into center and storage values. 
Center-pays compute is any job in the white list of gears below.
Center-pays storage is any file created by device, or as an output of one of the center-pays gears.
Everything else is treated as group-pays.

## Collection
Adds a new collection endpoint for usage report, intended to be called nightly by the cron container, at `/api/report/usage/collect`. Daily usage data is stored in the `usage_data` collection, indexed by year, month, group and project_id for fast aggregation. By default, the collect endpoint will collect yesterday's usage data. This can be overridden by supplying `year`, `month` and `day` query parameters. If an attempt is made to collect usage data where a record for that day already exists, then no record update will occur.
Two new metrics have been added to track usage collection:

- `fw_last_report_collection` indicates when the usage data was last collected successfully.
- `fw_report_collection_errors` is a counter that increases whenever a usage collection error occurs.

## Reporting
There are two new report endpoints. Both endpoints will report on a single month at a time, selected via `year` and `month` query parameters. Both endpoints support CSV download by passing the `csv=true` query parameter.
- `/api/report/usage` provides monthly summaries of usage by group and project. 
- `/api/report/daily-usage` provides detailed daily summaries of usage by group and project.

## Center-Pays Gear List
The center-pays gear list can be defined directly in the database by creating a `site` singleton, where `center_gears` is an array of algorithm names. If not set, then the default list will be `dcm2niix`, `dicom-mr-classifier` and `mriqc` for this PR.

An additional PR [has been](https://github.com/flywheel-io/core/pull/1476) drafted that supports setting these values via `/api/site/settings` endpoint.

## Utility Collection
A utility collection named `file_job_origin` has been created to facilitate joins between files and jobs, in order to determine which gear created the file. This collection is updated as part of the `collect` endpoint, prior to collecting that day's usage statistics.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
