### PR TITLE
Update Travis Pipeline Logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
 before_install:
 - sudo apt-get update
 - sudo apt-get -y install docker-ce realpath
-- gem install travis -v 1.8.9 --no-rdoc --no-ri
+- gem install travis -v 1.8.9 --no-document
 - yes | docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASS
 
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ cache:
 before_install:
 - sudo apt-get update
 - sudo apt-get -y install docker-ce realpath
+- gem install travis -v 1.8.8 --no-rdoc --no-ri
 - yes | docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASS
 
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
 before_install:
 - sudo apt-get update
 - sudo apt-get -y install docker-ce realpath
-- gem install travis -v 1.8.8 --no-rdoc --no-ri
+- gem install travis -v 1.8.9 --no-rdoc --no-ri
 - yes | docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASS
 
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ cache:
 before_install:
 - sudo apt-get update
 - sudo apt-get -y install docker-ce realpath
-- gem install travis -v 1.8.8 --no-rdoc --no-ri
 - yes | docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASS
 
 install: true


### PR DESCRIPTION
It looks as though `gem` options `--no-rdoc` and  `--no-ri` have been beyond deprecated but are also causing errors within the `before_install` step. While troubleshooting this `gem` issue, I've also updated the version to latest stable 1.8.9.

Branch name was from the original summation that we could just drop the travis gem. Not so!