### PR TITLE
Add SDK methods and docs for accessing zip members

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -38,6 +38,8 @@ After running make.sh (above), tests can be run by invoking `sdk/scripts/docker-
 * **x-sdk-positional** - Normally arguments to matlab models are named parameters - this will make the defined parameter positional instead.
 * **x-sdk-download-ticket** - Special casing for downloads, will produce both a normal download operation, and a get download url operation. 
 		The value of this field is the name of the get download url operation.
+* **x-sdk-get-zip-info** - Special case for files, retrieves zip member information.
+        The value of this field is the name of the get zip info operation.
 * **x-sdk-download-url** - Will be set to the operationId for retrieving a download url via ticket.
 * **x-sdk-download-file-param** - Parameter name for destination file parameter for download operations.
 * **x-sdk-include-empty** - On a JSON definition - indicates that the following list of properties should be included on JSON even when empty.

--- a/sdk/codegen/src/main/java/io/flywheel/codegen/UpdateParameterOp.java
+++ b/sdk/codegen/src/main/java/io/flywheel/codegen/UpdateParameterOp.java
@@ -1,0 +1,7 @@
+package io.flywheel.codegen;
+
+import io.swagger.codegen.CodegenParameter;
+
+public interface UpdateParameterOp {
+    void update(CodegenParameter param);
+}

--- a/sdk/codegen/src/main/resources/fw-python/mixins.py
+++ b/sdk/codegen/src/main/resources/fw-python/mixins.py
@@ -261,6 +261,18 @@ class FileMethods(object):
         entry = self.get_file()
         return entry.ref() if entry else None
 
+    def get_file_zip_info(self, file_name):
+        """Get zip member information for this file"""
+        return self._invoke_container_api('get_{}_file_zip_info', self.id, file_name)
+
+    def download_file_zip_member(self, file_name, member_path, dest_file):
+        """Download file's zip member to the given path"""
+        return self._invoke_container_api('download_file_from_{}', self.id, file_name, dest_file, member=member_path)
+
+    def read_file_zip_member(self, file_name, member_path):
+        """Read contents of file's zip member"""
+        return self._invoke_container_api('download_file_from_{}_as_data', self.id, file_name, member=member_path)
+
 
 class TimestampMethods(object):
     @property
@@ -466,6 +478,18 @@ class FileMixin(ContainerBase):
         ref = self._parent.ref()
         ref['name'] = self.name
         return ref
+
+    def get_zip_info(self):
+        """Get zip member information for this file"""
+        return self._parent.get_file_zip_info(self.name)
+
+    def download_zip_member(self, member_path, dest_file):
+        """Download file's zip member to the given path"""
+        return self._parent.download_file_zip_member(self.name, member_path, dest_file)
+
+    def read_zip_member(self, member_path):
+        """Read contents of file's zip member"""
+        return self._parent.read_file_zip_member(self.name, member_path)
 
 
 class JobMixin(ContainerBase):

--- a/sdk/codegen/src/main/resources/matlab/mixins/FileMethods.mustache
+++ b/sdk/codegen/src/main/resources/matlab/mixins/FileMethods.mustache
@@ -81,5 +81,14 @@ classdef FileMethods < handle
         function [returnData, resp] = deleteFileClassification(obj, fileName, classification)
             [returnData, resp] = obj.invokeContainerApi('delete%sFileClassificationFields', obj.get('id'), fileName, classification);
         end
+        function [returnData, resp] = getFileZipInfo(obj, fileName)
+            [returnData, resp] = obj.invokeContainerApi('get%sFileZipInfo', obj.get('id'), fileName);
+        end
+        function [returnData, resp] = downloadFileZipMember(obj, fileName, memberPath, destFile, varargin)
+            [returnData, resp] = obj.invokeContainerApi('downloadFileFrom%s', obj.get('id'), fileName, destFile, 'member', memberPath, varargin{:});
+        end
+        function [returnData, resp] = readFileZipMember(obj, fileName, memberPath, varargin)
+            [returnData, resp] = obj.invokeContainerApi('downloadFileFrom%sAsData', obj.get('id'), fileName, 'member', memberPath, varargin{:});
+        end
     end
 end

--- a/sdk/codegen/src/main/resources/matlab/mixins/FileMixin.mustache
+++ b/sdk/codegen/src/main/resources/matlab/mixins/FileMixin.mustache
@@ -18,7 +18,7 @@ classdef FileMixin < {{packageName}}.mixins.ContainerBase
             resp = obj.parent_.downloadFile(obj.get('name'), destFile, varargin{:});
         end
         function resp = read(obj, varargin)
-            resp = obj.parent_.readFile(obj.get('name'));
+            resp = obj.parent_.readFile(obj.get('name'), varargin{:});
         end
         function resp = update(obj, varargin)
             resp = obj.parent_.updateFile(obj.get('name'), varargin{:});
@@ -46,6 +46,15 @@ classdef FileMixin < {{packageName}}.mixins.ContainerBase
                 'type', obj.parent_.containerType, ...
                 'id', obj.parent_.id, ...
                 'name', obj.name);
+        end
+        function resp = getZipInfo(obj)
+            resp = obj.parent_.getFileZipInfo(obj.get('name'));
+        end
+        function resp = downloadZipMember(obj, destFile, memberPath, varargin)
+            resp = obj.parent_.downloadFileZipMember(obj.get('name'), memberPath, destFile, varargin{:});
+        end
+        function resp = readZipMember(obj, memberPath, varargin)
+            resp = obj.parent_.readFileZipMember(obj.get('name'), memberPath, varargin{:});
         end
     end
 end

--- a/sdk/src/matlab/sphinx/src/getting_started.rst
+++ b/sdk/src/matlab/sphinx/src/getting_started.rst
@@ -228,6 +228,24 @@ Supported ``OutputType`` values are:
 	% Download file directly to memory as a char cell array
 	data = project.readFile('hello.txt', 'OutputType', 'char');
 
+Working with Zip Members
+++++++++++++++++++++++++
+Occasionally you may want to see the contents of a zip file, and possibly download a single member without downloading
+the entire zipfile. There are a few operations provided to enable this. For example:
+
+.. code-block:: matlab
+
+	% Get information about a zip file
+	zipInfo = acquisition.getZipInfo('my-archive.zip');
+
+	% Download the first zip entry to /tmp/{entry_name}
+	entryName = zipInfo.members{1}.path;
+	outPath = fullfile('/tmp', entryName);
+	acquisition.downloadFileZipMember('my-archive.zip', entryName, outPath);
+
+	% Read the "readme.txt" zip entry directly to memory
+	zipData = acquisition.readFileZipMember('my-archive.zip', 'readme.txt', 'OutputType', 'char');
+
 Handling Exceptions
 -------------------
 When an error is encountered while accessing an endpoint, an exception is thrown. The exception message 

--- a/sdk/src/python/sphinx/source/getting_started.rst
+++ b/sdk/src/python/sphinx/source/getting_started.rst
@@ -199,6 +199,25 @@ When downloading, you specify the destination file, or you can download directly
 	# Download file contents directly to memory
 	data = project.read_file('hello.txt')
 
+Working with Zip Members
+++++++++++++++++++++++++
+Occasionally you may want to see the contents of a zip file, and possibly download a single member without downloading
+the entire zipfile. There are a few operations provided to enable this. For example:
+
+.. code-block:: python
+
+	# Get information about a zip file
+	zip_info = acquisition.get_file_zip_info('my-archive.zip')
+
+	# Download the first zip entry to /tmp/{entry_name}
+	entry_name = zip_info.members[0].path
+	out_path = os.path.join('/tmp', entry_name)
+	acquisition.download_file_zip_member('my-archive.zip', entry_name, out_path)
+
+	# Read the "readme.txt" zip entry directly to memory
+	zip_data = acquisition.read_file_zip_member('my-archive.zip', 'readme.txt')
+
+
 Handling Exceptions
 -------------------
 When an error is encountered while accessing an endpoint, an :class:`flywheel.rest.ApiException` is thrown. 

--- a/sdk/src/python/tests/integration_tests/test_zip_member.py
+++ b/sdk/src/python/tests/integration_tests/test_zip_member.py
@@ -1,0 +1,63 @@
+import datetime
+import os
+import tempfile
+import unittest
+import zipfile
+
+from sdk_test_case import SdkTestCase
+from test_acquisition import create_test_acquisition
+
+import flywheel
+
+ENTRY_TEXT = 'Hello World!'
+ENTRY_SIZE = len(ENTRY_TEXT)
+ENTRY_TIMESTAMP = (2018, 10, 30, 2, 5, 10)
+
+class ZipMemberTestCases(SdkTestCase):
+    def setUp(self):
+        self.group_id, self.project_id, self.session_id, self.acquisition_id = create_test_acquisition()
+
+    def tearDown(self):
+        self.fw.delete_project(self.project_id)
+        self.fw.delete_group(self.group_id)
+
+        if self.zip_path:
+            os.remove(self.zip_path)
+
+    def test_zip_members(self):
+        fw = self.fw
+
+        # Create a zip file with comments
+        fd, self.zip_path = tempfile.mkstemp(suffix='.zip')
+        with os.fdopen(fd, 'wb') as f:
+            with zipfile.ZipFile(f, 'w') as zf:
+                zf.comment = b'This is a zipfile comment'
+
+                entry_info = zipfile.ZipInfo(filename='test-entry.txt', date_time=ENTRY_TIMESTAMP)
+                entry_info.comment = b'This is a zipinfo comment'
+                zf.writestr(entry_info, ENTRY_TEXT)
+
+        # Upload the file
+        filename = os.path.basename(self.zip_path)
+        fw.upload_file_to_acquisition(self.acquisition_id, self.zip_path)
+
+        # Get zip info
+        zip_info = fw.get_acquisition_file_zip_info(self.acquisition_id, filename)
+        self.assertEqual(zip_info.comment, 'This is a zipfile comment')
+        self.assertEqual(len(zip_info.members), 1)
+        zip_entry_info = zip_info.members[0]
+        self.assertEqual(zip_entry_info.path, 'test-entry.txt')
+        timestamp = zip_entry_info.timestamp.replace(tzinfo=None)
+        self.assertEqual(timestamp, datetime.datetime(*ENTRY_TIMESTAMP))
+        self.assertEqual(zip_entry_info.size, ENTRY_SIZE)
+        self.assertEqual(zip_entry_info.comment, 'This is a zipinfo comment')
+
+        # Download the zip member
+        data = fw.download_file_from_acquisition_as_data(self.acquisition_id, filename, member='test-entry.txt')
+        self.assertEqual(data, ENTRY_TEXT.encode('ascii'))
+
+        # Use helper mixin
+        acq = fw.get(self.acquisition_id)
+        zip_info2 = acq.get_file_zip_info(filename)
+        self.assertEqual(zip_info, zip_info2)
+

--- a/swagger/schemas/definitions/file.json
+++ b/swagger/schemas/definitions/file.json
@@ -64,6 +64,29 @@
           "type": "integer",
           "description": "Number of entries in the zip archive"
         },
+        "file-zip-entry": {
+          "type": "object",
+          "properties": {
+            "comment":   {"type": "string"},
+            "path":      {"type": "string"},
+            "timestamp": {"type": "string", "format": "date-time"},
+            "size":      {"$ref":"#/definitions/size"}
+          },
+          "description": "A zip member description",
+          "additionalProperties": false
+        },
+        "file-zip-info": {
+          "type": "object",
+          "properties": {
+            "comment": {"type": "string"},
+            "members": {
+              "type": "array",
+              "items": {"$ref":"#/definitions/file-zip-entry"}
+            }
+          },
+          "description": "Zip file information",
+          "additionalProperties": false
+        },
         "file-entry": {
           "type": "object",
           "properties": {

--- a/swagger/templates/file-item.yaml
+++ b/swagger/templates/file-item.yaml
@@ -56,6 +56,7 @@ template: |
         type: string
         description: The filename of a zipfile member to download rather than the entire file
     x-sdk-download-ticket: get_{{resource}}_download_ticket
+    x-sdk-get-zip-info: get_{{resource}}_file_zip_info
     responses:
       '200':
         description: ''


### PR DESCRIPTION
New SDK method added to get zip info, and helper functions added to the object model for getting zip info or retrieving an individual zip member.

[Getting Started Documentation](https://github.com/flywheel-io/core/compare/sdk-zip-member?expand=1#diff-ca255ab80827ae35ec6e0ea32b691152R202) has also been updated.

Closes #1461 

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
- Extra care is taken and log messages are created for [Critical Data](https://github.com/flywheel-io/core/wiki/Critical-Data-Flows)
