### PR TITLE
Api bulk operations 

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -16,6 +16,7 @@ from .handlers.roothandler              import RootHandler
 from .handlers.schemahandler            import SchemaHandler
 from .handlers.userhandler              import UserHandler
 from .handlers.uidhandler               import UIDHandler
+from .handlers.bulkhandler              import BulkHandler
 from .master_subject_code.handlers      import MasterSubjectCodeHandler
 from .jobs.handlers                     import BatchHandler, JobsHandler, JobHandler, GearsHandler, GearHandler, RulesHandler, RuleHandler
 from .metrics.handler                   import MetricsHandler
@@ -400,5 +401,8 @@ endpoints = [
         prefix('/subjects/master-code', [
             route('/<_id:[^/]+>',      MasterSubjectCodeHandler, h='verify_code', m=['GET'])
         ]),
+
+        # Bulk Operations
+        route('/bulk/<operation:move|copy|delete>/<source_cont_name:{cname}>', BulkHandler, h='bulk', m=['POST']),
     ]),
 ]

--- a/api/dao/basecontainerstorage.py
+++ b/api/dao/basecontainerstorage.py
@@ -399,6 +399,12 @@ class ContainerStorage(object):
         else:
             replace_info_with_bool = False
 
+        # We can assume if you use an _id query it is going to be an $in clause otherwise you would use the get_el function
+        if query.get('_id') and query['_id'].get('$in'):
+            # if the $in is ints this will still be a safe loop
+            for i in range(len(query['_id']['$in'])):
+                query['_id']['$in'][i] = self.format_id(query['_id']['$in'][i])
+
         kwargs['filter'] = query
         kwargs['projection'] = projection
         page = dbutil.paginate_find(self.dbc, kwargs, pagination)

--- a/api/dao/basecontainerstorage.py
+++ b/api/dao/basecontainerstorage.py
@@ -399,12 +399,6 @@ class ContainerStorage(object):
         else:
             replace_info_with_bool = False
 
-        # We can assume if you use an _id query it is going to be an $in clause otherwise you would use the get_el function
-        if query.get('_id') and query['_id'].get('$in'):
-            # if the $in is ints this will still be a safe loop
-            for i in range(len(query['_id']['$in'])):
-                query['_id']['$in'][i] = self.format_id(query['_id']['$in'][i])
-
         kwargs['filter'] = query
         kwargs['projection'] = projection
         page = dbutil.paginate_find(self.dbc, kwargs, pagination)

--- a/api/dao/containerstorage.py
+++ b/api/dao/containerstorage.py
@@ -553,7 +553,8 @@ class SessionStorage(ContainerStorage):
 
         # Save all the new subjects in one call
         # There will be time where the new containers exist prior to the new subject existing
-        config.db.subjects.insert_many(new_subjects)
+        if new_subjects:
+            config.db.subjects.insert_many(new_subjects)
 
 
 class AcquisitionStorage(ContainerStorage):

--- a/api/dao/containerstorage.py
+++ b/api/dao/containerstorage.py
@@ -340,6 +340,26 @@ class SessionStorage(ContainerStorage):
         return {'info': 0, 'files.info': 0, 'analyses': 0, 'tags': 0, 'age': 0}
 
 
+    def move_sessions_to_subject(self, source_list, dest_subject, conflict_mode=None):
+
+        dest_subject_obj = SubjectStorage().get_el(dest_subject)
+
+        query = {}
+        update = {'$set': {
+            'parents.subject': dest_subject_obj['_id'],
+            'parents.project': dest_subject_obj['parents']['project'],
+            'parents.group': dest_subject_obj['parents']['group'],
+            'subject': dest_subject_obj['_id'],
+            'project': dest_subject_obj['parents']['project'],
+            'group': dest_subject_obj['parents']['group'],
+            'permissions': dest_subject_obj['permissions']
+        }}
+
+        # Sessions can not have conflicts so just bilndly move them all over to the new subject.
+        containerutil.bulk_propagate_changes('sessions', source_list, query,
+             update, include_refs=True)
+
+
     def move_sessions_to_project(self, source_list, dest_project, conflict_mode=None):
 
         dest_project_obj = ProjectStorage().get_el(dest_project)

--- a/api/dao/containerstorage.py
+++ b/api/dao/containerstorage.py
@@ -383,8 +383,11 @@ class SessionStorage(ContainerStorage):
         source_subject_id_by_code = {} # We need the mapping of source id by code for conflicts later
         for source in source_subjects:
             source_subject_ids.append(source['_id'])
+            # We can have missing subjects. Not sure this is a valid case
+            if not source['subject_doc']:
+                continue
             source_projects.append(source['subject_doc'][0]['project'])
-            # not all subejcts have a code.  If not they will not be a conflict anyway
+            # not all subjects have a code.  If not they will not be a conflict anyway
             if source['subject_doc'][0].get('code'):
                 source_subject_codes.append(source['subject_doc'][0]['code'])
                 source_subject_id_by_code[source['subject_doc'][0]['code']] = source['_id']
@@ -433,14 +436,23 @@ class SessionStorage(ContainerStorage):
         # We just leave conflicts alone for now.
         search_subjects = list(set(source_subject_ids) - set(conflict_subject_source_ids))
 
+
+        # TODO: We only need one search. with the sessions aggregated
+        # IF the sessions are a subset its move if not its copy
+        # Regardless of how many sessions the subject has
+        copy_subjects = []
+        move_subjects = []
         sessions = config.db.sessions.aggregate([
             {'$match': {'subject': {'$in': search_subjects}}},
-            {'$group': {'_id': '$subject', 'count': {'$sum':1}}},
+            {'$group': {'_id': '$subject', 'count': {'$sum':1}, 'sessions': {'$push': "$_id"}}},
             {'$match': {'count': {'$gt': 1}}},
-            {'$project': {'_id': 1}}
+            {'$project': {'_id': 1, 'sessions': 1, 'count': 1}}
         ])
-        copy_subjects = []
         for session in sessions:
+            # If we are moving all the sessions then we dont need to copy the subject.
+            if set(session['sessions']).issubset(set(source_list)):
+                move_subjects.append(session['_id'])
+                continue
             copy_subjects.append(session['_id'])
 
         sessions = config.db.sessions.aggregate([
@@ -449,7 +461,6 @@ class SessionStorage(ContainerStorage):
             {'$match': {'count': {'$eq': 1}}},
             {'$project': {'_id': 1}}
         ])
-        move_subjects = []
         for session in sessions:
             move_subjects.append(session['_id'])
 
@@ -496,7 +507,7 @@ class SessionStorage(ContainerStorage):
                 for session in sessions:
                     moves.append(session['_id'])
 
-                containerutil.bulk_propagate_changes('sessions', moves, query, 
+                containerutil.bulk_propagate_changes('sessions', moves, query,
                     update, include_refs=True)
 
 
@@ -505,6 +516,7 @@ class SessionStorage(ContainerStorage):
         update = {
             '$set': {
                 'parents.project': dest_project_obj['_id'],
+                'parents.group': dest_project_obj['parents']['group'],
                 'project': dest_project_obj['_id'],
                 'permissions': dest_project_obj['permissions']
             }
@@ -518,15 +530,16 @@ class SessionStorage(ContainerStorage):
         # With mongo 4.1 we can do this in a pipeline.
         # Currently we have to pass the data back and update docs manually
         for subject in copy_subjects:
-            subject_doc = config.db.subjects.find_one({'_id': {'$in': copy_subjects}})
+            subject_doc = config.db.subjects.find_one({'_id': bson.ObjectId(subject)})
             del subject_doc['_id']
             subject_doc['permissions'] = dest_project_obj['permissions']
             subject_doc['project'] = dest_project_obj['_id']
+            subject_doc['parents']['group'] = dest_project_obj['parents']['group']
             subject_doc['parents']['project'] = dest_project_obj['_id']
             # These we need to do one at a time because we need the inserted id.
             # We could tweak this by creating a placeholder and then updating the unique 
             # placeholder once the final subjects are flushed and have vaild objectIds
-            new_subject = config.db.subject.insert_one(subject_doc)
+            new_subject = config.db.subjects.insert_one(subject_doc)
 
             analysis = config.db.analyses.find({'parent.type': 'subject', 'parent.id': subject})
             # We might have a memory issue depending on the size of  anayses we have to move
@@ -540,6 +553,7 @@ class SessionStorage(ContainerStorage):
                 a['parent']['id'] = new_subject.inserted_id
                 a['parents']['subject'] = new_subject.inserted_id
                 a['parents']['project'] = dest_project_obj['id']
+                a['parents']['group'] = dest_project_obj['parents']['group']
                 if count <= page:
                     insert_analyses.append(a)
                 else:
@@ -563,6 +577,7 @@ class SessionStorage(ContainerStorage):
             update = {'$set': {
                 'permissions': dest_project_obj['permissions'],
                 'project': dest_project_obj['_id'],
+                'parents.group': dest_project_obj['parents']['group'],
                 'parents.project': dest_project_obj['_id'],
                 'parents.subject': new_subject.inserted_id,
                 'subject': new_subject.inserted_id,

--- a/api/dao/containerutil.py
+++ b/api/dao/containerutil.py
@@ -51,40 +51,39 @@ PARENT_FROM_CHILD = {c: CONTAINER_HIERARCHY[ind]   for ind, c in enumerate(CONTA
 
 NON_OBJECT_ID_COLLECTIONS = ['groups', 'users']
 
-def propagate_changes(cont_name, cont_ids, query, update, include_refs=False):
+def propagate_changes(cont_name, cont_id, query, update, include_refs=False):
     """
-    Propagates changes down the heirarchy tree recursively.
+    Propagates changes through the hierarcy from the bottom to the current cont_name level, iteratively.
 
     cont_name and cont_ids refer to top level containers (which will not be modified here)
     """
 
-    containers = ['groups', 'projects', 'subjects', 'sessions', 'acquisitions']
-    if not isinstance(cont_ids, list):
-        cont_ids = [cont_ids]
+    if isinstance(cont_id, list):
+        raise Exception('only one container can be specified')
     if query is None:
         query = {}
 
     if include_refs:
         analysis_query = copy.deepcopy(query)
-        analysis_query.update({'parent.type': singularize(cont_name), 'parent.id': {'$in': cont_ids}})
+        analysis_query.update({'parent.type': singularize(cont_name), 'parent.id': cont_id})
+
         analysis_update = copy.deepcopy(update)
         analysis_update.get('$set', {}).pop('permissions', None)
         config.db.analyses.update_many(analysis_query, analysis_update)
 
         # Update job parents by destination
-        job_query = { 'parents.{}'.format(singularize(cont_name)) : {'$in': cont_ids} }
+        job_query = {'parents.{}'.format(singularize(cont_name)) :cont_id}
         config.db.jobs.update_many(job_query, analysis_update)
 
-    if cont_name in containers[:-1]:
-        child_cont = containers[containers.index(cont_name) + 1]
-        child_ids = [c['_id'] for c in config.db[child_cont].find({singularize(cont_name): {'$in': cont_ids}}, [])]
-
-        if child_ids:
-            child_query = copy.deepcopy(query)
-            child_query['_id'] = {'$in': child_ids}
-            config.db[child_cont].update_many(child_query, update)
-            # Recurse to the next hierarchy level
-            propagate_changes(child_cont, child_ids, query, update, include_refs=include_refs)
+    containers = ['acquisitions', 'sessions', 'subjects', 'projects', 'groups']
+    query.update({'parents.' + cont_name: cont_id})
+    # TODO validate we dont send in invalid data in the update.  Can only be common data to the current level of hierarccy we are updating
+    for cur_cont in containers:
+        config.db[cur_cont].update_many(query, update)
+        if cont_name == cur_cont:
+            return
+    raise Exception('Never reached top level container')
+    return
 
 
 def attach_raw_subject(session, subject, additional_fields=None):

--- a/api/dao/containerutil.py
+++ b/api/dao/containerutil.py
@@ -45,6 +45,8 @@ CONTAINER_HIERARCHY = [
     'acquisitions'
 ]
 
+CONTAINER_PROPAGATE = ('aquisitions', 'sessions', 'subjects', 'projects', 'groups'))
+
 # Generate {child: parent} and {parent: child} maps from ordered hierarchy list
 CHILD_FROM_PARENT = {p: CONTAINER_HIERARCHY[ind+1] for ind, p in enumerate(CONTAINER_HIERARCHY[:-1] )}
 PARENT_FROM_CHILD = {c: CONTAINER_HIERARCHY[ind]   for ind, c in enumerate(CONTAINER_HIERARCHY[1:]  )}
@@ -64,7 +66,6 @@ def propagate_changes(cont_name, cont_id, query, update, include_refs=False):
     if query is None:
         query = {}
 
-    containers = ['acquisitions', 'sessions', 'subjects', 'projects', 'groups']
     query.update({'parents.' + singularize(cont_name): cont_id})
 
     if include_refs:
@@ -77,17 +78,16 @@ def propagate_changes(cont_name, cont_id, query, update, include_refs=False):
         config.db.jobs.update_many(job_query, analysis_update)
 
     # Non standard containers only need to update related analysis and jobs, if any
-    if cont_name not in containers:
+    if cont_name not in CONTAINER_PROPAGATE:
         return
 
     # TODO validate we dont send in invalid data in the update.  Can only be common data to the current level of hierarccy we are updating
-    for cur_cont in containers:
+    for cur_cont in CONTAINER_PROPAGATE:
         config.db[cur_cont].update_many(query, update)
         if cont_name == cur_cont:
             return
 
     raise Exception('Never reached top level container from: {}'.format(cont_name))
-
 
 
 def bulk_propagate_changes(cont_name, cont_ids, query, update, top_level_update=None, include_refs=False):
@@ -103,9 +103,7 @@ def bulk_propagate_changes(cont_name, cont_ids, query, update, top_level_update=
     if not top_level_update:
         top_level_update = update
 
-    containers = ['acquisitions', 'sessions', 'subjects', 'projects', 'groups']
     query.update({'parents.' + singularize(cont_name): {'$in': cont_ids}})
-
 
     if include_refs:
         analysis_update = copy.deepcopy(update)
@@ -117,24 +115,16 @@ def bulk_propagate_changes(cont_name, cont_ids, query, update, top_level_update=
         config.db.jobs.update_many(job_query, analysis_update)
 
     # Non standard containers only need to update related analysis and jobs, if any
-    if cont_name not in containers:
+    if cont_name not in CONTAINER_PROPAGATE:
         return
 
     # TODO validate we dont send in invalid data in the update.  Can only be common data to the current level of hierarccy we are updating
-    for cur_cont in containers:
+    for cur_cont in CONTAINER_PROPAGATE:
         if cont_name == cur_cont:
-
-            print 'updating top level so remove parents find'
-            print 'this is the initial query'
-            print query
             for key in ['parents.group', 'parents.project', 'parents.subject', 'parents.session', 'parents']:
                 if query.get(key):
-                    print 'removing key'
-                    print key
                     del query[key]
             query.update({'_id': {'$in': cont_ids}})
-            print 'this is the query after we are done'
-            print query
             config.db[cur_cont].update_many(query, top_level_update)
             return
 

--- a/api/dao/containerutil.py
+++ b/api/dao/containerutil.py
@@ -45,7 +45,7 @@ CONTAINER_HIERARCHY = [
     'acquisitions'
 ]
 
-CONTAINER_PROPAGATE = ('aquisitions', 'sessions', 'subjects', 'projects', 'groups'))
+CONTAINER_PROPAGATE = ('acquisitions', 'sessions', 'subjects', 'projects', 'groups')
 
 # Generate {child: parent} and {parent: child} maps from ordered hierarchy list
 CHILD_FROM_PARENT = {p: CONTAINER_HIERARCHY[ind+1] for ind, p in enumerate(CONTAINER_HIERARCHY[:-1] )}

--- a/api/dao/containerutil.py
+++ b/api/dao/containerutil.py
@@ -77,14 +77,17 @@ def propagate_changes(cont_name, cont_id, query, update, include_refs=False):
         job_query = {'parents.{}'.format(singularize(cont_name)) :cont_id}
         config.db.jobs.update_many(job_query, analysis_update)
 
+    # Non standard containers only need to update related analysis and jobs, if any
+    if cont_name not in containers:
+        return
+
     # TODO validate we dont send in invalid data in the update.  Can only be common data to the current level of hierarccy we are updating
     for cur_cont in containers:
         config.db[cur_cont].update_many(query, update)
         if cont_name == cur_cont:
             return
-    raise Exception('Never reached top level container')
-    return
 
+    raise Exception('Never reached top level container from: {}'.format(cont_name))
 
 def attach_raw_subject(session, subject, additional_fields=None):
     raw_subject_fields = ['firstname', 'lastname', 'sex', 'race', 'ethnicity']

--- a/api/dao/containerutil.py
+++ b/api/dao/containerutil.py
@@ -63,9 +63,11 @@ def propagate_changes(cont_name, cont_id, query, update, include_refs=False):
     if query is None:
         query = {}
 
+    containers = ['acquisitions', 'sessions', 'subjects', 'projects', 'groups']
+    query.update({'parents.' + singularize(cont_name): cont_id})
+
     if include_refs:
         analysis_query = copy.deepcopy(query)
-        analysis_query.update({'parent.type': singularize(cont_name), 'parent.id': cont_id})
 
         analysis_update = copy.deepcopy(update)
         analysis_update.get('$set', {}).pop('permissions', None)
@@ -75,8 +77,6 @@ def propagate_changes(cont_name, cont_id, query, update, include_refs=False):
         job_query = {'parents.{}'.format(singularize(cont_name)) :cont_id}
         config.db.jobs.update_many(job_query, analysis_update)
 
-    containers = ['acquisitions', 'sessions', 'subjects', 'projects', 'groups']
-    query.update({'parents.' + cont_name: cont_id})
     # TODO validate we dont send in invalid data in the update.  Can only be common data to the current level of hierarccy we are updating
     for cur_cont in containers:
         config.db[cur_cont].update_many(query, update)

--- a/api/handlers/bulkhandler.py
+++ b/api/handlers/bulkhandler.py
@@ -99,253 +99,28 @@ class BulkHandler(base.RequestHandler):
 
 
     def _move_sessions_to_projects(self):
+        '''
+        Requires a 2 phase approach.
+        First is the dry run the second is with the conflict mode set
 
-        source_session = self.source_storage.get_el(self.source_list[0])
-        dest_project = self.dest_storage.get_el(self.dest_list[0])
+        For the matter of subjects existing they will have the same 'code'
+        1. If the subject for the session in the source project does not exist in the destination project
+            a. If the subject in the source project has more than one session
+    		i. Copy the subject to the destination project and move the session to the copy
+    	    b. If the subject in the source project session has just the session to be moved
+    		i. Move the subject (with the session) to the destination project
+        2. If the subject for the session in the source project does exist
+            a. Raise an error (Conflict) on the dry run
+    	    b. On the full run either move or skip
+    		i. move the session to the subject in the destination but leave the subject in the source
+    		ii. Or skip the move entirely.
+        '''
 
-        # hash of projects by id for quick lookup
-
-
-        # Find all the source subjects first.
-        source_subjects = config.db.sessions.aggregate([
-            {'$match': {'_id': {'$in': self.source_list}}},
-            {'$group': {'_id': '$subject'}},
-            {'$lookup':{
-                'from': 'subjects',
-                'localField': '_id',
-                'foreignField': '_id',
-                'as': 'subject_doc'
-            }},
-            {'$project': {'_id': 1, 'subject_doc.code': 1, 'subject_doc.project': 1}}
-        ])
-
-        source_subject_ids = []
-        source_subject_codes = []
-        source_projects = []
-        source_subject_id_by_code = {} # We need the mapping of source id by code for conflicts later
-        for source in source_subjects:
-            source_subject_ids.append(source['_id'])
-            source_projects.append(source['subject_doc'][0]['project'])
-            # not all subejcts have a code.  If not they will not be a conflict anyway
-            if source['subject_doc'][0].get('code'):
-                source_subject_codes.append(source['subject_doc'][0]['code'])
-                source_subject_id_by_code[source['subject_doc'][0]['code']] = source['_id']
-
-        print 'we have these subjects to move'
-        print source_subject_ids
-        print source_subject_codes
-        print '----------------------------'
-
-
-        # Conflict codes are subject codes that exist in the destination already
-        conflicts = config.db.subjects.find({
-            'code': {'$in': source_subject_codes},
-            'project': self.dest_list[0]
-            }, projection={'_id': 1, 'code': 1})
-
-        # first we find conflicts as those are needed for dry run regardless.
-        conflict_subject_codes = []
-        conflict_subject_dest_ids_by_code = {}
-        for conflict in conflicts:
-            conflict_subject_codes.append(conflict['code'])
-            conflict_subject_dest_ids_by_code[conflict['code']] = conflict['_id']
 
         if (not self.payload.get('conflict_mode', False) or
                 self.payload['conflict_mode'] is None or self.payload['conflict_mode'] == ''):
-            # TODO: Raise an error
-            return conflict_subject_codes
-
-        # The id of the subjects in the source that have the same code
-        conflict_subject_source_ids = []
-        #conflict_subject_source_ids_by_code = {} # might be needed for conflict resolution later
-        conflicts = config.db.subjects.find(
-                {'code': {'$in': conflict_subject_codes}, 'project': {'$in': list(set(source_projects))}},
-            projection={'_id': 1, 'code': 1})
-        for conflict in conflicts:
-            conflict_subject_source_ids.append(conflict['_id'])
-            #conflict_subject_source_ids_by_code[conflict['code']] = conflict['_id']
+            return self.source_storage.move_sessions_to_project(self.source_list, self.dest_list[0], conflict_mode=self.payload.get('conflict_mode'))
 
 
-        print 'we have confilcts'
-        print conflict_subject_source_ids
-        import sys
-        sys.stdout.flush()
-
-        # We need source projects for all the sessions to update
-
-        # Next we need to find the two sets that are not conflicts
-            # copy: subjects that have more than one session in the source project
-            # move: subjects that have just the one session in the source project
-                # Techinically if all the sessions are in the move session
-
-        # We just leave conflicts alone for now.
-        search_subjects = list(set(source_subject_ids) - set(conflict_subject_source_ids))
-        print 'we have these subjects to search on'
-        print search_subjects
-
-        sessions = config.db.sessions.aggregate([
-            {'$match': {'subject': {'$in': search_subjects}}},
-            {'$group': {'_id': '$subject', 'count': {'$sum':1}}},
-            {'$match': {'count': {'$gt': 1}}},
-            {'$project': {'_id': 1}}
-        ])
-        copy_subjects = []
-        for session in sessions:
-            copy_subjects.append(session['_id'])
-
-        sessions = config.db.sessions.aggregate([
-            {'$match': {'subject': {'$in': search_subjects}}},
-            {'$group': {'_id': '$subject', 'count': {'$sum': 1}}},
-            {'$match': {'count': {'$eq': 1}}},
-            {'$project': {'_id': 1}}
-        ])
-        move_subjects = []
-        for session in sessions:
-            move_subjects.append(session['_id'])
-
-        # Perhaps we can make this better with a single aggregation
-        #sessions = config.db.sessions.aggregate([
-        #    {'subject': {'$in': search_subjects}},
-        #    { '$bucket': {
-        #        'groupBy': ,
-        #        'boundaries': [ 0, 200, 400 ],
-        #          default: "Other",
-        #          output: {
-        #            "count": { $sum: 1 },
-        #            "titles" : { $push: "$title" }
-        #          }
-        #        }
-        #    }
-
-
-        print 'we have these subjects to copy'
-        print copy_subjects
-        print 'we have these subjects to move'
-        print move_subjects
-        print 'we have these conflict subjects'
-        print conflict_subject_source_ids
-        print 'Innintal total size of subjects'
-        print source_subject_ids
-        import sys
-        sys.stdout.flush()
-
-        # quick sanity check
-        assert len(source_subject_ids) == (
-            len(move_subjects) + len(copy_subjects) + len(conflict_subject_source_ids))
-
-        if self.payload['conflict_mode'] == 'move':
-            # We have to move the sessions which means updating the session to have the new subject id and parent, project, permissions
-            # But we need to find the ID of the subject in the dest project first.
-            for code in conflict_subject_codes:
-                print 'processing a conflict code'
-                print code
-                query = {
-                    'parents.subject': source_subject_id_by_code[code],
-                    '_id': {'$in': self.source_list}
-                }
-                update = {'$set': {
-                    'subject': conflict_subject_dest_ids_by_code[code],
-                    'parents.subject': conflict_subject_dest_ids_by_code[code],
-                    'parents.project': self.dest_list[0],
-                    'project': self.dest_list[0],
-                    'permissions': dest_project['permissions']
-                }}
-
-                moves = []
-                sessions = config.db.sessions.find({
-                    'subject': source_subject_id_by_code[code],
-                    '_id': {'$in': self.source_list}}, projection= {'_id': 1})
-                for session in sessions:
-                    moves.append(session['_id'])
-
-                print 'we are propogating a move for these conflict sessions'
-                print moves
-                import sys
-                sys.stdout.flush()
-
-                containerutil.bulk_propagate_changes('sessions', moves, query, update, include_refs=True)
-
-
-        # Move subjects just need to have the pointers and permissions adjusted
-        #query = {'_id': {'$in': move_subjects}, '_id': {'$in': self.source_list}}
-        query = {}
-        update = {
-            '$set': {
-                'parents.project': self.dest_list[0],
-                'project': self.dest_list[0],
-                'permissions': dest_project['permissions']
-            }
-        }
-
-        # Validate this method really works as expected
-        print 'We are propogating a move for these subjects'
-        print move_subjects
-        containerutil.bulk_propagate_changes('subjects', move_subjects, query, update, include_refs=True)
-
-        # Copy sessions need to be copied including all related sub docs.
-        # With mongo 4.1 we can do this in a pipeline.
-        # Currently we have to pass the data back and update docs manually
-        for subject in copy_subjects:
-            subject_doc = config.db.subjects.find_one({'_id': {'$in': copy_subjects}})
-            del subject_doc['_id']
-            subject_doc['permissions'] = dest_project['permissions']
-            subject_doc['project'] = dest_project['_id']
-            subject_doc['parents']['project'] = dest_project['_id']
-            new_subject = config.db.subject.insert_one(subject_doc)
-            print 'we have a new subject'
-            print new_subject
-
-            analysis = config.db.analyses.find({'parent.type': 'subject', 'parent.id': subject})
-            for a in analysis:
-                print 'we are updating an analysis'
-                print analysis
-                import sys
-                sys.stdout.flush()
-                a['_id'] = None
-                a['permissions'] = dest_project['permissions']
-                a['parent']['id'] = new_subject.inserted_id
-                a['parents']['subject'] = new_subject.inserted_id
-                a['parents']['project'] = dest_project['id']
-
-                config.db.analysis.insert_one(analysis)
-
-            # Find the sessions for this subject that need to be moved now
-            sessions = config.db.sessions.find({
-                'subject': subject, '_id': {'$in': self.source_list}}, projection={'_id': 1})
-            moves = []
-            for session in sessions:
-                moves.append(session['_id'])
-
-
-            # Now the sessions can be moved to the new subject with propagation
-            #query = {'subject': subject, '_id': {'$in': self.source_list}}
-            query = {}
-            update = {'$set': {
-                'permissions': dest_project['permissions'],
-                'project': dest_project['_id'],
-                'parents.project': dest_project['_id'],
-                'parents.subject': new_subject.inserted_id,
-                'subject': new_subject.inserted_id,
-                }}
-            print 'We are propogating a move for these sessions now that we have a copied subject'
-            print moves
-            import sys
-            sys.stdout.flush()
-            containerutil.bulk_propagate_changes('sessions', moves, query, update, include_refs=True)
-
-            # Techinically any subjects in the source that no longer have sessions should be deleted
-            # Otherwise we have dangling subjects
-
-#        Requires a 2 phase approach.
-#First is the dry run the second is with the action set to do it
-#
-#1. If the subject for the session in the source project does not exist in the destination project
-#	a. If the subject in the source project has more than one session
-#		i. Copy the subject to the destination project and move the session to the copy
-#	b. If the subject in the source project session has just the session to be moved
-#		i. Move the subject (with the session) to the destination project
-#2. If the subject for the session in the source project does exist
-#	a. Raise an error (Conflict) on the dry run
-#	b. On the full run either move or skip
-#		i. move the session to the subject in the destination but leave the subject in the source
-#		ii. Or skip the move entirely.
+        self.source_storage.move_sessions_to_project(self.source_list, self.dest_list[0], conflict_mode=self.payload.get('conflict_mode'))
+        return True

--- a/api/handlers/bulkhandler.py
+++ b/api/handlers/bulkhandler.py
@@ -14,11 +14,6 @@ class BulkHandler(base.RequestHandler):
     The method it assigned based on the dynamically supplied operation
     """
 
-    bulk_operations = {
-        'copy': {
-        }
-    }
-
     def __init__(self, request=None, response=None):
 
         self.payload = request.json_body
@@ -37,7 +32,9 @@ class BulkHandler(base.RequestHandler):
 
         method = '_{}_{}_to_{}'.format(operation, source_cont_name,
                                        self.payload['destination_container_type'])
-        if not getattr(self, method):
+        try:
+            getattr(self, method)
+        except AttributeError:
             self.abort(501, 'This method is not implemented yet')
 
         self.dest_storage = ContainerStorage.factory(self.payload['destination_container_type'])

--- a/api/handlers/bulkhandler.py
+++ b/api/handlers/bulkhandler.py
@@ -6,6 +6,7 @@ from ..web import base
 from ..web.errors import APIPermissionException, APIValidationException
 from collections import namedtuple
 from ..validators import validate_data
+from ..auth import require_privilege, Privilege
 
 class BulkHandler(base.RequestHandler):
     """
@@ -28,7 +29,7 @@ class BulkHandler(base.RequestHandler):
 
         super(BulkHandler, self).__init__(request, response)
 
-    @require_login
+    @require_privilege(Privilege.is_user)
     def bulk(self, operation, source_cont_name):
         """Entry point for the bulk operations"""
 

--- a/api/handlers/bulkhandler.py
+++ b/api/handlers/bulkhandler.py
@@ -1,0 +1,106 @@
+
+import bson
+import copy
+import datetime
+import dateutil
+
+from ..api import config
+
+from ..auth import containerauth, always_ok
+from ..dao import containerstorage, containerutil
+from ..dao.containerstorage import AnalysisStorage
+from ..web import base
+from ..web.errors import APIPermissionException, APIValidationException, InputValidationException
+from ..web.request import log_access, AccessType
+
+
+class BulkHandler(base.RequestHandler):
+    """
+    """
+
+    def __init__(self, request=None, response=None):
+
+        self.payload = request.json_body
+        self.source_storage = None
+        self.dest_stroage = None
+
+        super(BulkHandler, self).__init__(request, response)
+
+    def bulk(self, operation, source_cont_name, **kwargs):
+        """Entry point for the bulk operations"""
+
+
+        # TODO: perform some permission checks first
+        #permchecker = self._get_permchecker(container)
+        # This line exec the actual get checking permissions using the decorator permchecker
+        #result = permchecker(self.storage.exec_op)('GET', _id)
+        #if result is None:
+        #    self.abort(404, 'Element not found in container {} {}'.format(self.storage.cont_name, _id))
+        #if not self.user_is_admin and not self.is_true('join_avatars'):
+        #    self._filter_permissions(result, self.uid)
+
+        print ('we are hitting it', operation, source_cont_name, self.payload)
+
+        self.dest_storage = getattr(containerstorage, containerutil.singularize(self.payload['destination_container_type']).capitalize() + 'Storage')()
+        self.source_storage = getattr(containerstorage, containerutil.singularize(source_cont_name).capitalize() + 'Storage')()
+        self._validate_inputs(source_cont_name) 
+
+        getattr(self, '_' + operation + '_' + source_cont_name)()
+
+    def _validate_inputs(self, source_cont):
+        """
+        Validate inputs are given and exist in the system
+        """
+
+        if not len(self.payload['sources']):
+            raise APIValidationException('You must provide at least one source')
+
+        if not len(self.payload['destinations']):
+            raise APIValidationException('You must provide at least one destination')
+
+        if len(self.payload['sources']) > 1 and len(self.payload['destinations']) > 1:
+            raise APIValidationException('You can not specify multiple sources and destinations.')
+
+        sources = self.source_storage.get_all_el(query={'_id': {'$in': self.payload['sources']}}, user=None, projection={'_id': 1})
+        if len(sources) != len(self.payload['sources']):
+            missing = set(self.payload['sources']) - set(sources)
+            raise APIValidationException('The following sources are not valid: {}'.format(', '.join(str(s) for s in missing)))
+
+        dests = self.dest_storage.get_all_el(query={'_id': {'$in': self.payload['sources']}}, user=None, projection={'_id': 1})
+        if len(sources) != len(self.payload['destinations']):
+            missing = set(self.payload['destinations']) - set(dests)
+            raise APIValidationException('The following destinations are not valid: {}'.format(', '.join(str(s) for s in missing)))
+
+
+    def _move_sessions(self):
+
+        # We move sessions to new project for now. Add dest of session later
+        query = {}
+        source_subject_codes = config.db.subjects.find_many(query, user=None, projection={'_id': 1, 'code': 1})
+
+        conflicts = config.db.subjects.find_many({'_id': 'test'})
+
+        # first we find conflicts as those are needed for dry run regardless.
+        # Then we return that on dry run.
+
+        # Next we need to find the two sets that are not conflicts
+            # move: conflicts have more than one session in the source project
+            # copy: subjects that have just the one session in the conflict  list
+
+
+#        Requires a 2 phase approach.
+#First is the dry run the second is with the action set to do it
+#
+#1. If the subject for the session in the source project does not exist in the destination project
+#	a. If the subject in the source project has more than one session
+#		i. Copy the subject to the destination project and move the session to the copy
+#	b. If the subject in the source project session has just the session to be moved
+#		i. Move the subject (with the session) to the destination project
+#2. If the subject for the session in the source project does exist
+#	a. Raise an error (Conflict) on the dry run
+#	b. On the full run either move or skip
+#		i. move the session to the subject in the destination but leave the subject in the source
+#		ii. Or skip the move entirely.
+
+
+

--- a/api/handlers/bulkhandler.py
+++ b/api/handlers/bulkhandler.py
@@ -4,12 +4,19 @@ from ..auth import containerauth
 from ..dao.basecontainerstorage import ContainerStorage
 from ..web import base
 from ..web.errors import APIPermissionException, APIValidationException
-#from ..web.request import log_access, AccessType
 from collections import namedtuple
+from ..validators import validate_data
 
 class BulkHandler(base.RequestHandler):
     """
+    Handle that processes bulk operations.
+    The method it assigned based on the dynamically supplied operation
     """
+
+    bulk_operations = {
+        'copy': {
+        }
+    }
 
     def __init__(self, request=None, response=None):
 
@@ -21,18 +28,16 @@ class BulkHandler(base.RequestHandler):
 
         super(BulkHandler, self).__init__(request, response)
 
-
+    @require_login
     def bulk(self, operation, source_cont_name):
         """Entry point for the bulk operations"""
 
+        validate_data(self.payload, 'bulk.json', 'input', 'POST')
 
-        if not getattr(self,
-            ('_' + operation + '_' + source_cont_name + '_to_' +
-             self.payload['destination_container_type']),
-             None):
-
+        method = '_{}_{}_to_{}'.format(operation, source_cont_name,
+                                       self.payload['destination_container_type'])
+        if not getattr(self, method):
             self.abort(501, 'This method is not implemented yet')
-
 
         self.dest_storage = ContainerStorage.factory(self.payload['destination_container_type'])
         self.source_storage = ContainerStorage.factory(source_cont_name)
@@ -50,28 +55,9 @@ class BulkHandler(base.RequestHandler):
 
         self._validate_inputs()
 
-
-        ## This is a stub to hold the assumed uid on the handler. We have multiple uids to check
-        #Handler = namedtuple('Handler', 'uid, scope')
-        #
-        #dest_cont = self.dest_storage.get_el(self.dest_list[0])
-        #source_cont = self.source_storage.get_el(self.source_list[0])
-        ## The container auth takes the object not the name. So we need to load the parent 
-        #self.source_permchecker = containerauth.default_container(Handler(self.source_list[0], self.scope), source_cont)
-        #dest_permchecker = containerauth.default_container(Handler(self.dest_list[0], self.scope), dest_cont)
-
-        #result = dest_permchecker(self.dest_storage.exec_op)('PUT', self.dest_list[0], payload=None)
-        #if result is None:
-        #    raise APIPermissionException('You do not have permission on the destination container')
         ## TODO: perform some permission checks first
         ## TODO: There does not seem to be a bulk perm checker. Do we want to check all the sources first?
-        ## FOr now just check the first one
-        #result = self.source_permchecker(self.source_storage.exec_op)('PUT', self.source_list[0], payload=None)
-        #if result is None:
-        #    raise APIPermissionException('You do not have permission on the destination container')
-
-
-        getattr(self, '_' + operation + '_' + source_cont_name + '_to_' + self.payload['destination_container_type'])()
+        getattr(self, method)()
 
     def _validate_inputs(self):
         """
@@ -131,7 +117,6 @@ class BulkHandler(base.RequestHandler):
 
 
         self.source_storage.move_sessions_to_project(self.source_list, self.dest_list[0], conflict_mode=self.payload.get('conflict_mode'))
-        return True
 
 
     def _move_sessions_to_subjects(self):
@@ -142,5 +127,3 @@ class BulkHandler(base.RequestHandler):
         '''
 
         self.source_storage.move_sessions_to_subject(self.source_list, self.dest_list[0], conflict_mode=None)
-        return True
-

--- a/api/handlers/bulkhandler.py
+++ b/api/handlers/bulkhandler.py
@@ -25,6 +25,15 @@ class BulkHandler(base.RequestHandler):
     def bulk(self, operation, source_cont_name):
         """Entry point for the bulk operations"""
 
+
+        if not getattr(self,
+            ('_' + operation + '_' + source_cont_name + '_to_' +
+             self.payload['destination_container_type']),
+             None):
+
+            self.abort(501, 'This method is not implemented yet')
+
+
         self.dest_storage = ContainerStorage.factory(self.payload['destination_container_type'])
         self.source_storage = ContainerStorage.factory(source_cont_name)
 

--- a/api/handlers/bulkhandler.py
+++ b/api/handlers/bulkhandler.py
@@ -123,3 +123,15 @@ class BulkHandler(base.RequestHandler):
 
         self.source_storage.move_sessions_to_project(self.source_list, self.dest_list[0], conflict_mode=self.payload.get('conflict_mode'))
         return True
+
+
+    def _move_sessions_to_subjects(self):
+        '''
+        Moves all sessions in the soruce list to the destination project
+        Subjects that do not exist in the destination will be copied
+        Conflicts are not an issue so its just a bulk move to update pointers
+        '''
+
+        self.source_storage.move_sessions_to_subject(self.source_list, self.dest_list[0], conflict_mode=None)
+        return True
+

--- a/api/handlers/bulkhandler.py
+++ b/api/handlers/bulkhandler.py
@@ -4,7 +4,7 @@ import copy
 import datetime
 import dateutil
 
-from ..api import config
+from .. import config
 
 from ..auth import containerauth, always_ok
 from ..dao import containerstorage, containerutil
@@ -39,34 +39,54 @@ class BulkHandler(base.RequestHandler):
         #if not self.user_is_admin and not self.is_true('join_avatars'):
         #    self._filter_permissions(result, self.uid)
 
-        print ('we are hitting it', operation, source_cont_name, self.payload)
-
         self.dest_storage = getattr(containerstorage, containerutil.singularize(self.payload['destination_container_type']).capitalize() + 'Storage')()
         self.source_storage = getattr(containerstorage, containerutil.singularize(source_cont_name).capitalize() + 'Storage')()
-        self._validate_inputs(source_cont_name) 
+
+        source_list = []
+        dest_list = []
+        if source_cont_name != 'groups':
+            for _s in self.payload['sources']:
+                print _s
+                import sys
+                sys.stdout.flush()
+                source_list.append(bson.ObjectId(_s['_id']))
+            for _d in self.payload['destinations']:
+                dest_list.append(bson.ObjectId(_d['_id']))
+        else:
+            source_list = self.payload['sources']
+            dest_list = self.payload(['destinations'])
+
+        self._validate_inputs(source_cont_name, source_list, dest_list)
 
         getattr(self, '_' + operation + '_' + source_cont_name)()
 
-    def _validate_inputs(self, source_cont):
+    def _validate_inputs(self, source_cont, source_list, dest_list):
         """
         Validate inputs are given and exist in the system
         """
 
-        if not len(self.payload['sources']):
+        if not len(source_list):
             raise APIValidationException('You must provide at least one source')
 
-        if not len(self.payload['destinations']):
+        if not len(dest_list):
             raise APIValidationException('You must provide at least one destination')
 
-        if len(self.payload['sources']) > 1 and len(self.payload['destinations']) > 1:
+        if len(source_list) > 1 and len(dest_list) > 1:
             raise APIValidationException('You can not specify multiple sources and destinations.')
 
-        sources = self.source_storage.get_all_el(query={'_id': {'$in': self.payload['sources']}}, user=None, projection={'_id': 1})
+        sources = self.source_storage.get_all_el(query={'_id': {'$in': source_list}},
+                user=None, projection={'_id': 1})
+
+        print len(sources)
+        print sources
+        import sys
+        sys.stdout.flush()
+
         if len(sources) != len(self.payload['sources']):
             missing = set(self.payload['sources']) - set(sources)
             raise APIValidationException('The following sources are not valid: {}'.format(', '.join(str(s) for s in missing)))
 
-        dests = self.dest_storage.get_all_el(query={'_id': {'$in': self.payload['sources']}}, user=None, projection={'_id': 1})
+        dests = self.dest_storage.get_all_el(query={'_id': {'$in': self.payload['destinations']}}, user=None, projection={'_id': 1})
         if len(sources) != len(self.payload['destinations']):
             missing = set(self.payload['destinations']) - set(dests)
             raise APIValidationException('The following destinations are not valid: {}'.format(', '.join(str(s) for s in missing)))
@@ -75,10 +95,38 @@ class BulkHandler(base.RequestHandler):
     def _move_sessions(self):
 
         # We move sessions to new project for now. Add dest of session later
-        query = {}
-        source_subject_codes = config.db.subjects.find_many(query, user=None, projection={'_id': 1, 'code': 1})
+        query = {'project': {'$in': self.payload['sources']}}
+        source_subjects = config.db.subjects.find_many(query, user=None, projection={'_id': 1, 'code': 1})
+        source_subject_ids = set()
+        source_subject_codes = set()
+        for source in source_subjects:
+            source_subject_ids.add(source['_id'])
+            source_subject_codes.add(source['code'])
 
-        conflicts = config.db.subjects.find_many({'_id': 'test'})
+        conflicts = config.db.subjects.find_many({
+            'code': {'$in': source_subject_codes},
+            'project': {'$in': self.payload['destinations']}
+        })
+
+        final_conflicts = []
+        for conflict in conflicts:
+            final_conflicts.append({'_id': conflict['_id'], 'code': conflict['code']})
+
+        if self.payload.get('conflict_mode', True) or self.payload['conflict_mode'] is None or self.payload['conflict_mode'] == '':
+            print 'we have these conflicts'
+            print final_conflicts
+            import sys
+            sys.stdout.flush()
+            return final_conflicts
+
+
+
+
+
+
+
+
+
 
         # first we find conflicts as those are needed for dry run regardless.
         # Then we return that on dry run.

--- a/swagger/paths/bulk.yaml
+++ b/swagger/paths/bulk.yaml
@@ -1,0 +1,77 @@
+$template_arguments:
+  tag: bulk
+
+/bulk/move/sessions:
+    summary: Perform a bulk move of sessions to either a subject or project
+    operationId: bulk_move_sessions
+    tags:
+    - bulk
+    parameters:
+      - name: body
+        in: body 
+        required: true
+        schema:
+            $ref: schemas/input/bulk.json#subject-move
+    responses:
+      '200':
+        description: ''
+        schema:
+          $ref: schemas/output/bulk.json
+      '400':
+        $ref: '#/responses/400:invalid-body-json'
+
+# These below need to be converted to the explicit generec endpoint type
+/bulk/move:
+    summary: Perform a bulk move operation
+    operationId: bulk_move
+    tags:
+    - bulk
+    parameters:
+      - name: body
+        in: body 
+        required: true
+        schema:
+          $ref: schemas/input/bulk.json
+    responses:
+      '200':
+        description: ''
+        schema:
+          $ref: schemas/output/bulk.json
+      '400':
+        $ref: '#/responses/400:invalid-body-json'
+/bulk/delete:
+    summary: Perform a bulk delete operation
+    operationId: bulk_delete
+    tags:
+    - bulk
+    parameters:
+      - name: body
+        in: body 
+        required: true
+        schema:
+          $ref: schemas/input/bulk.json
+    responses:
+      '200':
+        description: ''
+        schema:
+          $ref: schemas/output/bulk.json
+      '400':
+        $ref: '#/responses/400:invalid-body-json'
+/bulk/copy:
+    summary: Perform a bulk copy operation
+    operationId: bulk_copy
+    tags:
+    - bulk
+    parameters:
+      - name: body
+        in: body 
+        required: true
+        schema:
+          $ref: schemas/input/bulk.json
+    responses:
+      '200':
+        description: ''
+        schema:
+          $ref: schemas/output/bulk.json
+      '400':
+        $ref: '#/responses/400:invalid-body-json'

--- a/swagger/schemas/definitions/bulk.json
+++ b/swagger/schemas/definitions/bulk.json
@@ -33,9 +33,7 @@
                 }
             },
             "required": ["sources", "destination_container_type", "destinations", "conflict_mode"],
-            "additionalProperties": false,
-            "x-sdk-model": "bulk",
-            "x-sdk-container-mixin": "bulk-mixin"
+            "additionalProperties": false
         }
     }
 }

--- a/swagger/schemas/definitions/bulk.json
+++ b/swagger/schemas/definitions/bulk.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "definitions": {
+        "move-sessions": {
+            "type": "object",
+            "properties": {
+                "destination_container_type": {
+                  "type": "string",
+                  "enum": ["subjects", "projects"],
+                  "description": "The type of destination container"
+                },
+                "sources": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Array of continer Ids that you would like to bulk move"
+                },
+                "destinations": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                    "description": "Array with a single continer Id of the destination container's Id"
+                    }
+                },
+                "conflict_mode": {
+                    "type": "string",
+                    "items": {
+                        "type": "string",
+                        "enum": ["skip", "copy", null],
+                    "description": "How to handle conflicts.  A value of null results in a dry run only"
+                    }
+                }
+            },
+            "required": ["sources", "destination_container_type", "destinations", "conflict_mode"],
+            "additionalProperties": false,
+            "x-sdk-model": "bulk",
+            "x-sdk-container-mixin": "bulk-mixin"
+        }
+    }
+}

--- a/swagger/schemas/definitions/bulk.json
+++ b/swagger/schemas/definitions/bulk.json
@@ -27,7 +27,7 @@
                     "type": "string",
                     "items": {
                         "type": "string",
-                        "enum": ["skip", "copy", null],
+                        "enum": ["skip", "move", null],
                     "description": "How to handle conflicts.  A value of null results in a dry run only"
                     }
                 }

--- a/swagger/schemas/input/bulk.json
+++ b/swagger/schemas/input/bulk.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Bulk",
+    "type": "object",
+    "allOf": [{"$ref": "../definitions/bulk.json#/definitions/move-sessions"}]
+}

--- a/swagger/schemas/input/bulk.json
+++ b/swagger/schemas/input/bulk.json
@@ -2,5 +2,11 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "Bulk",
     "type": "object",
-    "allOf": [{"$ref": "../definitions/bulk.json#/definitions/move-sessions"}]
+    "allOf": [{"$ref": "../definitions/bulk.json#/definitions/move-sessions"}],
+	"example": {
+        "sources": ["5c6d69c4a6490f00160cc489", "5c6d69c4a6490f00170cc48c", "5c6f0e3e9f3fbde31560c6ad"],
+        "destination_container_type": "projects",
+        "destinations": ["5c6f040da91ced00257524e6"],
+        "conflict_mode": "move"
+	}
 }

--- a/tests/integration_tests/python/test_bulk.py
+++ b/tests/integration_tests/python/test_bulk.py
@@ -1,0 +1,188 @@
+
+from mock import patch
+import bson
+import pytest
+
+from flywheel_common import errors
+
+from api.dao import basecontainerstorage
+from api.site import providers
+from api.storage.py_fs.py_fs_storage import PyFsStorage
+
+
+def _create_project_tree(data_builder):
+
+    from collections import namedtuple
+    Project = namedtuple('Project', 'id, subjects')
+    Subject = namedtuple('Subject', 'id, sessions')
+
+
+    group = data_builder.create_group()
+
+    # First create a project with 3 unique subjects with 2 sessions each.
+    project1 = data_builder.create_project(group=group, label='source')
+    p1s1 = data_builder.create_subject(project=project1, code='unique1')
+    p1s1s1 = data_builder.create_session(project=project1, subject={'_id': p1s1})
+    p1s1s2 = data_builder.create_session(project=project1, subject={'_id': p1s1})
+    p1s2 = data_builder.create_subject(project=project1, code='unique2')
+    p1s2s1 = data_builder.create_session(project=project1, subject={'_id': p1s2})
+    p1s2s2 = data_builder.create_session(project=project1, subject={'_id': p1s2})
+    p1s3 = data_builder.create_subject(project=project1, code='conflict1')
+    p1s3s1 = data_builder.create_session(project=project1, subject={'_id': p1s3})
+    p1s3s2 = data_builder.create_session(project=project1, subject={'_id': p1s3})
+
+    projects = [Project(project1, [
+        #Subject(p1s1, [p1s1s1, p1s1s2, p1s1s3]),
+        Subject(p1s1, [p1s1s1, p1s1s2]),
+        Subject(p1s2, [p1s2s1, p1s2s2]),
+        Subject(p1s3, [p1s3s1, p1s3s2])
+    ])]
+
+    # Now create another project with 3 unique subjects and 2 sesions each.
+    # One of the subjects shares the same code as in project 1, a conflict
+    project2 = data_builder.create_project(group=group, label='destination')
+    p2s1 = data_builder.create_subject(project=project2, code='unique3')
+    p2s1s1 = data_builder.create_session(project=project2, subject={'_id': p2s1})
+    p2s1s2 = data_builder.create_session(project=project2, subject={'_id': p2s1})
+    p2s2 = data_builder.create_subject(project=project2, code='unique4')
+    p2s2s1 = data_builder.create_session(project=project2, subject={'_id': p2s2})
+    p2s2s2 = data_builder.create_session(project=project2, subject={'_id': p2s2})
+    p2s3 = data_builder.create_subject(project=project2, code='conflict1')
+    p2s3s1 = data_builder.create_session(project=project2, subject={'_id': p2s3})
+    p2s3s2 = data_builder.create_session(project=project2, subject={'_id': p2s3})
+
+    projects.append(Project(project2, [
+        Subject(p2s1, [p2s1s1, p2s1s2]),
+        Subject(p2s2, [p2s2s1, p2s2s2]),
+        Subject(p2s3, [p2s3s1, p2s3s2])
+    ]))
+
+    # Now create another project with 2 unique subjects and 2 sesions each.
+    # One of the subjects shares the same code as in project 1, a conflict but wont move
+    project3 = data_builder.create_project(group=group, label='outsideOfScope')
+    p3s1 = data_builder.create_subject(project=project3, code='unique5')
+    p3s1s1 = data_builder.create_session(project=project3, subject={'_id': p3s1})
+    p3s1s2 = data_builder.create_session(project=project3, subject={'_id': p3s1})
+    p3s2 = data_builder.create_subject(project=project3, code='conflict1')
+    p3s2s1 = data_builder.create_session(project=project3, subject={'_id': p3s2})
+    p3s2s2 = data_builder.create_session(project=project3, subject={'_id': p3s2})
+
+    projects.append(Project(project3, [
+        Subject(p3s1, [p3s1s1, p3s1s2]),
+        Subject(p3s2, [p3s2s1, p3s2s2])
+    ]))
+
+    return projects
+
+def test_bulk_move_session_to_project_move(data_builder, api_db, as_admin):
+    """ Test moving sessions to project with the move conflict resolution"""
+    projects = _create_project_tree(data_builder)
+    project1 = projects[0].id
+    project2 = projects[1].id
+    # The sessions we are going to move
+    sources = projects[0].subjects[0].sessions + projects[0].subjects[2].sessions
+
+    # We are going to move the sessions from unique1 and conflict1. All should end up
+    # In project 2 with conflict1 in project2 having 4 sessions total
+    r = as_admin.post('/bulk/move/sessions', json={
+	"sources": sources,
+	#"sources": [p1s1s1, p1s1s2, p1s3s1, p1s3s2]
+	"destination_container_type": "projects",
+	"destinations": [project2],
+	"conflict_mode": "move"
+    })
+    assert r.ok
+
+    object_ids = []
+    for s in sources:
+        object_ids.append(bson.ObjectId(s))
+    moved_sessions = api_db.sessions.find({'_id': {'$in': object_ids}})
+    assert moved_sessions.count() == 4
+    for session in moved_sessions:
+        assert str(session['project']) == project2
+        assert str(session['parents']['project']) == project2
+        # TODO: set some permissions to validate they follow through
+        #assert session['permissions'] == project2['permissions']
+    object_ids = []
+    for s in projects[0].subjects[1].sessions:
+        object_ids.append(bson.ObjectId(s))
+    not_moved_sessions = api_db.sessions.find({'_id': {'$in': object_ids}})
+    assert not_moved_sessions.count() == 2
+    for session in not_moved_sessions:
+        assert str(session['project']) == project1
+        assert str(session['parents']['project']) == project1
+
+    # Explicitely check each session in the conflict set
+    conflicts = projects[0].subjects[2].sessions + projects[1].subjects[2].sessions
+    object_ids = []
+    for c in conflicts:
+        object_ids.append(bson.ObjectId(c))
+    #conflict_sessions = api_db.sessions.find({'_id': {'$in' [p1s3s1, p1s3s2, p2s3s1, p2s3s2]}})
+    conflict_sessions = api_db.sessions.find({'_id': {'$in': object_ids}})
+    for session in conflict_sessions:
+        assert str(session['project']) == project2
+        assert str(session['subject']) == projects[1].subjects[2].id
+
+    #p1s2 should only have the unmoved sessions, p1s2s1 and p1s2s2 specifically
+    assert api_db.sessions.find({'subject': bson.ObjectId(projects[0].subjects[1].id)}).count() == 2
+
+    #Verify the session counts to make sure no sessions were lost or added
+    assert api_db.sessions.find({'project': bson.ObjectId(projects[0].id)}).count() == 2
+    assert api_db.sessions.find({'project': bson.ObjectId(projects[1].id)}).count() == 10
+    assert api_db.sessions.find({'project': bson.ObjectId(projects[2].id)}).count() == 4
+
+
+
+def test_bulk_move_session_to_project_skip(data_builder, api_db, as_admin):
+    """Test bulk move sessions to project with skip conflict resolution"""
+    projects = _create_project_tree(data_builder)
+    project1 = projects[0].id
+    project2 = projects[1].id
+    # THe sessions we are going to attempt to move
+    sources = projects[0].subjects[0].sessions + projects[0].subjects[2].sessions
+
+    # We are trying to move the sessions from unique1 and conflict1. 2 should end up
+    # In project 2 with conflict1 getting skipped
+    r = as_admin.post('/bulk/move/sessions', json={
+	"sources": sources,
+	"destination_container_type": "projects",
+	"destinations": [project2],
+	"conflict_mode": "skip"
+    })
+    assert r.ok
+
+    object_ids = []
+    for s in projects[0].subjects[0].sessions:
+        object_ids.append(bson.ObjectId(s))
+    moved_sessions = api_db.sessions.find({'_id': {'$in': object_ids}})
+    for session in moved_sessions:
+        assert str(session['project']) == project2
+        assert str(session['parents']['project']) == project2
+        # TODO: set some permissions to validate they follow through
+        #assert session['permissions'] == project2['permissions']
+    object_ids = []
+    for s in projects[0].subjects[1].sessions:
+        object_ids.append(bson.ObjectId(s))
+    not_moved_sessions = api_db.sessions.find({'_id': {'$in': object_ids}})
+    for session in not_moved_sessions:
+        assert str(session['project']) == project1
+        assert str(session['parents']['project']) == project1
+
+    # Explicitly check each session in the conflict set was skipped and remains in project1
+    object_ids = []
+    for s in projects[0].subjects[2].sessions:
+        object_ids.append(bson.ObjectId(s))
+    conflict_sessions = api_db.sessions.find({'_id': {'$in': object_ids}})
+    for session in conflict_sessions:
+        assert str(session['project']) == project1
+        assert str(session['subject']) == projects[0].subjects[2].id
+
+    #p1s2 should still have the unmoved sessions
+    assert api_db.sessions.find({'subject': bson.ObjectId(projects[0].subjects[1].id)}).count() == 2
+    #p1s3 should have unmoved sessions as they should be skipped
+    assert api_db.sessions.find({'subject': bson.ObjectId(projects[0].subjects[2].id)}).count() == 2
+
+    #Verify the session counts to make sure no sessions were lost or added
+    assert api_db.sessions.find({'project': bson.ObjectId(projects[0].id)}).count() == 4
+    assert api_db.sessions.find({'project': bson.ObjectId(projects[1].id)}).count() == 8
+    assert api_db.sessions.find({'project': bson.ObjectId(projects[2].id)}).count() == 4

--- a/tests/integration_tests/python/test_bulk.py
+++ b/tests/integration_tests/python/test_bulk.py
@@ -90,7 +90,12 @@ def test_bulk_invalid_operations(as_admin):
     assert r.status_code == 404
 
     # Valid operations and containers that are not implemented yet will give a 501 as opposed to 404
-    r = as_admin.post('/bulk/move/subjects', json={})
+    r = as_admin.post('/bulk/move/subjects', json={
+        "sources": ['anycontainer'],
+        "destination_container_type": "projects",
+        "destinations": ['anyproject'],
+        "conflict_mode": "move"
+        })
     assert not r.ok
     assert r.status_code == 501
 

--- a/tests/integration_tests/python/test_bulk.py
+++ b/tests/integration_tests/python/test_bulk.py
@@ -78,6 +78,22 @@ def _create_project_tree(data_builder):
 
     return projects
 
+
+def test_bulk_invalid_operations(as_admin):
+
+    r = as_admin.post('/bulk/invalid_operation/projects')
+    assert not r.ok
+    assert r.status_code == 404
+
+    r = as_admin.post('/bulk/move/invalid_container')
+    assert not r.ok
+    assert r.status_code == 404
+
+    # Valid operations and containers that are not implemented yet will give a 501 as opposed to 404
+    r = as_admin.post('/bulk/move/subjects', json={})
+    assert not r.ok
+    assert r.status_code == 501
+
 def test_bulk_move_session_to_project_move(data_builder, api_db, as_admin):
     """ Test moving sessions to project with the move conflict resolution"""
     projects = _create_project_tree(data_builder)


### PR DESCRIPTION
Creates a bulk API endpoint for performing operations on multiple containers at once.

This PR implements the bulk move for sessions and subjects. As we add more operations and container types we can fill in the remaining methods as needed.

This is an intermediate PR, missing the permissions isolation which are added in the following PR:
https://github.com/flywheel-io/core/pull/1667



### Review Checklist

- Tests were added to cover all code changes
- Is there a DB upgrade or fix?
  - If so is it covered by integeration tests and run against dev?
- Would this PR benefit from a test plan? If so, is one provided?
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
- Extra care is taken and log messages are created for [Critical Data](https://github.com/flywheel-io/core/wiki/Critical-Data-Flows)
