### PR TITLE
Add /jobs/ask

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -148,9 +148,9 @@ endpoints = [
 
         route( '/jobs',                             JobsHandler),
         prefix('/jobs', [
+            route('/ask',                           JobsHandler, h='ask',                  m=['POST']),
             route('/next',                          JobsHandler, h='next',                 m=['GET']),
             route('/stats',                         JobsHandler, h='stats',                m=['GET']),
-            route('/pending',                       JobsHandler, h='pending',              m=['GET']),
             route('/reap',                          JobsHandler, h='reap_stale',           m=['POST']),
             route('/add',                           JobsHandler, h='add',                  m=['POST']),
             route('/<:[^/]+>',                      JobHandler),

--- a/api/config.py
+++ b/api/config.py
@@ -272,7 +272,8 @@ def get_public_config():
 
     # Start publishing features as a boolean map
     features = {
-        'job_tickets': True,  #  Support for modern job-ticket workflow
+        'job_tickets': True,  #  Job completion tickets, which allow a new success/failure flow and advanced profiling.
+        'job_ask': True,      #  Job queue /jobs/ask route.
         'signed_url': hasattr(fs, 'get_signed_url'),
     }
 

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -155,7 +155,7 @@ class ContainerHandler(base.RequestHandler):
                         [('analysis', an['_id']) for an in analyses] +
                         [('acquisition', aq['_id']) for aq in acquisitions]
                     ]
-        jobs = Queue.search(cont_refs, states=states, tags=tags)
+        jobs = Queue.search_containers(cont_refs, states=states, tags=tags)
 
         unique_jobs = {}
         gear_ids = set()

--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -14,8 +14,6 @@ from ..dao.containerutil import create_filereference_from_dictionary, create_con
 from .. import config
 from ..web.errors import APINotFoundException
 
-log = config.log
-
 class Job(object):
     def __init__(self, gear, inputs, destination=None, tags=None,
                  attempt=1, previous_job_id=None, created=None,

--- a/api/jobs/jobs.py
+++ b/api/jobs/jobs.py
@@ -14,6 +14,7 @@ from ..dao.containerutil import create_filereference_from_dictionary, create_con
 from .. import config
 from ..web.errors import APINotFoundException
 
+log = config.log
 
 class Job(object):
     def __init__(self, gear, inputs, destination=None, tags=None,
@@ -105,8 +106,9 @@ class Job(object):
         # Partial join of gear info at time of execution
         gear_info = {
             'category': gear.get('category'),
-            'name': gear['gear'].get('name'),
-            'version': gear['gear'].get('version')
+            'name': gear['gear']['name'],
+            'version': gear['gear']['version'],
+            'capabilities': gear['gear'].get('capabilities', [])
         }
 
         self.gear_id            = gear_id
@@ -155,7 +157,6 @@ class Job(object):
         else:
             return False
 
-
     @classmethod
     def load(cls, e):
         # TODO: validate
@@ -186,7 +187,8 @@ class Job(object):
             'category': gear_info.get('category'),
             'gear': {
                 'name': gear_info.get('name'),
-                'version': gear_info.get('version')
+                'version': gear_info.get('version'),
+                'capabilities': gear_info.get('capabilities', []),
             }
         }
 
@@ -470,7 +472,6 @@ class JobTicket(object):
     def remove(_id):
         """Remove a single ticket by id"""
         config.db.job_tickets.remove({'_id': bson.ObjectId(_id)})
-
 
 class Logs(object):
 

--- a/swagger/paths/jobs.yaml
+++ b/swagger/paths/jobs.yaml
@@ -41,6 +41,24 @@
         examples:
           response:
             _id: 573cb66b135d87002660597c
+
+/jobs/ask:
+  post:
+    summary: Ask the queue a question
+    description: Ask the queue a question, recieving work or statistics in return.
+    operationId: ask_jobs
+    tags:
+    - jobs
+    parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: schemas/input/job-ask.json
+    responses:
+      '200':
+        description: ''
+
 /jobs/next:
   get:
     summary: Get the next job in the queue

--- a/swagger/schemas/definitions/job.json
+++ b/swagger/schemas/definitions/job.json
@@ -410,6 +410,61 @@
       },
       "required": ["config", "destination", "inputs"]
     },
+    "job-gear-match": {
+      "type": "object",
+      "properties": {
+        "group": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "A set of groups that are in the hierarchy of an input or destination"
+        },
+        "gear-name": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "A set of gear.name matches"
+        },
+        "tag": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "A set of job.tags matches"
+        }
+      },
+      "additionalProperties":false,
+      "required": [ ],
+      "description": "An object describing characteristics to match on gears"
+    },
+    "job-ask": {
+      "type": "object",
+      "properties": {
+        "whitelist": {
+          "$ref":"#/definitions/job-config-inputs",
+          "description": "Properties that must match against jobs"
+        },
+        "blacklist": {
+          "$ref":"#/definitions/job-config-inputs",
+          "description": "Properties that must NOT match against jobs"
+        },
+        "capabilities": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "A set of capabilities that must be a superset of matched jobs"
+        },
+        "return": {
+          "type": "object",
+          "properties": {
+            "jobs":   { "type": "integer" },
+            "peek":   { "type": "boolean" },
+            "states": { "type": "boolean" }
+          },
+          "additionalProperties":false,
+          "required": [ ],
+          "description": "Which sorts of return values to receive from ask"
+        }
+      },
+      "additionalProperties":false,
+      "required": [ "whitelist", "blacklist", "capabilities", "return" ],
+      "description": "Describes how a job should be transitioned after outputs have been uploaded"
+    },
     "job-completion-input": {
       "type": "object",
       "properties": {

--- a/swagger/schemas/definitions/job.json
+++ b/swagger/schemas/definitions/job.json
@@ -430,8 +430,17 @@
         }
       },
       "additionalProperties":false,
-      "required": [ ],
       "description": "An object describing characteristics to match on gears"
+    },
+    "job-ask-return": {
+      "type": "object",
+      "properties": {
+        "jobs":   { "type": "integer" },
+        "peek":   { "type": "boolean" },
+        "states": { "type": "boolean" }
+      },
+      "additionalProperties":false,
+      "description": "Which sorts of return values to receive from ask"
     },
     "job-ask": {
       "type": "object",
@@ -450,14 +459,7 @@
           "description": "A set of capabilities that must be a superset of matched jobs"
         },
         "return": {
-          "type": "object",
-          "properties": {
-            "jobs":   { "type": "integer" },
-            "peek":   { "type": "boolean" },
-            "states": { "type": "boolean" }
-          },
-          "additionalProperties":false,
-          "required": [ ],
+          "$ref":"#/definitions/job-ask-return",
           "description": "Which sorts of return values to receive from ask"
         }
       },

--- a/swagger/schemas/input/job-ask.json
+++ b/swagger/schemas/input/job-ask.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "allOf": [{"$ref": "../definitions/job.json#/definitions/job-ask"}],
+    "example": {
+        "whitelist": {
+            "group": [],
+            "gear-name": [],
+            "tag": []
+        },
+        "blacklist": {
+            "group": [],
+            "gear-name": [],
+            "tag": []
+        },
+        "capabilities": [],
+        "return": {
+            "jobs": 0,
+            "peek": true,
+            "states": true
+        }
+    }
+}

--- a/tests/integration_tests/python/test_jobs.py
+++ b/tests/integration_tests/python/test_jobs.py
@@ -10,9 +10,6 @@ def test_jobs_access(as_user):
     r = as_user.get('/jobs/stats')
     assert r.status_code == 403
 
-    r = as_user.get('/jobs/pending')
-    assert r.status_code == 403
-
     r = as_user.post('/jobs/reap')
     assert r.status_code == 403
     r = as_user.get('/jobs/test-job')
@@ -445,10 +442,6 @@ def test_jobs(data_builder, default_payload, as_public, as_user, as_admin, as_ro
     api_db.jobs.delete_one({"_id": bson.ObjectId("5a007cdb0f352600d94c845f")})
 
     r = as_admin.get('/jobs/stats')
-    assert r.ok
-    r = as_admin.get('/jobs/pending')
-    assert r.ok
-    r = as_admin.get('/jobs/pending', params={'tags': 'auto,unused'})
     assert r.ok
     r = as_admin.get('/jobs/stats', params={'all': '1'})
     assert r.ok

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,6 @@
 attrdict==2.0.0
 coverage==4.0.3
+deepdiff>=3.3.0
 mock==2.0.0
 mongomock==3.8.0
 pdbpp==0.9.2

--- a/tests/unit_tests/python/test_queue.py
+++ b/tests/unit_tests/python/test_queue.py
@@ -120,6 +120,8 @@ class QueueTestCases(unittest.TestCase):
             whitelist = case[0]
             blacklist = case[1]
             expected  = case[2]
+            capabilities = []
 
-            result = Queue.lists_to_query(whitelist, blacklist)
+            result = Queue.lists_to_query(whitelist, blacklist, capabilities)
+            del result['gear_info.capabilities']
             self.deep_equal(result, expected)

--- a/tests/unit_tests/python/test_queue.py
+++ b/tests/unit_tests/python/test_queue.py
@@ -1,0 +1,125 @@
+import pytest
+import unittest
+
+from deepdiff import DeepDiff
+
+from api.jobs.queue import Queue
+
+# Map request keys to DB keys
+groupK = 'group'
+groupD = 'parents.group'
+gearNameK = 'gear-name'
+gearNameD = 'gear_info.name'
+tagK = 'tag'
+tagD = 'tags'
+
+# Mongo query keys
+Ycontains = "$in"
+Ncontains = "$nin"
+
+# Example keys
+A = 'Almond'
+B = 'Black'
+C = 'Charcoal'
+D = 'Denim'
+E = 'Electric'
+F = 'Folly'
+
+class QueueTestCases(unittest.TestCase):
+
+    def deep_equal(self, result, expected):
+        """
+        This could move into a type hierarchy; needs to be downstream from TestCase.
+
+        https://github.com/seperman/deepdiff#using-deepdiff-in-unit-tests
+        """
+
+        diff = DeepDiff(result, expected)
+
+        if diff != {}:
+            print('Result:   ' + str(result))
+            print('Expected: ' + str(expected))
+            # print('Diff:     ' + str(diff))
+
+        self.assertEqual(DeepDiff(result, expected), {})
+
+    def test_queue_lists_to_query(self):
+
+        # Whitelist, blacklist, and expected result
+        matrix = [
+            [
+                # Empty lists should match all jobs
+                { },
+                { },
+                { },
+            ], [
+                # Whitelisting a group
+                { groupK: [A] },
+                {},
+                { groupD: { Ycontains: [A] }},
+            ], [
+                # Blacklisting a group
+                {},
+                { groupK: [A] },
+                { groupD: { Ncontains: [A] }},
+            ], [
+                # Both groups
+                { groupK: [A] },
+                { groupK: [B] },
+                { groupD: { Ycontains: [A], Ncontains: [B] }},
+            ], [
+                # Whitelisting a gear name
+                { gearNameK: [A] },
+                {},
+                { gearNameD: { Ycontains: [A] }},
+            ], [
+                # Blacklisting a gear name
+                {},
+                { gearNameK: [A] },
+                { gearNameD: { Ncontains: [A] }},
+            ], [
+                # Both gearNames
+                { gearNameK: [A] },
+                { gearNameK: [B] },
+                { gearNameD: { Ycontains: [A], Ncontains: [B] }},
+            ], [
+                # Whitelisting a tag
+                { tagK: [A] },
+                {},
+                { tagD: { Ycontains: [A] }},
+            ], [
+                # Blacklisting a tag
+                {},
+                { tagK: [A] },
+                { tagD: { Ncontains: [A] }},
+            ], [
+                # Both tags
+                { tagK: [A] },
+                { tagK: [B] },
+                { tagD: { Ycontains: [A], Ncontains: [B] }},
+            ], [
+                # Overlapping tags - nonsensical, but relied upon for legacy endpoints.
+                { tagK: [A] },
+                { tagK: [A] },
+                { tagD: { Ycontains: [A], Ncontains: [A] }},
+            ], [
+                # Combine all filters
+                { groupK: [A], gearNameK: [C], tagK: [E] },
+                { groupK: [B], gearNameK: [D], tagK: [F] },
+                {
+                    groupD:    { Ycontains: [A], Ncontains: [B] },
+                    gearNameD: { Ycontains: [C], Ncontains: [D] },
+                    tagD:      { Ycontains: [E], Ncontains: [F] },
+                },
+            ]
+        ]
+
+        for case in matrix:
+            assert len(case) == 3
+
+            whitelist = case[0]
+            blacklist = case[1]
+            expected  = case[2]
+
+            result = Queue.lists_to_query(whitelist, blacklist)
+            self.deep_equal(result, expected)

--- a/tests/unit_tests/python/test_validators.py
+++ b/tests/unit_tests/python/test_validators.py
@@ -77,9 +77,9 @@ def test_file_output_invalid():
     schema, resolver = validators._resolve_schema(schema_uri)
     with pytest.raises(jsonschema.exceptions.ValidationError):
         validators._validate_json(payload, schema, resolver)
-    
+
 def test_jsonschema_validate_enum_with_null():
-    schema = { 
+    schema = {
         'oneOf': [
             { 'type': 'null' },
             { 'type': 'string', 'enum': ['true', 'false'] }
@@ -100,7 +100,7 @@ def test_example_payload_valid(schema_type, schema_name):
         schema_uri = validators.schema_uri(schema_type, '{0}.json'.format(schema_name))
         schema, resolver = validators._resolve_schema(schema_uri)
         validators._validate_json(example_data, schema, resolver)
-    
+
 # Generate unit tests for all schema files
 # These tests will fail if examples are missing
 def pytest_generate_tests(metafunc):
@@ -114,12 +114,12 @@ def pytest_generate_tests(metafunc):
         for filename in files:
             if fnmatch.fnmatch(filename, '*.json'):
                 path = os.path.join(root, filename)
-                relpath = path[len(SCHEMAS_PATH):]     
+                relpath = path[len(SCHEMAS_PATH):]
                 if relpath not in IGNORED_SCHEMAS:
                     schema_files.append( relpath )
 
     test_args = []
-    for relpath in schema_files:        
+    for relpath in schema_files:
         # Get schema path, and test name
         schema_type, schema_name = os.path.split(relpath)
         if schema_type == 'input' or schema_type == 'output':


### PR DESCRIPTION

Adds a new route `/jobs/ask`  - ask the job queue a question.
Does away with the flak from `/jobs/next` and `/jobs/stats` to unify job filtering under a common struct. 

Along the way, several function signatures got a lot more readable. Moved existing calls around a bit and made them call the new hotness. Also removed `/jobs/pending` on the basis that it's never been used.

Tests / docs / schema TBD after approach is reviewed.
Multi-job support not in scope for this PR as a later addition. Func sigs support it.

Adds a deep_equals helper, that lives on `QueueTestCases` for now. Useful output:

```
# stdout capture
Result:   {'tags': {'$in': ['example-tag']}}
Expected: {'tags': {'$nin': ['example-tag']}}

# stderr capture
{'dictionary_item_removed': set(["root['tags']['$in']"]), 'dictionary_item_added': set(["root['tags']['$nin']"])}
```
