### PR TITLE
Fix data view match containers

### DIFF
--- a/api/data_views/pipeline/match_containers.py
+++ b/api/data_views/pipeline/match_containers.py
@@ -1,5 +1,5 @@
 from .pipeline import PipelineStage
-from ..util import filtered_container_list, file_filter_to_regex, nil_value
+from ..util import filtered_container_list, file_filter_to_regex, nil_value, is_nil
 
 def pop_collection(cont, key):
     """Nested pop of key from container.
@@ -21,7 +21,7 @@ def pop_collection(cont, key):
         if not cont:
             break
 
-    if cont:
+    if cont and not is_nil(cont):
         result = cont.pop(parts[-1], [])
 
     return result

--- a/tests/integration_tests/python/test_data_views.py
+++ b/tests/integration_tests/python/test_data_views.py
@@ -967,6 +967,25 @@ def test_adhoc_data_view_analyses_files(data_builder, file_form, as_admin, as_dr
     assert {'filename':'values2.csv'} in rows
     assert {'filename':'values3.csv'} in rows
 
+    # Execute data view, no match
+    r = as_admin.post('/views/data?containerId={}'.format(project), json={
+        'includeIds': False,
+        'includeLabels': False,
+        'columns': [
+            {'src': 'file.name'}
+        ],
+        'fileSpec': {
+            'container': 'session',
+            'filter': {'value': '*.csv'},
+            'analysisFilter': {'label': {'value': 'invalid-match'}},
+        }
+    })
+
+    assert r.ok
+    rows = r.json()['data']
+    assert len(rows) == 1
+    assert {'file.name': None} in rows
+
     api_db.analyses.delete_one({'_id': bson.ObjectId(analysis1)})
     api_db.analyses.delete_one({'_id': bson.ObjectId(analysis2)})
 


### PR DESCRIPTION
I found an issue when I tried to execute an adhoc data view with analysis filter. If the filter doesn't match a container, then data view creation failed with the following exception:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/webapp2.py", line 1546, in __call__
    return response(environ, start_response)
  File "/src/core/api/metrics/request_wrapper.py", line 65, in handler
    return fn(environ, start_response_wrapper)
  File "/src/core/api/data_views/handlers.py", line 196, in response_handler
    view.execute(self.request, self.origin, write, write_progress_fn=write_progress)
  File "/src/core/api/data_views/data_view.py", line 218, in execute
    self.pipeline.process(self._tree)
  File "/src/core/api/data_views/pipeline/aggregate.py", line 78, in process
    self.emit(rows)
  File "/src/core/api/data_views/pipeline/pipeline.py", line 34, in emit
    self._next.process(payload)
  File "/src/core/api/data_views/pipeline/match_containers.py", line 79, in process
    self.emit(rows + unmatched)
  File "/src/core/api/data_views/pipeline/pipeline.py", line 34, in emit
    self._next.process(payload)
  File "/src/core/api/data_views/pipeline/match_containers.py", line 65, in process
    containers = pop_collection(row, self.collection_key)
  File "/src/core/api/data_views/pipeline/match_containers.py", line 25, in pop_collection
    result = cont.pop(parts[-1], [])
AttributeError: 'object' object has no attribute 'pop'
```

I added a test which demonstrate what was the problem. Checking that the container is not nil in `pop_collection` solves the problem.

### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
- Extra care is taken and log messages are created for [Critical Data](https://github.com/flywheel-io/core/wiki/Critical-Data-Flows)
