### PR TITLE
Accomodate dynamic type from urlparse().port

### DIFF
--- a/api/jobs/gears.py
+++ b/api/jobs/gears.py
@@ -233,14 +233,19 @@ def get_registry_connectivity():
     c = config.get_config()
     pw = c['core']['drone_secret']
     url =  urlparse(c['site']['redirect_url'])
-    host = url.hostname + ':' + str(url.port)
+
+    if url.port is None or url.port == 443:
+        host = url.hostname
+    else:
+        host = url.hostname + ':' + str(url.port)
+
     api_key = ''
     username = 'device.flywheel'
 
-    if url.port != 443:
-        api_key = url.hostname + ':' + str(url.port) + ':' + pw
-    else:
+    if url.port is None or url.port == 443:
         api_key = url.hostname + ':' + pw
+    else:
+        api_key = url.hostname + ':' + str(url.port) + ':' + pw
 
     return host, username, api_key
 

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -609,12 +609,12 @@ class JobHandler(base.RequestHandler):
                         else:
                             raise Exception('Cannot provide an API key to a job not launched by a user')
 
-                        parsed_url = urlparse(config.get_item('site', 'api_url'))
+                        url = urlparse(config.get_item('site', 'api_url'))
 
-                        if parsed_url.port != 443:
-                            api_key = parsed_url.hostname + ':' + str(parsed_url.port) + ':' + api_key
+                        if url.port is None or url.port == 443:
+                            api_key = url.hostname + ':' + api_key
                         else:
-                            api_key = parsed_url.hostname + ':' + api_key
+                            api_key = url.hostname + ':' + str(url.port) + ':' + api_key
 
                         if c.get('inputs') is None:
                             c['inputs'] = {}


### PR DESCRIPTION
When the return from `urlparse().port` would match what urlparse expects for `urlparse().scheme`, port will be of type `None` instead of type `int`. This gets stringified to `"None"` in some parts of our code, causing an error.

This change allows for `None` or `443`, essentially hiding the dynamic type behavior.