### PR TITLE
Handle mail_format in ldap auth provider [FLYW-762]

### DIFF
--- a/api/auth/authproviders.py
+++ b/api/auth/authproviders.py
@@ -102,7 +102,7 @@ class JWTAuthProvider(AuthProvider):
         r = requests.post(self.config['verify_endpoint'], data={'token': token}, verify=self.config.get('check_ssl', True))
         if not r.ok:
             raise APIAuthProviderException('User token not valid')
-        uid = json.loads(r.content).get('mail')
+        uid = self._get_uid(json.loads(r.content))
         if not uid:
             raise APIAuthProviderException('Auth provider did not provide user email')
 
@@ -110,6 +110,16 @@ class JWTAuthProvider(AuthProvider):
         self.set_user_gravatar(uid, uid)
 
         return uid
+
+    def _get_uid(self, token_data):
+        mail_format = self.config.get('mail_format')
+        if mail_format:
+            try:
+                return mail_format.format(**token_data)
+            except KeyError:
+                return None
+        return token_data.get('mail')
+
 
 class GoogleOAuthProvider(AuthProvider):
 

--- a/api/config.py
+++ b/api/config.py
@@ -310,6 +310,7 @@ def get_public_config():
     auth = copy.deepcopy(cfg.get('auth'))
     for values in auth.itervalues():
         values.pop('client_secret', None)
+        values.pop('mail_format', None)
 
     return {
         'created': __config.get('created'),


### PR DESCRIPTION
Add support for customers where the correct mail address (and therefore uid) is a combination of the `uid` field and a domain name.

This permits adding a `mail_format` attribute to the LDAP config that can produce a mail address from components of the JWT. For example: `{uid}@test.com`

### Review Checklist

- Tests were added to cover all code changes
- Is there a DB upgrade or fix?
  - If so is it covered by integeration tests and run against dev?
- Would this PR benefit from a test plan? If so, is one provided?
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
- Extra care is taken and log messages are created for [Critical Data](https://github.com/flywheel-io/core/wiki/Critical-Data-Flows)
