### PR TITLE
Use a config variable when accessing UID key during SAML SSO

### DIFF
--- a/api/auth/authproviders.py
+++ b/api/auth/authproviders.py
@@ -364,8 +364,6 @@ class SAMLAuthProvider(AuthProvider):
         uid = None
         attributes = json.loads(r.content).get('attributes', [])
 
-        log.warning('The attributes are: \n\n{}\n\n'.format(attributes))
-
         for a in attributes:
             if a.get('name') == self.config['uid_key_name']:
                 values = a.get('values')

--- a/api/auth/authproviders.py
+++ b/api/auth/authproviders.py
@@ -364,8 +364,10 @@ class SAMLAuthProvider(AuthProvider):
         uid = None
         attributes = json.loads(r.content).get('attributes', [])
 
+        log.warning('The attributes are: \n\n{}\n\n'.format(attributes))
+
         for a in attributes:
-            if a.get('name') == 'mail':
+            if a.get('name') == self.config['uid_key_name']:
                 values = a.get('values')
                 uid = values[0] if values else None
 

--- a/tests/unit_tests/python/test_auth.py
+++ b/tests/unit_tests/python/test_auth.py
@@ -353,7 +353,8 @@ def test_saml_auth(config, as_drone, as_public, api_db):
         auth_endpoint='http://saml.test/secure/login/saml',
         verify_endpoint='http://saml.test/Shibboleth.sso/Session',
         refresh_rate=300,
-        display_string='SAML Auth')
+        display_string='SAML Auth',
+        uid_key_name='mail')
 
 
     uid = 'saml_uid@saml.test'


### PR DESCRIPTION
Each SAML IdP provides a different key that means "user email". Allow the key name to be stored on config. 


### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
