### PR TITLE
Allow users with project permissions to resolve groups [FLYW-612]

### DIFF
--- a/api/dao/containerutil.py
+++ b/api/dao/containerutil.py
@@ -140,7 +140,7 @@ def extract_subject(session, project):
     return subject
 
 
-def get_resolvable_groups(uid):
+def get_project_groups(uid):
     pipeline = [
         {
             '$match': {'permissions._id': uid}

--- a/api/dao/containerutil.py
+++ b/api/dao/containerutil.py
@@ -141,6 +141,14 @@ def extract_subject(session, project):
 
 
 def get_project_groups(uid):
+    """Get the ids of groups for which a user access to any of the porjects
+
+    Args:
+        uid (str): The user id to find permissions for
+
+    Returns:
+        list: list of group ids (str)
+    """
     pipeline = [
         {
             '$match': {'permissions._id': uid}

--- a/api/dao/containerutil.py
+++ b/api/dao/containerutil.py
@@ -140,6 +140,20 @@ def extract_subject(session, project):
     return subject
 
 
+def get_resolvable_groups(uid):
+    pipeline = [
+        {
+            '$match': {'permissions._id': uid}
+        },
+        {
+            '$group': {
+                '_id': '$group'
+            }
+        }
+    ]
+    return [doc['_id'] for doc in config.db.projects.aggregate(pipeline)]
+
+
 def get_stats(cont, cont_type):
     """
     Add a session, subject, non-compliant session and attachment count to a project or collection

--- a/api/handlers/containerhandler.py
+++ b/api/handlers/containerhandler.py
@@ -534,7 +534,7 @@ class ContainerHandler(base.RequestHandler):
         """
         method to return the list of groups for which there are projects accessible to the user
         """
-        group_ids = list(set((p['group'] for p in self.get_all('projects'))))
+        group_ids = containerutil.get_project_groups(self.uid)
         return list(config.db.groups.find({'_id': {'$in': group_ids}}, ['label']))
 
     def set_project_template(self, **kwargs):

--- a/api/handlers/resolvehandler.py
+++ b/api/handlers/resolvehandler.py
@@ -71,19 +71,22 @@ class ResolveHandler(base.RequestHandler):
 
         resolver = Resolver(id_only=id_only, include_subjects=self.is_enabled('Subject-Container'))
         result = resolver.resolve(doc['path'])
-        path_length = len(result['path'])
 
         # Cancel the request if anything in the path is unauthorized; remove any children that are unauthorized.
         # Except for the group, only check permissions for groups if it's the only container in the path
         if not self.user_is_admin:
+            resolvable_groups = containerutil.get_resolvable_groups(self.uid)
             for x in result["path"]:
                 ok = False
-                if (path_length == 1 and x['container_type'] == 'group') or x['container_type'] in ['acquisition', 'session', 'project']:
+                if x['container_type'] in ['acquisition', 'session', 'project', 'group']:
                     perms = x.get('permissions', [])
                     for y in perms:
                         if y.get('_id') == self.uid:
                             ok = True
                             break
+
+                    if x['container_type'] == 'group' and not ok:
+                        ok = x['_id'] in resolvable_groups
 
                     if not ok:
                         self.abort(403, "Not authorized")
@@ -98,6 +101,8 @@ class ResolveHandler(base.RequestHandler):
                         if y.get('_id') == self.uid:
                             ok = True
                             break
+                    if x['container_type'] == 'group' and not ok:
+                        ok = x['_id'] in resolvable_groups
                 else:
                     ok = True
 

--- a/api/handlers/resolvehandler.py
+++ b/api/handlers/resolvehandler.py
@@ -71,11 +71,11 @@ class ResolveHandler(base.RequestHandler):
 
         resolver = Resolver(id_only=id_only, include_subjects=self.is_enabled('Subject-Container'))
         result = resolver.resolve(doc['path'])
+        resolvable_groups = containerutil.get_project_groups(self.uid)
 
         # Cancel the request if anything in the path is unauthorized; remove any children that are unauthorized.
         # Except for the group, only check permissions for groups if it's the only container in the path
         if not self.user_is_admin:
-            resolvable_groups = containerutil.get_resolvable_groups(self.uid)
             for x in result["path"]:
                 ok = False
                 if x['container_type'] in ['acquisition', 'session', 'project', 'group']:


### PR DESCRIPTION
Users should be able to resolve any subset of a path they can already resolve.

#### Example:
If `fw ls scitran/Neuroscience` returns something other than a 403 for me, I should be able to see Neuroscience with `fw ls scitran` but only the projects I have access to.
And with `fw ls` I should see scitran even if I don't have permission for the group but I do for a child.


Not sure if there's a better way to do the `get_resolvable_groups` function, or if we should just implement a get_projects_groups endpoint which may help frontend out too.
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
- Extra care is taken and log messages are created for [Critical Data](https://github.com/flywheel-io/core/wiki/Critical-Data-Flows)
