### PR TITLE
Make elapsed optional on job tickets

### DIFF
--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -883,11 +883,17 @@ class JobHandler(base.RequestHandler):
     def prepare_complete(self, _id):
         payload = self.request.json
         success = payload['success']
-        elapsed = payload['elapsed']
+        elapsed = payload.get('elapsed')
         failure_reason = payload.get('failure_reason') if not success else None
 
         # Create the ticket
-        ticket = JobTicket.create(_id, success, elapsed, failure_reason=failure_reason)
+        ticket = JobTicket.create(_id, success, failure_reason=failure_reason)
+
+        # Poly-fill elapsed_time_ms from elapsed time
+        # This is for backward compatibility with older versions of engine
+        if elapsed is not None:
+            profile = payload.setdefault('profile', {})
+            profile.setdefault('elapsed_time_ms', elapsed)
 
         # Allow profile updates on prepare-complete
         profile = payload.get('profile')

--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -453,13 +453,12 @@ class JobTicket(object):
         return config.db.job_tickets.find_one({'_id': bson.ObjectId(_id)})
 
     @staticmethod
-    def create(job_id, success, elapsed, failure_reason=None):
+    def create(job_id, success, failure_reason=None):
         j = Job.get(job_id)
 
         result = config.db.job_tickets.insert_one({
             'job': j.id_,
             'success': success,
-            'elapsed': elapsed,
             'timestamp': datetime.datetime.utcnow(),
             'failure_reason': failure_reason
         })

--- a/api/placer.py
+++ b/api/placer.py
@@ -383,7 +383,6 @@ class EnginePlacer(Placer):
 
             update_doc ={
                 'state': 'complete' if success else 'failed',
-                'profile.elapsed_time_ms': job_ticket['elapsed'],
                 'profile.total_output_files': output_file_count,
                 'profile.total_output_size_bytes': output_file_size_bytes
             }
@@ -819,7 +818,6 @@ class AnalysisJobPlacer(Placer):
 
             update_doc = {
                 'state': 'complete' if success else 'failed',
-                'profile.elapsed_time_ms': job_ticket['elapsed'],
                 'profile.total_output_files': output_file_count,
                 'profile.total_output_size_bytes': output_file_size_bytes
             }

--- a/swagger/schemas/definitions/job.json
+++ b/swagger/schemas/definitions/job.json
@@ -416,17 +416,13 @@
           "type": "boolean",
           "description": "Whether or not the job succeeded"
         },
-        "elapsed": {
-          "type": "integer",
-          "description": "The elapsed time of the job, in seconds"
-        },
         "failure_reason": {
           "type": "string",
           "description": "An optional suspected reason for job failure"
         },
         "profile": {"$ref": "#/definitions/job-profile-input"}
       },
-      "required": ["success", "elapsed"]
+      "required": ["success"]
     },
     "job-completion-ticket": {
         "type":"object",


### PR DESCRIPTION
This makes the `elapsed` time optional on job completion tickets in a backward compatible manner. 
If `elapsed` is specified and no `profile` is given, then `elapsed will be used.
Otherwise `profile.elapsed_time_ms` will take precedence.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
- Extra care is taken and log messages are created for [Critical Data](https://github.com/flywheel-io/core/wiki/Critical-Data-Flows)
