### PR TITLE
Critical data logging

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -5,3 +5,4 @@
 - Tests were added to cover all code changes
 - Documentation was added / updated
 - Code and tests follow standards in CONTRIBUTING.md
+- Extra care is taken and log messages are created for [Critical Data](https://github.com/flywheel-io/core/wiki/Critical-Data-Flows)

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -91,6 +91,7 @@ class Queue(object):
 
             # Set transition timestamp
             mutation['transitions.{}'.format(mutation['state'])] = now
+            log.info('Transitioning job %s from %s to %s', job.id_, job.state, mutation['state'])
 
         # Any modification must be a timestamp update
         mutation['modified'] = now
@@ -352,7 +353,7 @@ class Queue(object):
         if gear_name not in tags:
             tags.append(gear_name)
 
-        job = Job(gear, inputs, destination=destination, tags=tags, config_=config_, attempt=attempt_n, 
+        job = Job(gear, inputs, destination=destination, tags=tags, config_=config_, attempt=attempt_n,
             previous_job_id=previous_job_id, origin=origin, batch=batch, parents=parents, profile=profile,
             related_container_ids=list(related_containers))
 

--- a/api/jobs/rules.py
+++ b/api/jobs/rules.py
@@ -254,24 +254,32 @@ def create_jobs(db, container_before, container_after, container_type, replaced_
     # Using a uniqueness constraint, create a list of the set difference of jobs_after \ jobs_before
     # (members of jobs_after that are not in jobs_before)
     for ja in jobs_after:
+        replaced_file_name = ''
 
         replaced_file_in_job_inputs = False
         list_of_inputs = [i for i in ja['job'].inputs.itervalues()]
-        for rf in replaced_files:
-            if rf in list_of_inputs:
+        for replaced_file in replaced_files:
+            if replaced_file in list_of_inputs:
+                replaced_file_name = replaced_file.name
                 replaced_file_in_job_inputs = True
                 break
 
         if replaced_file_in_job_inputs:
             # one of the replaced files is an input
+            log.info('Scheduling job for %s=%s via rule=<%s>, replaced_file=<%s>.',
+                container_type, container_before['_id'], ja['rule'].get('name'), replaced_file_name)
             potential_jobs.append(ja)
         else:
             should_enqueue_job = True
             for jb in jobs_before:
                 if ja['job'].intention_equals(jb['job']):
+                    log.info('Ignoring rule: <%s> for %s=%s - Job has already been queued!',
+                        ja['rule'].get('name'), container_type, container_before['_id'])
                     should_enqueue_job = False
                     break # this job matched in both before and after, ignore
             if should_enqueue_job:
+                log.info('Scheduling job for %s=%s via rule=<%s>.',
+                    container_type, container_before['_id'], ja['rule'].get('name'))
                 potential_jobs.append(ja)
 
 

--- a/api/placer.py
+++ b/api/placer.py
@@ -25,7 +25,7 @@ class Placer(object):
     Interface for a placer, which knows how to process files and place them where they belong - on disk and database.
     """
 
-    def __init__(self, container_type, container, id_, metadata, timestamp, origin, context, file_processor, access_logger):
+    def __init__(self, container_type, container, id_, metadata, timestamp, origin, context, file_processor, access_logger, logger=config.log):
         self.container_type = container_type
         self.container      = container
         self.id_            = id_
@@ -51,6 +51,9 @@ class Placer(object):
 
         # A list of files that have been ignored by save_file() because a file with the same name and hash already existed
         self.ignored        = []
+
+        # Context logger
+        self.logger         = logger
 
 
     def check(self):
@@ -99,7 +102,8 @@ class Placer(object):
         # Update the DB
         if file_attrs is not None:
 
-            container_before, self.container, saved_state = hierarchy.upsert_fileinfo(self.container_type, self.id_, file_attrs, self.access_logger, ignore_hash_replace=ignore_hash_replace)
+            container_before, self.container, saved_state = hierarchy.upsert_fileinfo(self.container_type, self.id_, file_attrs, self.access_logger,
+                ignore_hash_replace=ignore_hash_replace, logger=self.logger)
 
             # If this file was ignored because an existing file with the same name and hash existed on this project,
             # add the file to the ignored list and move on
@@ -190,8 +194,8 @@ class UIDPlacer(Placer):
     ignore_hash_replace = False
 
 
-    def __init__(self, container_type, container, id_, metadata, timestamp, origin, context, file_processor, access_logger):
-        super(UIDPlacer, self).__init__(container_type, container, id_, metadata, timestamp, origin, context, file_processor, access_logger)
+    def __init__(self, container_type, container, id_, metadata, timestamp, origin, context, file_processor, access_logger, logger=config.log):
+        super(UIDPlacer, self).__init__(container_type, container, id_, metadata, timestamp, origin, context, file_processor, access_logger, logger=logger)
         self.metadata_for_file = {}
         self.session_id = None
         self.count = 0
@@ -407,8 +411,8 @@ class TokenPlacer(Placer):
     Intended for use with a token that tracks where the files will be stored.
     """
 
-    def __init__(self, container_type, container, id_, metadata, timestamp, origin, context, file_processor, access_logger):
-        super(TokenPlacer, self).__init__(container_type, container, id_, metadata, timestamp, origin, context, file_processor, access_logger)
+    def __init__(self, container_type, container, id_, metadata, timestamp, origin, context, file_processor, access_logger, logger=config.log):
+        super(TokenPlacer, self).__init__(container_type, container, id_, metadata, timestamp, origin, context, file_processor, access_logger, logger=logger)
 
         self.paths  =   []
         self.folder =   None
@@ -446,8 +450,8 @@ class PackfilePlacer(Placer):
     A placer that can accept N files, save them into a zip archive, and place the result on an acquisition.
     """
 
-    def __init__(self, container_type, container, id_, metadata, timestamp, origin, context, file_processor, access_logger):
-        super(PackfilePlacer, self).__init__(container_type, container, id_, metadata, timestamp, origin, context, file_processor, access_logger)
+    def __init__(self, container_type, container, id_, metadata, timestamp, origin, context, file_processor, access_logger, logger=config.log):
+        super(PackfilePlacer, self).__init__(container_type, container, id_, metadata, timestamp, origin, context, file_processor, access_logger, logger=logger)
 
         # This endpoint is an SSE endpoint
         self.sse            = True

--- a/api/upload.py
+++ b/api/upload.py
@@ -108,7 +108,7 @@ def process_upload(request, strategy, access_logger, container_type=None, id_=No
                     f['name'] = name_fn(f['name'])
 
     placer_class = strategy.value
-    placer = placer_class(container_type, container, id_, metadata, timestamp, origin, context, file_processor, access_logger)
+    placer = placer_class(container_type, container, id_, metadata, timestamp, origin, context, file_processor, access_logger, logger=log)
     placer.check()
 
     # Browsers, when sending a multipart upload, will send files with field name "file" (if sinuglar)


### PR DESCRIPTION
Added log messages to cover critical data paths, as documented [here](https://github.com/flywheel-io/core/wiki/Critical-Data-Flows).

Also updated the PR template (included in this PR)

Sample output for an engine run:
```
uwsgi_1           | 2018-12-18 15:59:51      scitran.api                  base.py    53:DEBU Initialized request request_id=4587e9fb-1545148791
uwsgi_1           | 2018-12-18 15:59:51      scitran.api                  base.py   455:DEBU from None POST /api/engine {u'job': u'5c1919711de0d9001409056c', u'id': u'5c19123c28f84b007d60abce', u'level': u'acquisition'} request_id=4587e9fb-1545148791 origin=job:5c1919711de0d9001409056c
uwsgi_1           | 2018-12-18 15:59:51      scitran.api                upload.py    64:DEBU process_upload request_id=4587e9fb-1545148791
uwsgi_1           | 2018-12-18 15:59:51      scitran.api             hierarchy.py   263:INFO File id=a8fa244d-76a2-43d9-9d52-5c86a3f68e84, name=<8892_5_1_inversion_recovery.nii.gz> replaced existing file (id=719d9bb2-8fdf-4214-b5e8-b6e1b7daf039) on acquisitions=5c19123c28f84b007d60abce request_id=4587e9fb-1545148791
uwsgi_1           | 2018-12-18 15:59:51      scitran.api                 rules.py   277:INFO Ignoring rule: <Run dcm2niix on dicom (dicoms containing images)> for acquisition=5c19123c28f84b007d60abce - Job has already been queued!
uwsgi_1           | 2018-12-18 15:59:51      scitran.api                 rules.py   277:INFO Ignoring rule: <Run dicom-mr-classifier on dicom> for acquisition=5c19123c28f84b007d60abce - Job has already been queued!
uwsgi_1           | 2018-12-18 15:59:51      scitran.api                  base.py    53:DEBU Initialized request request_id=df47cb98-1545148791
uwsgi_1           | 2018-12-18 15:59:51      scitran.api                  base.py   455:DEBU from None PUT /api/jobs/5c1919711de0d9001409056c {} request_id=df47cb98-1545148791 origin=device:5c191194eb84a24111990917
uwsgi_1           | 2018-12-18 15:59:51      scitran.api                 queue.py    94:INFO Transitioning job 5c1919711de0d9001409056c from running to complete
```

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
- Extra care is taken and log messages are created for [Critical Data](https://github.com/flywheel-io/core/wiki/Critical-Data-Flows)